### PR TITLE
feat(blog): add brownbag post on autonomous agents with OpenClaw

### DIFF
--- a/apps/chat/content/writing/autonomous-agents-brownbag.mdx
+++ b/apps/chat/content/writing/autonomous-agents-brownbag.mdx
@@ -1,0 +1,85 @@
+---
+title: "Brownbag: Autonomous Agents with OpenClaw, Claude Code, and the Control Metalayer"
+summary: From security alert bots to 40+ auto-closed tickets — a team brownbag on building autonomous agent workflows with OpenClaw, Claude Code, Symphony, and compounding skills.
+date: 2026-03-18
+published: true
+tags:
+  - agents
+  - openclaw
+  - symphony
+  - automation
+  - control-metalayer
+---
+
+Last week we ran an internal brownbag on autonomous agent workflows. The session covered everything from deploying a security alert bot on Telegram to closing 40+ Linear tickets and pull requests autonomously using Claude Code, Symphony, and the control metalayer stack. Here is a distilled summary of what we discussed and what we learned.
+
+## Security alert automation
+
+Varsha built an OpenClaw agent that queries Azure for security logs — vulnerabilities, port statuses, exposed IPs — and sends a daily briefing to Telegram at 9am CST. No more manual portal checks every morning. The plan is to extend this to Slack so the full team gets visibility into the security posture without anyone having to remember to look.
+
+The bot runs locally today using Docker, but the natural next step is cloud deployment for 24/7 operation. Railway is the easiest on-ramp (create an instance, SSH in, configure), while Azure VMs make more sense for production given existing credits and enterprise networking. The key insight: local is fine for iteration, but security alerting needs to be always-on.
+
+## Autonomous ticket handling
+
+The core demo showed a workflow where agents autonomously pick up Linear tickets, create pull requests, review their own code, iterate on feedback, and merge when CI checks pass. Over 40 tickets and pull requests were handled this way — created, reviewed, and closed without manual intervention.
+
+The workflow is driven by a prompt that composes several skills:
+
+- **Symphony** — a runtime that listens to a Linear project and dispatches agents per ticket
+- **Control metalayer** — feedback loops that govern agent behavior and ensure alignment with project standards
+- **Knowledge graph memory** — Obsidian-indexed project context that agents reference when developing
+
+When an agent creates a pull request, it does not just fire and forget. It reviews its own changes, responds to CI failures, iterates on comments, and only merges when checks are green. Some tickets get closed as irrelevant — the agent reasons about code context and conversation history to make that call.
+
+## Compounding skills
+
+The architecture is modular. Skills are installed via terminal (or by the agent itself) and can be scoped globally or per-project. The stack we use:
+
+- **Agentic control kernel** — the umbrella skill that ties control, memory, and consciousness layers together
+- **Knowledge graph memory** — bridges Claude Code conversation logs to an Obsidian vault, giving agents indexed project context
+- **Agent consciousness** — persistent memory across sessions, combining conversation history, code context, and knowledge graphs
+
+These skills compound. An agent with access to the control metalayer, a knowledge graph, and Symphony can reason about a ticket, reference project conventions from the graph, create a pull request that follows those conventions, iterate on review feedback, and merge — all autonomously.
+
+## Cloud deployment patterns
+
+For always-on agents, we discussed three deployment targets:
+
+| Platform | Best for | Notes |
+|----------|----------|-------|
+| Railway | Quick tests, personal agents | Simple setup, SSH access, fast iteration |
+| Azure VM | Production, team agents | Enterprise networking, existing credits, full control |
+| Local | Development, prototyping | Fast feedback loop, but stops when machine sleeps |
+
+The recommendation: start on Railway to nail down configuration, then move to Azure for production workloads. Cloud deployment also unlocks the ability to trigger agents from Slack — multiple OpenClaw instances responding to team commands.
+
+## Guardrails and human oversight
+
+Autonomy without oversight is a liability. The system uses pull requests as natural checkpoints:
+
+1. Agent creates a PR from a Linear ticket
+2. CI checks run automatically
+3. Agent reviews its own PR, iterates on issues
+4. Other agents or humans can comment and request changes
+5. Agent only merges when all checks pass
+
+This layered approach — automated reasoning plus human-reviewable artifacts — balances speed with safety. The agent handles the volume; the team handles the judgment calls.
+
+## Cost and resource management
+
+Running multiple heartbeats and API calls adds up. The practical approach:
+
+- Set up automation first, optimize later
+- Monitor usage through the Anthropic console
+- Adjust heartbeat frequency based on actual consumption
+- Watch for rate limit errors as a signal to tune concurrency
+
+## Key takeaways
+
+1. **Start simple, compound later.** A Telegram security bot is a great first agent. Once comfortable, layer in Symphony, knowledge graphs, and autonomous ticket handling.
+2. **Cloud deploy for reliability.** Local is fine for development, but production agents need to be always-on.
+3. **Skills are the multiplier.** Each skill you add compounds the agent's capability. Control metalayer + knowledge graph + Symphony turns a chatbot into an autonomous developer.
+4. **Pull requests are guardrails.** They give humans a natural review point without slowing down the autonomous loop.
+5. **The team learns together.** Sharing experiments, failures, and configurations accelerates everyone's adoption.
+
+The brownbag format works well for this — hands-on demos, live questions, and concrete next steps. We will keep iterating on these workflows and sharing what we learn.


### PR DESCRIPTION
## Summary
- Adds a new blog post covering the team brownbag session on autonomous agent workflows
- Topics: OpenClaw security alert automation, 40+ autonomous ticket closures via Symphony, compounding skills (control metalayer, knowledge graph, agent consciousness), cloud deployment patterns (Railway vs Azure), and guardrails via PR-based human oversight

## Test plan
- [ ] Verify the post renders correctly at `/writing/autonomous-agents-brownbag`
- [ ] Confirm frontmatter is valid (title, summary, date, tags)
- [ ] Check that the writing index page lists the new post

🤖 Generated with [Claude Code](https://claude.com/claude-code)