### PR TITLE
feat(prompts): write API with DB storage and admin GitHub sync

### DIFF
--- a/apps/chat/app/api/prompts/[slug]/route.ts
+++ b/apps/chat/app/api/prompts/[slug]/route.ts
@@ -1,16 +1,130 @@
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 import { getContentBySlug } from "@/lib/content";
+import { getSafeSession } from "@/lib/auth";
+import {
+  getPromptBySlug,
+  updateUserPrompt,
+  softDeleteUserPrompt,
+} from "@/lib/db/queries";
+import { updatePromptSchema } from "@/lib/prompts/validation";
+import { isAdmin } from "@/lib/prompts/admin";
+import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> },
 ) {
   const { slug } = await params;
-  const entry = await getContentBySlug("prompts", slug);
 
+  // DB first
+  const dbPrompt = await getPromptBySlug(slug);
+  if (dbPrompt) {
+    return NextResponse.json({
+      title: dbPrompt.title,
+      summary: dbPrompt.summary ?? "",
+      content: dbPrompt.content,
+      html: "",
+      date: dbPrompt.updatedAt.toISOString(),
+      slug: dbPrompt.slug,
+      kind: "prompts",
+      published: true,
+      pinned: false,
+      tags: dbPrompt.tags ?? [],
+      links: dbPrompt.links ?? [],
+      category: dbPrompt.category ?? undefined,
+      model: dbPrompt.model ?? undefined,
+      version: dbPrompt.version ?? undefined,
+      variables: dbPrompt.variables ?? undefined,
+    });
+  }
+
+  // MDX fallback
+  const entry = await getContentBySlug("prompts", slug);
   if (!entry) {
     return NextResponse.json({ error: "Prompt not found" }, { status: 404 });
   }
-
   return NextResponse.json(entry);
+}
+
+async function getAuth(request: Request) {
+  const apiKey = request.headers.get("authorization")?.replace("Bearer ", "");
+  if (apiKey && apiKey === process.env.PROMPT_API_KEY) {
+    return {
+      userId: process.env.PROMPT_ADMIN_USER_ID ?? "admin",
+      email: "carlosdavidescobar@gmail.com",
+    };
+  }
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) return null;
+  return { userId: session.user.id, email: session.user.email };
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await getAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  const dbPrompt = await getPromptBySlug(slug);
+  if (!dbPrompt) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (dbPrompt.userId !== auth.userId && !isAdmin(auth.email)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const parsed = updatePromptSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const updated = await updateUserPrompt(
+    dbPrompt.id,
+    dbPrompt.userId,
+    parsed.data,
+  );
+  if (!updated) {
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+
+  if (isAdmin(auth.email)) {
+    await commitPromptToGitHub(updated);
+  }
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const auth = await getAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  const dbPrompt = await getPromptBySlug(slug);
+  if (!dbPrompt) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (dbPrompt.userId !== auth.userId && !isAdmin(auth.email)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await softDeleteUserPrompt(dbPrompt.id, dbPrompt.userId);
+  return NextResponse.json({ deleted: true });
 }

--- a/apps/chat/app/api/prompts/route.ts
+++ b/apps/chat/app/api/prompts/route.ts
@@ -1,6 +1,36 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { getContentList, getContentBySlug } from "@/lib/content";
+import { headers } from "next/headers";
+import { getContentList } from "@/lib/content";
+import { getSafeSession } from "@/lib/auth";
+import {
+  getAllPublicPrompts,
+  createUserPrompt,
+  getPromptBySlug,
+} from "@/lib/db/queries";
+import { createPromptSchema } from "@/lib/prompts/validation";
+import { isAdmin, generateSlug } from "@/lib/prompts/admin";
+import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
+import type { UserPrompt } from "@/lib/db/schema";
+import type { ContentSummary } from "@/lib/content";
+
+function dbToSummary(p: UserPrompt): ContentSummary {
+  return {
+    title: p.title,
+    summary: p.summary ?? "",
+    date: p.updatedAt.toISOString(),
+    slug: p.slug,
+    kind: "prompts",
+    published: true,
+    pinned: false,
+    tags: p.tags ?? [],
+    links: p.links ?? [],
+    category: p.category ?? undefined,
+    model: p.model ?? undefined,
+    version: p.version ?? undefined,
+    variables: p.variables ?? undefined,
+  };
+}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -9,24 +39,106 @@ export async function GET(request: NextRequest) {
   const model = searchParams.get("model");
   const format = searchParams.get("format");
 
-  let entries = await getContentList("prompts");
+  // DB prompts (public)
+  const dbPrompts = await getAllPublicPrompts({ category, tag, model });
+  const dbSlugs = new Set(dbPrompts.map((p) => p.slug));
+  const dbSummaries = dbPrompts.map(dbToSummary);
 
-  if (category) {
-    entries = entries.filter((e) => e.category === category);
-  }
-  if (tag) {
-    entries = entries.filter((e) => e.tags.includes(tag));
-  }
-  if (model) {
-    entries = entries.filter((e) => e.model === model);
-  }
+  // MDX fallback (only include entries not already in DB)
+  let mdxEntries = await getContentList("prompts");
+  mdxEntries = mdxEntries.filter((e) => !dbSlugs.has(e.slug));
+  if (category) mdxEntries = mdxEntries.filter((e) => e.category === category);
+  if (tag) mdxEntries = mdxEntries.filter((e) => e.tags.includes(tag));
+  if (model) mdxEntries = mdxEntries.filter((e) => e.model === model);
+
+  const merged = [...dbSummaries, ...mdxEntries].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
 
   if (format === "full") {
+    // For DB prompts, add content directly
+    // For MDX, load via getContentBySlug
+    const { getContentBySlug } = await import("@/lib/content");
     const full = await Promise.all(
-      entries.map((e) => getContentBySlug("prompts", e.slug)),
+      merged.map(async (entry) => {
+        const dbMatch = dbPrompts.find((p) => p.slug === entry.slug);
+        if (dbMatch) {
+          return { ...entry, content: dbMatch.content, html: "" };
+        }
+        return getContentBySlug("prompts", entry.slug);
+      }),
     );
     return NextResponse.json(full.filter(Boolean));
   }
 
-  return NextResponse.json(entries);
+  return NextResponse.json(merged);
+}
+
+export async function POST(request: NextRequest) {
+  // Auth: check session or API key
+  const apiKey = request.headers.get("authorization")?.replace("Bearer ", "");
+  let userId: string | null = null;
+  let userEmail: string | null = null;
+
+  if (apiKey && apiKey === process.env.PROMPT_API_KEY) {
+    // API key auth (for CLI usage) — treat as admin
+    userId = process.env.PROMPT_ADMIN_USER_ID ?? "admin";
+    userEmail = "carlosdavidescobar@gmail.com";
+  } else {
+    // Session auth
+    const { data: session } = await getSafeSession({
+      fetchOptions: { headers: await headers() },
+    });
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    userId = session.user.id;
+    userEmail = session.user.email;
+  }
+
+  const body = await request.json();
+  const parsed = createPromptSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const slug = generateSlug(parsed.data.title);
+
+  // Check slug uniqueness
+  const existing = await getPromptBySlug(slug);
+  if (existing) {
+    return NextResponse.json(
+      { error: `Prompt with slug "${slug}" already exists` },
+      { status: 409 },
+    );
+  }
+
+  const prompt = await createUserPrompt({
+    userId,
+    slug,
+    title: parsed.data.title,
+    content: parsed.data.content,
+    summary: parsed.data.summary ?? null,
+    category: parsed.data.category ?? null,
+    model: parsed.data.model ?? null,
+    version: parsed.data.version ?? null,
+    tags: parsed.data.tags ?? [],
+    variables: parsed.data.variables ?? null,
+    links: parsed.data.links ?? null,
+    visibility: parsed.data.visibility ?? "private",
+    deletedAt: null,
+  });
+
+  // Admin: commit to GitHub → triggers Vercel redeploy
+  if (isAdmin(userEmail)) {
+    const ghResult = await commitPromptToGitHub(prompt);
+    if (!ghResult.success) {
+      console.error("GitHub commit failed:", ghResult.error);
+    }
+  }
+
+  return NextResponse.json(prompt, { status: 201 });
 }

--- a/apps/chat/app/api/prompts/route.ts
+++ b/apps/chat/app/api/prompts/route.ts
@@ -77,12 +77,12 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   // Auth: check session or API key
   const apiKey = request.headers.get("authorization")?.replace("Bearer ", "");
-  let userId: string | null = null;
-  let userEmail: string | null = null;
+  let userId = "";
+  let userEmail = "";
 
   if (apiKey && apiKey === process.env.PROMPT_API_KEY) {
     // API key auth (for CLI usage) — treat as admin
-    userId = process.env.PROMPT_ADMIN_USER_ID ?? "admin";
+    userId = process.env.PROMPT_ADMIN_USER_ID ?? "";
     userEmail = "carlosdavidescobar@gmail.com";
   } else {
     // Session auth

--- a/apps/chat/app/api/prompts/user/route.ts
+++ b/apps/chat/app/api/prompts/user/route.ts
@@ -21,9 +21,12 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
+  const title = body.title ?? "Untitled";
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
   const prompt = await createUserPrompt({
     userId: session.user.id,
-    title: body.title,
+    slug,
+    title,
     content: body.content,
     summary: body.summary ?? null,
     category: body.category ?? null,
@@ -31,7 +34,9 @@ export async function POST(request: NextRequest) {
     version: body.version ?? null,
     tags: body.tags ?? [],
     variables: body.variables ?? null,
+    links: body.links ?? null,
     visibility: body.visibility ?? "private",
+    deletedAt: null,
   });
 
   return NextResponse.json(prompt, { status: 201 });

--- a/apps/chat/lib/db/migrations/0045_add_prompt_slug_links_deleted.sql
+++ b/apps/chat/lib/db/migrations/0045_add_prompt_slug_links_deleted.sql
@@ -1,0 +1,20 @@
+-- Add slug, links, and deletedAt columns to UserPrompt table
+
+ALTER TABLE "UserPrompt" ADD COLUMN "slug" varchar(256);
+ALTER TABLE "UserPrompt" ADD COLUMN "links" json;
+ALTER TABLE "UserPrompt" ADD COLUMN "deletedAt" timestamp;
+
+-- Backfill slug from title for existing rows
+UPDATE "UserPrompt" SET "slug" = LOWER(REGEXP_REPLACE(REPLACE(title, ' ', '-'), '[^a-z0-9-]', '', 'g')) WHERE "slug" IS NULL;
+
+-- Ensure uniqueness by appending id suffix to any duplicates
+WITH dupes AS (
+  SELECT id, slug, ROW_NUMBER() OVER (PARTITION BY slug ORDER BY "createdAt") AS rn
+  FROM "UserPrompt"
+)
+UPDATE "UserPrompt" SET slug = "UserPrompt".slug || '-' || SUBSTRING("UserPrompt".id::text, 1, 8)
+FROM dupes WHERE "UserPrompt".id = dupes.id AND dupes.rn > 1;
+
+-- Now make slug NOT NULL and add unique index
+ALTER TABLE "UserPrompt" ALTER COLUMN "slug" SET NOT NULL;
+CREATE UNIQUE INDEX "UserPrompt_slug_unique" ON "UserPrompt" ("slug");

--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -1229,7 +1229,7 @@ export async function getUserPrompts(userId: string): Promise<UserPrompt[]> {
   return db
     .select()
     .from(userPrompt)
-    .where(eq(userPrompt.userId, userId))
+    .where(and(eq(userPrompt.userId, userId), isNull(userPrompt.deletedAt)))
     .orderBy(desc(userPrompt.updatedAt));
 }
 
@@ -1237,11 +1237,17 @@ export async function getVisiblePrompts(
   userId?: string
 ): Promise<UserPrompt[]> {
   const conditions = userId
-    ? or(
-        eq(userPrompt.userId, userId),
-        eq(userPrompt.visibility, "public")
+    ? and(
+        or(
+          eq(userPrompt.userId, userId),
+          eq(userPrompt.visibility, "public")
+        ),
+        isNull(userPrompt.deletedAt)
       )
-    : eq(userPrompt.visibility, "public");
+    : and(
+        eq(userPrompt.visibility, "public"),
+        isNull(userPrompt.deletedAt)
+      );
   return db
     .select()
     .from(userPrompt)
@@ -1287,6 +1293,54 @@ export async function deleteUserPrompt(
 ): Promise<boolean> {
   const result = await db
     .delete(userPrompt)
+    .where(and(eq(userPrompt.id, id), eq(userPrompt.userId, userId)))
+    .returning({ id: userPrompt.id });
+  return result.length > 0;
+}
+
+export async function getPromptBySlug(
+  slug: string
+): Promise<UserPrompt | undefined> {
+  const [result] = await db
+    .select()
+    .from(userPrompt)
+    .where(and(eq(userPrompt.slug, slug), isNull(userPrompt.deletedAt)));
+  return result;
+}
+
+export async function getAllPublicPrompts(filters?: {
+  category?: string | null;
+  tag?: string | null;
+  model?: string | null;
+}): Promise<UserPrompt[]> {
+  const conditions = [
+    eq(userPrompt.visibility, "public"),
+    isNull(userPrompt.deletedAt),
+  ];
+  if (filters?.category)
+    conditions.push(eq(userPrompt.category, filters.category));
+  if (filters?.model) conditions.push(eq(userPrompt.model, filters.model));
+
+  const results = await db
+    .select()
+    .from(userPrompt)
+    .where(and(...conditions))
+    .orderBy(desc(userPrompt.updatedAt));
+
+  // Tag filtering in JS since tags is JSON
+  if (filters?.tag) {
+    return results.filter((p) => p.tags?.includes(filters.tag!));
+  }
+  return results;
+}
+
+export async function softDeleteUserPrompt(
+  id: string,
+  userId: string
+): Promise<boolean> {
+  const result = await db
+    .update(userPrompt)
+    .set({ deletedAt: new Date() })
     .where(and(eq(userPrompt.id, id), eq(userPrompt.userId, userId)))
     .returning({ id: userPrompt.id });
   return result.length > 0;

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -430,6 +430,7 @@ export const userPrompt = pgTable(
     userId: text("userId")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    slug: varchar("slug", { length: 256 }).notNull(),
     title: varchar("title", { length: 256 }).notNull(),
     content: text("content").notNull(),
     summary: text("summary"),
@@ -440,6 +441,7 @@ export const userPrompt = pgTable(
     variables: json("variables").$type<
       Array<{ name: string; description: string; default?: string }>
     >(),
+    links: json("links").$type<Array<{ label: string; url: string }>>(),
     visibility: varchar("visibility", { enum: ["public", "private"] })
       .notNull()
       .default("private"),
@@ -448,12 +450,14 @@ export const userPrompt = pgTable(
       .notNull()
       .defaultNow()
       .$onUpdate(() => new Date()),
+    deletedAt: timestamp("deletedAt"),
   },
   (t) => ({
     UserPrompt_user_id_idx: index("UserPrompt_user_id_idx").on(t.userId),
     UserPrompt_visibility_idx: index("UserPrompt_visibility_idx").on(
       t.visibility
     ),
+    UserPrompt_slug_idx: uniqueIndex("UserPrompt_slug_unique").on(t.slug),
   })
 );
 

--- a/apps/chat/lib/prompts/admin.ts
+++ b/apps/chat/lib/prompts/admin.ts
@@ -1,0 +1,12 @@
+const ADMIN_EMAIL = "carlosdavidescobar@gmail.com";
+
+export function isAdmin(email: string | undefined | null): boolean {
+  return email === ADMIN_EMAIL;
+}
+
+export function generateSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/apps/chat/lib/prompts/github-commit.ts
+++ b/apps/chat/lib/prompts/github-commit.ts
@@ -1,0 +1,126 @@
+const GITHUB_OWNER = "broomva";
+const GITHUB_REPO = "broomva.tech";
+const PROMPTS_PATH = "apps/chat/content/prompts";
+
+export async function commitPromptToGitHub(prompt: {
+  slug: string;
+  title: string;
+  content: string;
+  summary?: string | null;
+  category?: string | null;
+  model?: string | null;
+  version?: string | null;
+  tags?: string[] | null;
+  variables?: Array<{
+    name: string;
+    description: string;
+    default?: string;
+  }> | null;
+  links?: Array<{ label: string; url: string }> | null;
+}): Promise<{ success: boolean; error?: string }> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    return { success: false, error: "GITHUB_TOKEN not set" };
+  }
+
+  const filePath = `${PROMPTS_PATH}/${prompt.slug}.mdx`;
+  const mdxContent = buildMdx(prompt);
+
+  // Get existing file SHA (needed for updates)
+  let sha: string | undefined;
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${filePath}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+      },
+    );
+    if (res.ok) {
+      const data = await res.json();
+      sha = data.sha;
+    }
+  } catch {
+    // File doesn't exist yet, that's fine
+  }
+
+  // Create or update file
+  const res = await fetch(
+    `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${filePath}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: `chore(prompts): ${sha ? "update" : "add"} ${prompt.slug}`,
+        content: Buffer.from(mdxContent).toString("base64"),
+        ...(sha && { sha }),
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    const err = await res.text();
+    return { success: false, error: `GitHub API: ${res.status} ${err}` };
+  }
+  return { success: true };
+}
+
+function buildMdx(prompt: {
+  title: string;
+  content: string;
+  summary?: string | null;
+  category?: string | null;
+  model?: string | null;
+  version?: string | null;
+  tags?: string[] | null;
+  variables?: Array<{
+    name: string;
+    description: string;
+    default?: string;
+  }> | null;
+  links?: Array<{ label: string; url: string }> | null;
+}): string {
+  const lines: string[] = ["---"];
+  lines.push(`title: "${prompt.title}"`);
+  lines.push(`summary: "${prompt.summary ?? ""}"`);
+  lines.push(`date: ${new Date().toISOString().split("T")[0]}`);
+  lines.push("published: true");
+
+  if (prompt.category) lines.push(`category: ${prompt.category}`);
+  if (prompt.model) lines.push(`model: ${prompt.model}`);
+  lines.push(`version: "${prompt.version ?? "1.0"}"`);
+
+  if (prompt.tags?.length) {
+    lines.push("tags:");
+    for (const tag of prompt.tags) lines.push(`  - ${tag}`);
+  }
+
+  if (prompt.variables?.length) {
+    lines.push("variables:");
+    for (const v of prompt.variables) {
+      lines.push(`  - name: ${v.name}`);
+      lines.push(`    description: "${v.description}"`);
+      if (v.default) lines.push(`    default: "${v.default}"`);
+    }
+  }
+
+  if (prompt.links?.length) {
+    lines.push("links:");
+    for (const l of prompt.links) {
+      lines.push(`  - label: "${l.label}"`);
+      lines.push(`    url: "${l.url}"`);
+    }
+  }
+
+  lines.push("---");
+  lines.push("");
+  lines.push(prompt.content);
+  lines.push("");
+  return lines.join("\n");
+}

--- a/apps/chat/lib/prompts/validation.ts
+++ b/apps/chat/lib/prompts/validation.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+const promptVariableSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  default: z.string().optional(),
+});
+
+const promptLinkSchema = z.object({
+  label: z.string().min(1),
+  url: z.string().url(),
+});
+
+export const createPromptSchema = z.object({
+  title: z.string().min(1).max(256),
+  content: z.string().min(1),
+  summary: z.string().nullable().optional(),
+  category: z.string().max(128).nullable().optional(),
+  model: z.string().max(128).nullable().optional(),
+  version: z.string().max(32).nullable().optional().default("1.0"),
+  tags: z.array(z.string()).optional().default([]),
+  variables: z.array(promptVariableSchema).nullable().optional(),
+  links: z.array(promptLinkSchema).nullable().optional(),
+  visibility: z.enum(["public", "private"]).optional().default("private"),
+});
+
+export const updatePromptSchema = createPromptSchema.partial();

--- a/apps/chat/scripts/seed-prompts.ts
+++ b/apps/chat/scripts/seed-prompts.ts
@@ -1,0 +1,58 @@
+import { getContentList, getContentBySlug } from "../lib/content";
+import { db } from "../lib/db/client";
+import { userPrompt } from "../lib/db/schema";
+import { eq } from "drizzle-orm";
+
+const ADMIN_USER_ID = process.env.PROMPT_ADMIN_USER_ID;
+
+async function main() {
+  if (!ADMIN_USER_ID) {
+    console.error("Set PROMPT_ADMIN_USER_ID env var");
+    process.exit(1);
+  }
+
+  const mdxPrompts = await getContentList("prompts");
+  console.log(`Found ${mdxPrompts.length} MDX prompts`);
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const summary of mdxPrompts) {
+    // Check if slug already in DB
+    const [existing] = await db
+      .select({ id: userPrompt.id })
+      .from(userPrompt)
+      .where(eq(userPrompt.slug, summary.slug));
+
+    if (existing) {
+      console.log(`[skip] ${summary.slug} (already in DB)`);
+      skipped++;
+      continue;
+    }
+
+    const full = await getContentBySlug("prompts", summary.slug);
+    if (!full) continue;
+
+    await db.insert(userPrompt).values({
+      userId: ADMIN_USER_ID,
+      slug: summary.slug,
+      title: summary.title,
+      content: full.content,
+      summary: summary.summary || null,
+      category: summary.category || null,
+      model: summary.model || null,
+      version: summary.version || null,
+      tags: summary.tags,
+      variables: summary.variables || null,
+      links: summary.links?.length ? summary.links : null,
+      visibility: "public",
+    });
+    console.log(`[seed] ${summary.slug}`);
+    created++;
+  }
+
+  console.log(`\nDone: ${created} created, ${skipped} skipped`);
+  process.exit(0);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

- Add `POST /api/prompts` — create prompt (session or API key auth)
- Add `PUT /api/prompts/[slug]` — update prompt (owner or admin)
- Add `DELETE /api/prompts/[slug]` — soft-delete (owner or admin)
- `GET` now merges DB prompts with MDX fallback (DB takes precedence by slug)
- Admin user commits MDX to GitHub on push/update → triggers Vercel redeploy
- Migration 0045: adds `slug`, `links`, `deletedAt` columns to `UserPrompt`
- Zod validation for all write operations
- Seed script to migrate existing MDX prompts to DB
- Updated `prompt-sync.py` CLI with `remote-push`, `remote-update`, `remote-delete`

## New env vars

- `PROMPT_API_KEY` — bearer token for CLI/API access
- `PROMPT_ADMIN_USER_ID` — user ID for admin operations
- `GITHUB_TOKEN` — PAT with repo write scope (for MDX commits)

## Test plan

- [ ] Run migration 0045 against staging DB
- [ ] Seed existing MDX prompts via `seed-prompts.ts`
- [ ] Verify `GET /api/prompts` returns merged DB + MDX results
- [ ] Test `POST /api/prompts` with API key auth
- [ ] Test `PUT /api/prompts/[slug]` updates DB + commits MDX to GitHub
- [ ] Test `DELETE /api/prompts/[slug]` soft-deletes
- [ ] Verify `prompt-sync.py remote-push` works end-to-end
- [ ] Verify Vercel preview deploy builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)