### PR TITLE
fix(chat): add pointer-events layering to dock nav

### DIFF
--- a/apps/chat/components/site/dock.tsx
+++ b/apps/chat/components/site/dock.tsx
@@ -113,7 +113,7 @@ function Dock({
           mouseX.set(Infinity);
         }}
         className={cn(
-          "mx-auto flex w-fit gap-4 rounded-2xl bg-zinc-900/80 px-4 backdrop-blur-md border border-zinc-800/50",
+          "pointer-events-auto mx-auto flex w-fit gap-4 rounded-2xl bg-zinc-900/80 px-4 backdrop-blur-md border border-zinc-800/50",
           className,
         )}
         style={{ height: panelHeight }}

--- a/apps/chat/components/site/top-nav.tsx
+++ b/apps/chat/components/site/top-nav.tsx
@@ -42,7 +42,7 @@ export function TopNav() {
   const router = useRouter();
 
   return (
-    <header className="fixed bottom-4 left-0 right-0 z-40">
+    <header className="pointer-events-none fixed bottom-4 left-0 right-0 z-40">
       <nav aria-label="Main navigation">
         <Dock
           magnification={60}


### PR DESCRIPTION
## Summary
- Adds `pointer-events-none` to the fixed dock header to prevent blocking clicks on page content
- Adds `pointer-events-auto` to the dock itself so it remains interactive

## Test plan
- [ ] Verify dock navigation still works (hover, click)
- [ ] Verify page content below the dock is clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)