### PR TITLE
fix(auth): harden cookie secret and fix proxy dead code

### DIFF
--- a/apps/chat/lib/auth.ts
+++ b/apps/chat/lib/auth.ts
@@ -3,10 +3,23 @@ import { env } from "@/lib/env";
 
 const neonAuthBaseUrl = process.env.NEON_AUTH_BASE_URL;
 
+const cookieSecret =
+  process.env.NEON_AUTH_COOKIE_SECRET || env.AUTH_SECRET || "";
+
+if (
+  neonAuthBaseUrl &&
+  process.env.NODE_ENV === "production" &&
+  cookieSecret.length < 32
+) {
+  throw new Error(
+    "AUTH_SECRET or NEON_AUTH_COOKIE_SECRET must be set (>=32 chars) in production",
+  );
+}
+
 export const auth = createNeonAuth({
   baseUrl: neonAuthBaseUrl || process.env.APP_URL || "http://localhost:3001",
   cookies: {
-    secret: process.env.NEON_AUTH_COOKIE_SECRET || env.AUTH_SECRET || "default_secret_for_build",
+    secret: cookieSecret || "insecure-dev-only-secret-do-not-use-in-prod",
   },
 });
 

--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -46,24 +46,32 @@ export async function proxy(req: NextRequest) {
   const url = req.nextUrl;
   const { pathname } = url;
 
+  // Always allow public API routes, metadata, and public pages
   if (
     isPublicApiRoute(pathname) ||
     isMetadataRoute(pathname) ||
-    isPublicPage(pathname) ||
-    isAuthPage(pathname)
+    isPublicPage(pathname)
   ) {
     return;
   }
 
+  // Auth pages (/login, /register) need a session check so we can redirect
+  // logged-in users away — don't short-circuit them above
   const { data: session } = await getSafeSession({
     fetchOptions: { headers: req.headers },
   });
   const isLoggedIn = !!session?.user;
 
-  if (isLoggedIn && isAuthPage(pathname)) {
-    return NextResponse.redirect(new URL("/", url));
+  if (isAuthPage(pathname)) {
+    // Redirect authenticated users away from login/register
+    if (isLoggedIn) {
+      return NextResponse.redirect(new URL("/", url));
+    }
+    // Allow unauthenticated users to reach auth pages
+    return;
   }
 
+  // Block all other routes for unauthenticated users
   if (!isLoggedIn) {
     return NextResponse.redirect(new URL("/login", url));
   }


### PR DESCRIPTION
## Summary

- **Remove unsafe cookie secret fallback**: The `createNeonAuth()` call used `"default_secret_for_build"` as a last-resort cookie signing secret. If both `NEON_AUTH_COOKIE_SECRET` and `AUTH_SECRET` were unset in production, cookies were signed with a known static string — a session forging vulnerability. Now fails loudly in production if no valid secret (>=32 chars) is configured.

- **Fix proxy auth-page redirect dead code**: `isAuthPage()` was included in the early-return guard alongside `isPublicPage()`, causing the logged-in user redirect (`isLoggedIn && isAuthPage → redirect /`) to be unreachable. Authenticated users could still visit `/login` and `/register`. Now auth pages are checked separately after the session lookup so logged-in users are properly redirected away.

## Account linking note

Better Auth 1.4.6 (wrapped by `@neondatabase/auth@0.2.0-beta.1`) **auto-links accounts by default** when the OAuth provider returns a verified email. Google always provides verified emails, so email→Google linking works out of the box. GitHub may not always return `emailVerified: true`, so linking there depends on the user's GitHub email verification status. No code change needed — this is handled server-side by the Neon Auth service.

## Test plan

- [x] `bun run test:types` — passes
- [x] `bun run check:links` — passes
- [ ] Verify Vercel preview deployment builds successfully
- [ ] Manual: confirm unauthenticated user can access `/login`
- [ ] Manual: confirm authenticated user visiting `/login` is redirected to `/`
- [ ] Manual: confirm production deployment has `AUTH_SECRET` set (>=32 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)