### PR TITLE
feat(chat): security hardening — rate limits, credit floor, CORS, telemetry

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -57,7 +57,11 @@ import { createModuleLogger } from "@/lib/logger";
 import type { AnonymousSession } from "@/lib/types/anonymous";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
 import { generateUUID } from "@/lib/utils";
-import { checkAnonymousRateLimit, getClientIP } from "@/lib/utils/rate-limit";
+import {
+  checkAnonymousRateLimit,
+  checkAuthenticatedRateLimit,
+  getClientIP,
+} from "@/lib/utils/rate-limit";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 
@@ -393,6 +397,7 @@ async function createChatStream({
         budgetAllowedTools: allowedTools,
         abortSignal: abortController.signal,
         messageId,
+        chatId,
         dataStream,
         onError: (error) => {
           log.error({ error }, "streamText error");
@@ -837,6 +842,18 @@ export async function POST(request: NextRequest) {
 
     // Handle authenticated user validation and credit check
     if (userId) {
+      // Rate limit authenticated users
+      const authRateLimit = await checkAuthenticatedRateLimit(
+        userId,
+        redisPublisher,
+      );
+      if (!authRateLimit.success) {
+        return Response.json(
+          { error: authRateLimit.error, type: "RATE_LIMIT_EXCEEDED" },
+          { status: 429, headers: authRateLimit.headers || {} },
+        );
+      }
+
       const result = await handleUserValidationAndCredits({
         chatId,
         userId,

--- a/apps/chat/chat.config.ts
+++ b/apps/chat/chat.config.ts
@@ -127,6 +127,12 @@ const config = {
       requestsPerMonth: isProd ? 10 : 1000,
     },
   },
+  authenticated: {
+    rateLimit: {
+      requestsPerMinute: isProd ? 20 : 120,
+      requestsPerHour: isProd ? 100 : 1000,
+    },
+  },
   attachments: {
     maxBytes: 1024 * 1024, // 1MB
     maxDimension: 2048,

--- a/apps/chat/lib/ai/core-chat-agent.ts
+++ b/apps/chat/lib/ai/core-chat-agent.ts
@@ -21,6 +21,7 @@ export async function createCoreChatAgent({
   budgetAllowedTools,
   abortSignal,
   messageId,
+  chatId,
   dataStream,
   onError,
   onChunk,
@@ -37,6 +38,7 @@ export async function createCoreChatAgent({
   budgetAllowedTools: ToolName[];
   abortSignal?: AbortSignal;
   messageId: string;
+  chatId: string;
   dataStream: StreamWriter;
   onError?: (error: unknown) => void;
   onChunk?: () => void;
@@ -140,6 +142,11 @@ export async function createCoreChatAgent({
     experimental_telemetry: {
       isEnabled: true,
       functionId: "chat-response",
+      metadata: {
+        userId: userId ?? "anonymous",
+        modelId: selectedModelId,
+        chatId,
+      },
     },
     tools: allTools,
     onError: (error) => {

--- a/apps/chat/lib/ai/eval-agent.ts
+++ b/apps/chat/lib/ai/eval-agent.ts
@@ -72,6 +72,7 @@ async function executeAgentAndGetOutput({
     budgetAllowedTools: activeTools,
     abortSignal,
     messageId,
+    chatId: `eval-${messageId}`,
     dataStream: noOpStreamWriter,
     onError: (error) => {
       throw error;

--- a/apps/chat/lib/config-schema.ts
+++ b/apps/chat/lib/config-schema.ts
@@ -157,6 +157,22 @@ export const anonymousConfigSchema = z
     },
   });
 
+export const authenticatedConfigSchema = z
+  .object({
+    rateLimit: z
+      .object({
+        requestsPerMinute: z.number(),
+        requestsPerHour: z.number(),
+      })
+      .describe("Rate limits for authenticated users"),
+  })
+  .default({
+    rateLimit: {
+      requestsPerMinute: 20,
+      requestsPerHour: 100,
+    },
+  });
+
 export const attachmentsConfigSchema = z
   .object({
     maxBytes: z.number().describe("Max file size in bytes after compression"),
@@ -342,6 +358,8 @@ export const configSchema = z.object({
 
   anonymous: anonymousConfigSchema,
 
+  authenticated: authenticatedConfigSchema,
+
   attachments: attachmentsConfigSchema,
 
   deepResearch: deepResearchConfigSchema,
@@ -356,6 +374,7 @@ export type AttachmentsConfig = z.infer<typeof attachmentsConfigSchema>;
 export type DeepResearchConfig = z.infer<typeof deepResearchConfigSchema>;
 export type FeaturesConfig = z.infer<typeof featuresConfigSchema>;
 export type AuthenticationConfig = z.infer<typeof authenticationConfigSchema>;
+export type AuthenticatedConfig = z.infer<typeof authenticatedConfigSchema>;
 
 // Gateway-aware input types: model IDs narrowed per gateway for autocomplete
 type ZodConfigInput = z.input<typeof configSchema>;

--- a/apps/chat/lib/db/credits.ts
+++ b/apps/chat/lib/db/credits.ts
@@ -30,25 +30,29 @@ export async function getCredits(userId: string): Promise<number> {
 }
 
 /**
- * Check if user has positive credits (can spend).
+ * Check if user has sufficient credits (can spend).
  */
-export async function canSpend(userId: string): Promise<boolean> {
+export async function canSpend(
+  userId: string,
+  minimumBalance = 0,
+): Promise<boolean> {
   const credits = await getCredits(userId);
-  return credits > 0;
+  return credits > minimumBalance;
 }
 
 /**
- * Deduct credits from user. Allows going slightly negative for in-progress operations.
+ * Deduct credits from user. Caps overdraft at maxOverdraft cents (default $1.00).
  */
 export async function deductCredits(
   userId: string,
-  amount: number
+  amount: number,
+  maxOverdraft = 100,
 ): Promise<void> {
   await ensureUserCreditRow(userId);
   await db
     .update(userCredit)
     .set({
-      credits: sql`${userCredit.credits} - ${amount}`,
+      credits: sql`GREATEST(${userCredit.credits} - ${amount}, -${maxOverdraft})`,
     })
     .where(eq(userCredit.userId, userId));
 }

--- a/apps/chat/lib/utils/rate-limit.ts
+++ b/apps/chat/lib/utils/rate-limit.ts
@@ -17,6 +17,39 @@ type RateLimitOptions = {
   keyPrefix: string;
 };
 
+// In-memory fallback for when Redis is unavailable
+const inMemoryCounters = new Map<string, { count: number; resetAt: number }>();
+
+function inMemoryRateLimit(
+  key: string,
+  limit: number,
+  windowSize: number,
+): RateLimitResult {
+  const now = Date.now();
+  const resetTime =
+    Math.floor(now / (windowSize * 1000)) * windowSize * 1000 +
+    windowSize * 1000;
+  const entry = inMemoryCounters.get(key);
+  if (!entry || entry.resetAt <= now) {
+    inMemoryCounters.set(key, { count: 1, resetAt: resetTime });
+    return { success: true, remaining: limit - 1, resetTime };
+  }
+  entry.count++;
+  if (entry.count > limit) {
+    return {
+      success: false,
+      remaining: 0,
+      resetTime,
+      error: "Rate limit exceeded",
+    };
+  }
+  return {
+    success: true,
+    remaining: Math.max(0, limit - entry.count),
+    resetTime,
+  };
+}
+
 async function checkRateLimit({
   identifier,
   limit,
@@ -24,15 +57,12 @@ async function checkRateLimit({
   redisClient,
   keyPrefix,
 }: RateLimitOptions): Promise<RateLimitResult> {
+  const key = `${keyPrefix}:${identifier}`;
+
   if (!redisClient) {
-    return {
-      success: true,
-      remaining: limit,
-      resetTime: Date.now() + windowSize * 1000,
-    };
+    return inMemoryRateLimit(key, limit, windowSize);
   }
 
-  const key = `${keyPrefix}:${identifier}`;
   const now = Date.now();
   const windowStart = Math.floor(now / (windowSize * 1000)) * windowSize * 1000;
   const resetTime = windowStart + windowSize * 1000;
@@ -67,13 +97,8 @@ async function checkRateLimit({
       resetTime,
     };
   } catch (error) {
-    console.error("Rate limit check failed:", error);
-    // Fail open - allow request if Redis is down
-    return {
-      success: true,
-      remaining: limit,
-      resetTime,
-    };
+    console.error("Rate limit check failed, falling back to in-memory:", error);
+    return inMemoryRateLimit(key, limit, windowSize);
   }
 }
 
@@ -144,6 +169,73 @@ export async function checkAnonymousRateLimit(
       "X-RateLimit-Limit-Month": RATE_LIMIT.REQUESTS_PER_MONTH.toString(),
       "X-RateLimit-Remaining-Month": monthResult.remaining.toString(),
       "X-RateLimit-Reset-Month": monthResult.resetTime.toString(),
+    },
+  };
+}
+
+const WINDOW_SIZE_HOUR = 3600;
+
+export async function checkAuthenticatedRateLimit(
+  userId: string,
+  redisClient: any,
+): Promise<{
+  success: boolean;
+  error?: string;
+  headers?: Record<string, string>;
+}> {
+  const { rateLimit } = config.authenticated;
+
+  // Check per-minute limit
+  const minuteResult = await checkRateLimit({
+    identifier: userId,
+    limit: rateLimit.requestsPerMinute,
+    windowSize: WINDOW_SIZE_MINUTE,
+    redisClient,
+    keyPrefix: `${config.appPrefix}:auth-rate-limit:minute`,
+  });
+
+  if (!minuteResult.success) {
+    return {
+      success: false,
+      error: `Rate limit exceeded. You can make ${rateLimit.requestsPerMinute} requests per minute. Try again in ${Math.ceil((minuteResult.resetTime - Date.now()) / 1000)} seconds.`,
+      headers: {
+        "X-RateLimit-Limit": rateLimit.requestsPerMinute.toString(),
+        "X-RateLimit-Remaining": minuteResult.remaining.toString(),
+        "X-RateLimit-Reset": minuteResult.resetTime.toString(),
+      },
+    };
+  }
+
+  // Check per-hour limit
+  const hourResult = await checkRateLimit({
+    identifier: userId,
+    limit: rateLimit.requestsPerHour,
+    windowSize: WINDOW_SIZE_HOUR,
+    redisClient,
+    keyPrefix: `${config.appPrefix}:auth-rate-limit:hour`,
+  });
+
+  if (!hourResult.success) {
+    return {
+      success: false,
+      error: `Hourly rate limit exceeded. You can make ${rateLimit.requestsPerHour} requests per hour. Try again in ${Math.ceil((hourResult.resetTime - Date.now()) / 1000)} seconds.`,
+      headers: {
+        "X-RateLimit-Limit": rateLimit.requestsPerHour.toString(),
+        "X-RateLimit-Remaining": hourResult.remaining.toString(),
+        "X-RateLimit-Reset": hourResult.resetTime.toString(),
+      },
+    };
+  }
+
+  return {
+    success: true,
+    headers: {
+      "X-RateLimit-Limit-Minute": rateLimit.requestsPerMinute.toString(),
+      "X-RateLimit-Remaining-Minute": minuteResult.remaining.toString(),
+      "X-RateLimit-Reset-Minute": minuteResult.resetTime.toString(),
+      "X-RateLimit-Limit-Hour": rateLimit.requestsPerHour.toString(),
+      "X-RateLimit-Remaining-Hour": hourResult.remaining.toString(),
+      "X-RateLimit-Reset-Hour": hourResult.resetTime.toString(),
     },
   };
 }

--- a/apps/chat/next.config.ts
+++ b/apps/chat/next.config.ts
@@ -4,6 +4,29 @@ const nextConfig: NextConfig = {
   typedRoutes: true,
   cacheComponents: true,
 
+  async headers() {
+    return [
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "https://broomva.tech",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET, POST, PUT, DELETE, OPTIONS",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Content-Type, Authorization",
+          },
+          { key: "Access-Control-Allow-Credentials", value: "true" },
+        ],
+      },
+    ];
+  },
+
   experimental: {
     optimizePackageImports: [
       "react-tweet",


### PR DESCRIPTION
## Summary
- **Fail-closed rate limiting**: In-memory `Map` fallback when Redis is unavailable instead of bypassing all limits
- **Authenticated user rate limits**: 20 req/min + 100 req/hr in production (configurable via `chat.config.ts`)
- **Credit overdraft cap**: `deductCredits()` uses `GREATEST(credits - amount, -100)` to prevent balances below -$1.00
- **CORS policy**: API routes restricted to `https://broomva.tech` origin via Next.js `headers()`
- **Langfuse user attribution**: `userId`, `modelId`, and `chatId` added to telemetry metadata on all chat streams

## Test plan
- [ ] Remove `REDIS_URL`, send >5 anonymous requests/min — should get 429 (fail-closed)
- [ ] Send 21+ authenticated requests in 1 min — 21st returns 429
- [ ] Set test user credits to 1 cent, trigger chat, verify balance ≥ -$1.00
- [ ] `curl -H "Origin: https://evil.com" -I /api/chat` — no CORS header returned
- [ ] Check Langfuse dashboard for `userId`/`modelId` in trace metadata
- [ ] Deploy to preview, verify normal chat flow for both anonymous and authenticated users

🤖 Generated with [Claude Code](https://claude.com/claude-code)