### PR TITLE
feat: migrate all components to Arcan Glass tokens

### DIFF
--- a/apps/chat/app/(site)/contact/page.tsx
+++ b/apps/chat/app/(site)/contact/page.tsx
@@ -56,21 +56,21 @@ export default function ContactPage() {
         {contactLinks.map((item) => {
           const Icon = item.icon;
           const className =
-            "rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5 transition hover:-translate-y-0.5 hover:border-emerald-300/40 hover:bg-zinc-900";
+            "glass-card transition hover:-translate-y-0.5 hover:border-ai-blue/40";
           const content = (
             <div className="flex items-start justify-between gap-4">
               <div>
-                <p className="text-xs uppercase tracking-[0.18em] text-zinc-400">
+                <p className="text-xs uppercase tracking-[0.18em] text-text-muted">
                   {item.label}
                 </p>
-                <p className="mt-2 font-display text-2xl text-zinc-100">
+                <p className="mt-2 font-display text-2xl text-text-primary">
                   {item.handle}
                 </p>
-                <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+                <p className="mt-3 text-sm leading-relaxed text-text-secondary">
                   {item.description}
                 </p>
               </div>
-              <span className="rounded-full border border-zinc-700 p-2 text-zinc-200">
+              <span className="rounded-full border border-border p-2 text-text-primary">
                 <Icon size={18} />
               </span>
             </div>

--- a/apps/chat/app/(site)/links/page.tsx
+++ b/apps/chat/app/(site)/links/page.tsx
@@ -209,7 +209,7 @@ export const metadata = {
 
 function renderPill(link: { href: string; label: string; internal?: boolean }) {
   const className =
-    "rounded-full border border-zinc-700 px-3 py-1.5 text-xs uppercase tracking-[0.16em] text-zinc-300 transition hover:border-zinc-500 hover:text-emerald-200";
+    "rounded-full border border-border px-3 py-1.5 text-xs uppercase tracking-[0.16em] text-text-secondary transition hover:border-ai-blue/40 hover:text-ai-blue";
 
   if (link.internal) {
     return (
@@ -245,17 +245,17 @@ export default async function LinksPage() {
       <section className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
         {primaryDestinations.map((item) => {
           const className =
-            "group block rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5 transition hover:-translate-y-0.5 hover:border-emerald-300/40 hover:bg-zinc-900";
+            "group block rounded-2xl glass-card transition hover:-translate-y-0.5 hover:border-ai-blue/40";
 
           const content = (
             <>
-              <p className="text-xs uppercase tracking-[0.18em] text-zinc-400">
+              <p className="text-xs uppercase tracking-[0.18em] text-text-muted">
                 {item.label}
               </p>
-              <p className="mt-2 font-display text-2xl text-zinc-100 transition group-hover:text-emerald-200">
+              <p className="mt-2 font-display text-2xl text-text-primary transition group-hover:text-ai-blue">
                 {item.handle}
               </p>
-              <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+              <p className="mt-3 text-sm leading-relaxed text-text-secondary">
                 {item.description}
               </p>
             </>
@@ -287,17 +287,17 @@ export default async function LinksPage() {
         })}
       </section>
 
-      <section className="mt-12 rounded-3xl border border-zinc-800 bg-zinc-900/30 p-6 sm:p-8">
+      <section className="mt-12 rounded-3xl glass p-6 sm:p-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">
+            <p className="text-xs uppercase tracking-[0.2em] text-web3-green">
               Profiles
             </p>
-            <h2 className="mt-2 font-display text-3xl text-zinc-100">
+            <h2 className="mt-2 font-display text-3xl text-text-primary">
               Public accounts
             </h2>
           </div>
-          <p className="max-w-2xl text-sm leading-relaxed text-zinc-400">
+          <p className="max-w-2xl text-sm leading-relaxed text-text-muted">
             These are the main external profiles and legacy properties linked
             from the older public hub.
           </p>
@@ -310,14 +310,14 @@ export default async function LinksPage() {
       <section className="mt-12">
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">
+            <p className="text-xs uppercase tracking-[0.2em] text-web3-green">
               Projects
             </p>
-            <h2 className="mt-2 font-display text-3xl text-zinc-100">
+            <h2 className="mt-2 font-display text-3xl text-text-primary">
               Current work
             </h2>
           </div>
-          <p className="max-w-2xl text-sm leading-relaxed text-zinc-400">
+          <p className="max-w-2xl text-sm leading-relaxed text-text-muted">
             Every project page in this repo, plus its repository and live links
             when available.
           </p>
@@ -326,22 +326,22 @@ export default async function LinksPage() {
           {projects.map((project) => (
             <article
               key={project.slug}
-              className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5"
+              className="rounded-2xl glass-card"
             >
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <Link
                     href={`/projects/${project.slug}` as Route}
-                    className="font-display text-2xl text-zinc-100 transition hover:text-emerald-200"
+                    className="font-display text-2xl text-text-primary transition hover:text-ai-blue"
                   >
                     {project.title}
                   </Link>
-                  <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+                  <p className="mt-3 text-sm leading-relaxed text-text-secondary">
                     {project.summary}
                   </p>
                 </div>
                 {project.status ? (
-                  <span className="rounded-full border border-zinc-700 px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-zinc-300">
+                  <span className="rounded-full border border-border px-2 py-1 text-[10px] uppercase tracking-[0.2em] text-text-secondary">
                     {project.status}
                   </span>
                 ) : null}
@@ -367,14 +367,14 @@ export default async function LinksPage() {
       <section className="mt-12">
         <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">
+            <p className="text-xs uppercase tracking-[0.2em] text-web3-green">
               Deployment inventory
             </p>
-            <h2 className="mt-2 font-display text-3xl text-zinc-100">
+            <h2 className="mt-2 font-display text-3xl text-text-primary">
               `*.broomva.tech` scan
             </h2>
           </div>
-          <p className="max-w-2xl text-sm leading-relaxed text-zinc-400">
+          <p className="max-w-2xl text-sm leading-relaxed text-text-muted">
             Public subdomains discovered from live probing and certificate
             records. Inactive hosts stay listed here for completeness.
           </p>
@@ -386,20 +386,20 @@ export default async function LinksPage() {
               href={deployment.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5 transition hover:-translate-y-0.5 hover:border-emerald-300/40 hover:bg-zinc-900"
+              className="rounded-2xl glass-card transition hover:-translate-y-0.5 hover:border-ai-blue/40"
             >
               <div className="flex items-center justify-between gap-3">
-                <p className="font-display text-xl text-zinc-100">
+                <p className="font-display text-xl text-text-primary">
                   {deployment.host}
                 </p>
-                <span className="rounded-full border border-zinc-700 px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] text-zinc-300">
+                <span className="rounded-full border border-border px-2 py-0.5 text-[10px] uppercase tracking-[0.2em] text-text-secondary">
                   {deployment.status}
                 </span>
               </div>
-              <p className="mt-3 text-xs uppercase tracking-[0.16em] text-zinc-500">
+              <p className="mt-3 text-xs uppercase tracking-[0.16em] text-text-muted">
                 {deployment.category}
               </p>
-              <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+              <p className="mt-3 text-sm leading-relaxed text-text-secondary">
                 {deployment.description}
               </p>
             </a>

--- a/apps/chat/app/(site)/notes/[slug]/page.tsx
+++ b/apps/chat/app/(site)/notes/[slug]/page.tsx
@@ -42,10 +42,10 @@ export default async function NoteSlugPage({
   return (
     <main className="mx-auto w-full max-w-4xl px-4 pb-20 pt-10 sm:px-6 sm:pt-14">
       <PageHero title={entry.title} description={entry.summary} />
-      <p className="mt-8 text-xs uppercase tracking-[0.18em] text-zinc-400">
+      <p className="mt-8 text-xs uppercase tracking-[0.18em] text-text-muted">
         {formatDate(entry.date)}
       </p>
-      <div className="mt-8 rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6 sm:p-8">
+      <div className="mt-8 glass rounded-2xl p-6 sm:p-8">
         <ProseContent html={entry.html} />
       </div>
     </main>

--- a/apps/chat/app/(site)/now/page.tsx
+++ b/apps/chat/app/(site)/now/page.tsx
@@ -27,33 +27,33 @@ export default function NowPage() {
         description="A monthly snapshot of my current build focus, open questions, and where I want collaboration."
       />
       <section className="mt-10 grid gap-6 lg:grid-cols-2">
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6">
+        <div className="rounded-2xl glass p-6">
           <h2 className="font-display text-2xl">Building now</h2>
-          <ul className="mt-4 space-y-3 text-sm leading-relaxed text-zinc-300">
+          <ul className="mt-4 space-y-3 text-sm leading-relaxed text-text-secondary">
             {focus.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>
         </div>
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6">
+        <div className="rounded-2xl glass p-6">
           <h2 className="font-display text-2xl">Learning now</h2>
-          <ul className="mt-4 space-y-3 text-sm leading-relaxed text-zinc-300">
+          <ul className="mt-4 space-y-3 text-sm leading-relaxed text-text-secondary">
             {learning.map((item) => (
               <li key={item}>{item}</li>
             ))}
           </ul>
         </div>
       </section>
-      <section className="mt-10 rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6">
+      <section className="mt-10 rounded-2xl glass p-6">
         <h2 className="font-display text-2xl">Collaborate</h2>
-        <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+        <p className="mt-3 text-sm leading-relaxed text-text-secondary">
           If you are building production agent systems and want to compare
           architectures, constraints, or tooling, use the contact page and
           include your current bottleneck.
         </p>
         <Link
           href="/contact"
-          className="mt-5 inline-flex rounded-full border border-zinc-700 px-4 py-2 text-sm transition hover:border-zinc-500 hover:text-emerald-200"
+          className="mt-5 inline-flex rounded-full border border-border px-4 py-2 text-sm transition hover:border-ai-blue/40 hover:text-ai-blue"
         >
           Open contact options
         </Link>

--- a/apps/chat/app/(site)/projects/[slug]/page.tsx
+++ b/apps/chat/app/(site)/projects/[slug]/page.tsx
@@ -43,10 +43,10 @@ export default async function ProjectPage({
     <main className="mx-auto w-full max-w-4xl px-4 pb-20 pt-10 sm:px-6 sm:pt-14">
       <PageHero title={project.title} description={project.summary} />
 
-      <div className="mt-8 flex flex-wrap gap-3 text-xs uppercase tracking-[0.18em] text-zinc-400">
+      <div className="mt-8 flex flex-wrap gap-3 text-xs uppercase tracking-[0.18em] text-text-muted">
         <span>{formatDate(project.date)}</span>
         {project.status ? (
-          <span className="rounded-full border border-zinc-700 px-2 py-1">
+          <span className="rounded-full border border-border px-2 py-1">
             {project.status}
           </span>
         ) : null}
@@ -60,7 +60,7 @@ export default async function ProjectPage({
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-full border border-zinc-700 px-4 py-2 text-sm transition hover:border-zinc-500 hover:text-emerald-200"
+              className="rounded-full border border-border px-4 py-2 text-sm transition hover:border-ai-blue/40 hover:text-ai-blue"
             >
               {link.label}
             </a>
@@ -68,7 +68,7 @@ export default async function ProjectPage({
         </div>
       ) : null}
 
-      <div className="mt-10 rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6 sm:p-8">
+      <div className="mt-10 glass rounded-2xl p-6 sm:p-8">
         <ProseContent html={project.html} />
       </div>
     </main>

--- a/apps/chat/app/(site)/start-here/page.tsx
+++ b/apps/chat/app/(site)/start-here/page.tsx
@@ -32,10 +32,10 @@ export default async function StartHerePage() {
         description="I build autonomous software systems: a Rust Agent OS stack with orchestration, governance, and kernel layers that turn LLM capability into reliable, controllable workflows. This page is the shortest route to my best work."
       />
 
-      <section className="mt-10 grid gap-4 rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6 sm:grid-cols-2 sm:gap-6">
+      <section className="mt-10 grid gap-4 rounded-2xl glass p-6 sm:grid-cols-2 sm:gap-6">
         <div>
           <h2 className="font-display text-2xl">What I build</h2>
-          <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+          <p className="mt-3 text-sm leading-relaxed text-text-secondary">
             A Rust-native Agent OS stack: Symphony for orchestration, a control
             metalayer for governance, and aiOS as the kernel. Plus harness
             engineering patterns that make agents reliable in production.
@@ -43,7 +43,7 @@ export default async function StartHerePage() {
         </div>
         <div>
           <h2 className="font-display text-2xl">Why it matters</h2>
-          <p className="mt-3 text-sm leading-relaxed text-zinc-300">
+          <p className="mt-3 text-sm leading-relaxed text-text-secondary">
             Most failures are not model failures. They are harness failures. I
             focus on the systems-level primitives that make agents controllable,
             observable, and useful under real constraints.
@@ -56,7 +56,7 @@ export default async function StartHerePage() {
           <h2 className="font-display text-3xl">Best projects</h2>
           <Link
             href="/projects"
-            className="text-sm text-emerald-300 transition hover:text-emerald-200"
+            className="text-sm text-ai-blue transition hover:text-web3-green"
           >
             All projects
           </Link>
@@ -106,7 +106,7 @@ export default async function StartHerePage() {
         </div>
       </section>
 
-      <section className="mt-12 rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6">
+      <section className="mt-12 rounded-2xl glass p-6">
         <h2 className="font-display text-2xl">Where to follow</h2>
         <div className="mt-4 flex flex-wrap gap-3">
           {followLinks.map((item) => (
@@ -114,7 +114,7 @@ export default async function StartHerePage() {
               <Link
                 key={item.href}
                 href={item.href as Route}
-                className="rounded-full border border-zinc-700 px-4 py-2 text-sm transition hover:border-zinc-500 hover:text-emerald-200"
+                className="rounded-full border border-border px-4 py-2 text-sm transition hover:border-ai-blue/40 hover:text-ai-blue"
               >
                 {item.label}
               </Link>
@@ -124,7 +124,7 @@ export default async function StartHerePage() {
                 href={item.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-full border border-zinc-700 px-4 py-2 text-sm transition hover:border-zinc-500 hover:text-emerald-200"
+                className="rounded-full border border-border px-4 py-2 text-sm transition hover:border-ai-blue/40 hover:text-ai-blue"
               >
                 {item.label}
               </a>

--- a/apps/chat/app/(site)/writing/[slug]/page.tsx
+++ b/apps/chat/app/(site)/writing/[slug]/page.tsx
@@ -42,10 +42,10 @@ export default async function WritingSlugPage({
   return (
     <main className="mx-auto w-full max-w-4xl px-4 pb-20 pt-10 sm:px-6 sm:pt-14">
       <PageHero title={entry.title} description={entry.summary} />
-      <p className="mt-8 text-xs uppercase tracking-[0.18em] text-zinc-400">
+      <p className="mt-8 text-xs uppercase tracking-[0.18em] text-text-muted">
         {formatDate(entry.date)}
       </p>
-      <div className="mt-8 rounded-2xl border border-zinc-800 bg-zinc-900/30 p-6 sm:p-8">
+      <div className="mt-8 glass rounded-2xl p-6 sm:p-8">
         <ProseContent html={entry.html} />
       </div>
     </main>

--- a/apps/chat/components/artifact-actions.tsx
+++ b/apps/chat/components/artifact-actions.tsx
@@ -106,7 +106,7 @@ function PureArtifactActions({
                 </div>
               ) : (
                 <Button
-                  className={cn("h-fit dark:hover:bg-zinc-700", {
+                  className={cn("h-fit hover:bg-bg-hover", {
                     "p-2": !action.label,
                     "px-2 py-1.5": action.label,
                   })}

--- a/apps/chat/components/artifact-panel.tsx
+++ b/apps/chat/components/artifact-panel.tsx
@@ -283,7 +283,7 @@ function PureArtifactPanel({
       <ArtifactHeader className="items-start bg-background/80 p-2">
         <div className="flex flex-row items-start gap-4">
           <ArtifactClose
-            className="h-fit p-2 dark:hover:bg-zinc-700"
+            className="h-fit p-2 hover:bg-bg-hover"
             data-testid="artifact-close-button"
             onClick={closeArtifact}
             variant="outline"

--- a/apps/chat/components/console.tsx
+++ b/apps/chat/components/console.tsx
@@ -54,16 +54,16 @@ export function Console({
 
   return consoleOutputs.length > 0 ? (
     <div className={cn("flex w-full flex-col overflow-hidden", className)}>
-      <div className="flex h-full w-full flex-col overflow-x-hidden overflow-y-scroll border-zinc-200 border-t bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
-        <div className="sticky top-0 z-50 flex h-fit w-full flex-row items-center justify-between border-zinc-200 border-b bg-muted px-2 py-1 dark:border-zinc-700">
-          <div className="flex flex-row items-center gap-3 pl-2 text-sm text-zinc-800 dark:text-zinc-50">
+      <div className="flex h-full w-full flex-col overflow-x-hidden overflow-y-scroll border-border border-t bg-muted">
+        <div className="sticky top-0 z-50 flex h-fit w-full flex-row items-center justify-between border-border border-b bg-muted px-2 py-1">
+          <div className="flex flex-row items-center gap-3 pl-2 text-sm text-foreground">
             <div className="text-muted-foreground">
               <Terminal size={16} />
             </div>
             <div>Console</div>
           </div>
           <Button
-            className="size-fit p-1 hover:bg-zinc-200 dark:hover:bg-zinc-700"
+            className="size-fit p-1 hover:bg-bg-hover"
             onClick={() => setConsoleOutputs([])}
             size="icon"
             variant="ghost"
@@ -75,7 +75,7 @@ export function Console({
         <div>
           {consoleOutputs.map((consoleOutput, index) => (
             <div
-              className="flex flex-row border-zinc-200 border-b bg-zinc-50 px-4 py-2 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-900"
+              className="flex flex-row border-border border-b bg-muted px-4 py-2 font-mono text-sm"
               key={consoleOutput.id}
             >
               <div
@@ -84,8 +84,8 @@ export function Console({
                     "in_progress",
                     "loading_packages",
                   ].includes(consoleOutput.status),
-                  "text-emerald-500": consoleOutput.status === "completed",
-                  "text-red-400": consoleOutput.status === "failed",
+                  "text-web3-green": consoleOutput.status === "completed",
+                  "text-error": consoleOutput.status === "failed",
                 })}
               >
                 [{index + 1}]
@@ -102,7 +102,7 @@ export function Console({
                   </div>
                 </div>
               ) : (
-                <div className="flex w-full flex-col gap-2 overflow-x-scroll text-zinc-900 dark:text-zinc-50">
+                <div className="flex w-full flex-col gap-2 overflow-x-scroll text-foreground">
                   {consoleOutput.contents.map((content, contentIndex) =>
                     content.type === "image" ? (
                       <picture key={`${consoleOutput.id}-${contentIndex}`}>

--- a/apps/chat/components/greeting.tsx
+++ b/apps/chat/components/greeting.tsx
@@ -16,7 +16,7 @@ export const Greeting = () => (
     </motion.div>
     <motion.div
       animate={{ opacity: 1, y: 0 }}
-      className="text-2xl text-zinc-500"
+      className="text-2xl text-text-muted"
       exit={{ opacity: 0, y: 10 }}
       initial={{ opacity: 0, y: 10 }}
       transition={{ delay: 0.6 }}

--- a/apps/chat/components/image-modal.tsx
+++ b/apps/chat/components/image-modal.tsx
@@ -74,7 +74,7 @@ export function ImageActions({
   return (
     <div className={cn("flex items-center gap-1", className)}>
       <Button
-        className="bg-black/50 text-white hover:bg-black/70 hover:text-white"
+        className="bg-bg-deep/50 text-text-primary hover:bg-bg-deep/70 hover:text-text-primary"
         onClick={(e) => handleCopyImage(e, imageUrl)}
         size="icon-sm"
         title="Copy image"
@@ -84,7 +84,7 @@ export function ImageActions({
         <span className="sr-only">Copy image</span>
       </Button>
       <Button
-        className="bg-black/50 text-white hover:bg-black/70 hover:text-white"
+        className="bg-bg-deep/50 text-text-primary hover:bg-bg-deep/70 hover:text-text-primary"
         onClick={(e) => handleDownload(e, imageUrl)}
         size="icon-sm"
         title="Download image"

--- a/apps/chat/components/part/document-common.tsx
+++ b/apps/chat/components/part/document-common.tsx
@@ -128,7 +128,7 @@ function PureDocumentToolCall({
       type="button"
     >
       <div className="flex flex-row items-start gap-3">
-        <div className="mt-1 text-zinc-500">
+        <div className="mt-1 text-text-muted">
           {(() => {
             if (type === "create") {
               return <File size={16} />;

--- a/apps/chat/components/part/document-preview.tsx
+++ b/apps/chat/components/part/document-preview.tsx
@@ -137,7 +137,7 @@ const LoadingSkeleton = ({
   artifactKind: ArtifactKind;
 }) => (
   <div className="w-full">
-    <div className="flex h-[57px] flex-row items-center justify-between gap-2 rounded-t-2xl border border-b-0 p-4 dark:border-zinc-700 dark:bg-muted">
+    <div className="flex h-[57px] flex-row items-center justify-between gap-2 rounded-t-2xl border border-b-0 p-4 border-border bg-muted">
       <div className="flex flex-row items-center gap-3">
         <div className="text-muted-foreground">
           <div className="size-4 animate-pulse rounded-md bg-muted-foreground/20" />
@@ -149,7 +149,7 @@ const LoadingSkeleton = ({
       </div>
     </div>
 
-    <div className="overflow-y-scroll rounded-b-2xl border border-t-0 bg-muted p-8 pt-4 dark:border-zinc-700">
+    <div className="overflow-y-scroll rounded-b-2xl border border-t-0 bg-muted p-8 pt-4 border-border">
       <InlineDocumentSkeleton />
     </div>
   </div>
@@ -199,7 +199,7 @@ const PureHitboxLayer = ({
       role="presentation"
     >
       <div className="flex w-full items-center justify-end p-4">
-        <div className="absolute top-[13px] right-[9px] rounded-md p-2 hover:bg-zinc-100 dark:hover:bg-zinc-700">
+        <div className="absolute top-[13px] right-[9px] rounded-md p-2 hover:bg-bg-hover">
           <Maximize size={16} />
         </div>
       </div>
@@ -239,7 +239,7 @@ const PureDocumentHeader = ({
   isStreaming: boolean;
   type: "create" | "update";
 }) => (
-  <div className="flex flex-row items-start justify-between gap-2 rounded-t-2xl border border-b-0 p-4 sm:items-center dark:border-zinc-700 dark:bg-muted">
+  <div className="flex flex-row items-start justify-between gap-2 rounded-t-2xl border border-b-0 p-4 sm:items-center border-border bg-muted">
     <div className="flex flex-row items-start gap-3 sm:items-center">
       <div className="text-muted-foreground">
         {(() => {
@@ -281,7 +281,7 @@ const DocumentContent = ({ document }: { document: Document }) => {
   const { artifact } = useArtifact();
 
   const containerClassName = cn(
-    "h-[257px] overflow-y-scroll rounded-b-2xl border border-t-0 dark:border-zinc-700 dark:bg-muted",
+    "h-[257px] overflow-y-scroll rounded-b-2xl border border-t-0 border-border bg-muted",
     {
       "p-4 sm:px-14 sm:py-16": document.kind === "text",
       "p-0": document.kind === "code",

--- a/apps/chat/components/sheet-editor.tsx
+++ b/apps/chat/components/sheet-editor.tsx
@@ -57,8 +57,8 @@ const PureSpreadsheetEditor = ({
       frozen: true,
       width: 50,
       renderCell: ({ rowIdx }: { rowIdx: number }) => rowIdx + 1,
-      cellClass: "border-t border-r dark:bg-zinc-950 dark:text-zinc-50",
-      headerCellClass: "border-t border-r dark:bg-zinc-900 dark:text-zinc-50",
+      cellClass: "border-t border-r bg-bg-deep text-foreground",
+      headerCellClass: "border-t border-r bg-bg-surface text-foreground",
     };
 
     const dataColumns = Array.from({ length: MIN_COLS }, (_, i) => ({
@@ -66,10 +66,10 @@ const PureSpreadsheetEditor = ({
       name: String.fromCharCode(65 + i),
       renderEditCell: isReadonly ? undefined : textEditor,
       width: 120,
-      cellClass: cn("border-t dark:bg-zinc-950 dark:text-zinc-50", {
+      cellClass: cn("border-t bg-bg-deep text-foreground", {
         "border-l": i !== 0,
       }),
-      headerCellClass: cn("border-t dark:bg-zinc-900 dark:text-zinc-50", {
+      headerCellClass: cn("border-t bg-bg-surface text-foreground", {
         "border-l": i !== 0,
       }),
     }));

--- a/apps/chat/components/sidebar-chats-list.tsx
+++ b/apps/chat/components/sidebar-chats-list.tsx
@@ -106,7 +106,7 @@ export function SidebarChatsList() {
 
   if (chats.length === 0) {
     return (
-      <div className="flex w-full flex-row items-center justify-center gap-2 px-2 py-4 text-sm text-zinc-500">
+      <div className="flex w-full flex-row items-center justify-center gap-2 px-2 py-4 text-sm text-text-muted">
         Start chatting to see your conversation history!
       </div>
     );

--- a/apps/chat/components/site/page-hero.tsx
+++ b/apps/chat/components/site/page-hero.tsx
@@ -5,13 +5,13 @@ interface PageHeroProps {
 
 export function PageHero({ title, description }: PageHeroProps) {
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-zinc-800 bg-gradient-to-br from-zinc-900 to-zinc-900/30 px-6 py-10 sm:px-10">
-      <div className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-emerald-500/15 blur-3xl" />
-      <div className="pointer-events-none absolute -bottom-24 -left-16 h-56 w-56 rounded-full bg-sky-500/10 blur-3xl" />
-      <h1 className="relative font-display text-4xl text-zinc-100 sm:text-5xl">
+    <section className="glass-card relative overflow-hidden px-6 py-10 sm:px-10">
+      <div className="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-ai-blue/15 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-24 -left-16 h-56 w-56 rounded-full bg-web3-green/10 blur-3xl" />
+      <h1 className="relative font-display text-4xl text-text-primary sm:text-5xl">
         {title}
       </h1>
-      <p className="relative mt-4 max-w-3xl text-base leading-relaxed text-zinc-300 sm:text-lg">
+      <p className="relative mt-4 max-w-3xl text-base leading-relaxed text-text-secondary sm:text-lg">
         {description}
       </p>
     </section>

--- a/apps/chat/components/site/prose-content.tsx
+++ b/apps/chat/components/site/prose-content.tsx
@@ -5,7 +5,7 @@ interface ProseContentProps {
 export function ProseContent({ html }: ProseContentProps) {
   return (
     <article
-      className="prose prose-invert prose-zinc max-w-none prose-headings:font-display prose-headings:text-zinc-100 prose-a:text-emerald-300 hover:prose-a:text-emerald-200 prose-strong:text-zinc-100"
+      className="prose prose-invert max-w-none prose-headings:font-display prose-headings:text-text-primary prose-a:text-ai-blue hover:prose-a:text-web3-green prose-strong:text-text-primary"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/apps/chat/components/ui/alert-dialog.tsx
+++ b/apps/chat/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ function AlertDialogOverlay({
   return (
     <AlertDialogPrimitive.Overlay
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-bg-deep/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
         className
       )}
       data-slot="alert-dialog-overlay"

--- a/apps/chat/components/ui/dialog.tsx
+++ b/apps/chat/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ function DialogOverlay({
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-bg-deep/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
         className
       )}
       data-slot="dialog-overlay"

--- a/apps/chat/components/ui/drawer.tsx
+++ b/apps/chat/components/ui/drawer.tsx
@@ -27,7 +27,7 @@ const DrawerOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
-    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    className={cn("fixed inset-0 z-50 bg-bg-deep/80", className)}
     ref={ref}
     {...props}
   />

--- a/apps/chat/components/ui/sheet.tsx
+++ b/apps/chat/components/ui/sheet.tsx
@@ -35,7 +35,7 @@ function SheetOverlay({
   return (
     <SheetPrimitive.Overlay
       className={cn(
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-bg-deep/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
         className
       )}
       data-slot="sheet-overlay"


### PR DESCRIPTION
## Summary
- Replace every hardcoded `zinc-*`, `emerald-*`, `bg-black` color class with Arcan Glass semantic tokens across 22 files
- Covers site subpages (contact, links, now, start-here, writing/notes/projects slug pages)
- Covers shared components: console, artifacts, documents, greeting, sidebar, image-modal, sheet-editor
- Covers UI primitives: dialog, drawer, sheet, alert-dialog overlays (`bg-black/50` → `bg-bg-deep/50`)
- Covers prose styling: `prose-zinc` → semantic, `prose-a:text-emerald-300` → `prose-a:text-ai-blue`
- **Zero hardcoded color classes remain** — `grep` for `zinc-|emerald-|bg-black` returns 0 matches

## Test plan
- [ ] Verify prose content pages render correctly with AI Blue links
- [ ] Confirm console status colors (web3-green for completed, error for failed)
- [ ] Check modal/dialog/sheet overlays use tinted glass backdrop
- [ ] Verify contact cards, links page, now page all use glass components
- [ ] Test page-hero gradient blobs use AI Blue + Web3 Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)