### PR TITLE
feat: device code grant (RFC 8628) for CLI and agent auth

### DIFF
--- a/apps/chat/app/(auth)/device/page.tsx
+++ b/apps/chat/app/(auth)/device/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
+import { DeviceAuthForm } from "@/components/device-auth-form";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Authorize Device",
+  description: "Approve a device login request for the broomva CLI or agent.",
+};
+
+export default async function DevicePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ code?: string }>;
+}) {
+  const params = await searchParams;
+  const prefillCode = params.code ?? "";
+
+  return (
+    <div className="container mx-auto flex h-dvh w-screen flex-col items-center justify-center">
+      <Link
+        className={cn(
+          buttonVariants({ variant: "ghost" }),
+          "absolute top-4 left-4 md:top-8 md:left-8"
+        )}
+        href="/"
+      >
+        <ChevronLeft className="mr-2 h-4 w-4" />
+        Back
+      </Link>
+      <div className="mx-auto flex w-full flex-col items-center justify-center sm:w-[420px]">
+        <DeviceAuthForm prefillCode={prefillCode} />
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/api/auth/device/authorize/route.ts
+++ b/apps/chat/app/api/auth/device/authorize/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { db } from "@/lib/db/client";
+import { deviceAuthCode, session } from "@/lib/db/schema";
+import { eq, and, gt, desc } from "drizzle-orm";
+import { getSafeSession } from "@/lib/auth";
+
+/**
+ * POST /api/auth/device/authorize
+ *
+ * Called from the /device page when the logged-in user approves or denies a device code.
+ *
+ * Body: { "user_code": "ABCD-1234", "action": "approve" | "deny" }
+ */
+export async function POST(request: Request) {
+  // Require browser session
+  const { data: sessionData } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!sessionData?.user?.id) {
+    return NextResponse.json(
+      { error: "Not authenticated. Please sign in first." },
+      { status: 401 }
+    );
+  }
+
+  const body = await request.json();
+  const userCode = String(body.user_code ?? "")
+    .toUpperCase()
+    .trim();
+  const action = body.action as string;
+
+  if (!userCode || !["approve", "deny"].includes(action)) {
+    return NextResponse.json(
+      { error: "Invalid request. Provide user_code and action (approve|deny)." },
+      { status: 400 }
+    );
+  }
+
+  const [record] = await db
+    .select()
+    .from(deviceAuthCode)
+    .where(
+      and(
+        eq(deviceAuthCode.userCode, userCode),
+        eq(deviceAuthCode.status, "pending")
+      )
+    )
+    .limit(1);
+
+  if (!record) {
+    return NextResponse.json(
+      { error: "Code not found or already used." },
+      { status: 404 }
+    );
+  }
+
+  if (new Date() > record.expiresAt) {
+    await db
+      .update(deviceAuthCode)
+      .set({ status: "expired" })
+      .where(eq(deviceAuthCode.id, record.id));
+
+    return NextResponse.json(
+      { error: "Code has expired. Request a new one." },
+      { status: 410 }
+    );
+  }
+
+  if (action === "deny") {
+    await db
+      .update(deviceAuthCode)
+      .set({ status: "denied", userId: sessionData.user.id })
+      .where(eq(deviceAuthCode.id, record.id));
+
+    return NextResponse.json({ status: "denied" });
+  }
+
+  // Approve: get the user's most recent active session token
+  const [activeSession] = await db
+    .select({ token: session.token, expiresAt: session.expiresAt })
+    .from(session)
+    .where(
+      and(
+        eq(session.userId, sessionData.user.id),
+        gt(session.expiresAt, new Date())
+      )
+    )
+    .orderBy(desc(session.expiresAt))
+    .limit(1);
+
+  if (!activeSession) {
+    return NextResponse.json(
+      { error: "No active session found. Please sign in again." },
+      { status: 401 }
+    );
+  }
+
+  await db
+    .update(deviceAuthCode)
+    .set({
+      status: "approved",
+      userId: sessionData.user.id,
+      sessionToken: activeSession.token,
+    })
+    .where(eq(deviceAuthCode.id, record.id));
+
+  return NextResponse.json({
+    status: "approved",
+    client_id: record.clientId,
+  });
+}

--- a/apps/chat/app/api/auth/device/code/route.ts
+++ b/apps/chat/app/api/auth/device/code/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { randomBytes } from "node:crypto";
+import { db } from "@/lib/db/client";
+import { deviceAuthCode } from "@/lib/db/schema";
+
+/**
+ * POST /api/auth/device/code
+ *
+ * RFC 8628 — Device Authorization Request.
+ * Returns a device_code, user_code, and verification URI.
+ *
+ * Body (optional):
+ *   { "client_id": "broomva-cli", "scope": "" }
+ */
+export async function POST(request: Request) {
+  let clientId = "cli";
+  let scope = "";
+
+  try {
+    const body = await request.json();
+    if (body.client_id) clientId = String(body.client_id);
+    if (body.scope) scope = String(body.scope);
+  } catch {
+    // empty body is fine, use defaults
+  }
+
+  const deviceCode = randomBytes(32).toString("hex");
+  const userCode = generateUserCode();
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
+  const interval = 5; // seconds
+
+  await db.insert(deviceAuthCode).values({
+    deviceCode,
+    userCode,
+    scope,
+    clientId,
+    status: "pending",
+    expiresAt,
+    pollingInterval: interval,
+  });
+
+  const baseUrl =
+    process.env.APP_URL ||
+    (process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : "http://localhost:3001");
+
+  return NextResponse.json({
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: `${baseUrl}/device`,
+    verification_uri_complete: `${baseUrl}/device?code=${userCode}`,
+    expires_in: 900,
+    interval,
+  });
+}
+
+/**
+ * Generate a short, human-friendly code like "ABCD-1234".
+ * Avoids ambiguous characters (0/O, 1/I/L).
+ */
+function generateUserCode(): string {
+  const chars = "ABCDEFGHJKMNPQRSTUVWXYZ";
+  const digits = "23456789";
+  const pick = (set: string, n: number) =>
+    Array.from({ length: n }, () => set[Math.floor(Math.random() * set.length)]).join("");
+  return `${pick(chars, 4)}-${pick(digits, 4)}`;
+}

--- a/apps/chat/app/api/auth/device/token/route.ts
+++ b/apps/chat/app/api/auth/device/token/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db/client";
+import { deviceAuthCode } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+/**
+ * POST /api/auth/device/token
+ *
+ * RFC 8628 — Device Access Token Request.
+ * The CLI polls this endpoint until the user approves/denies or the code expires.
+ *
+ * Body: { "device_code": "...", "grant_type": "urn:ietf:params:oauth:grant-type:device_code" }
+ *
+ * Responses follow RFC 8628 error codes:
+ *   - authorization_pending: user hasn't acted yet
+ *   - slow_down: polling too fast (not enforced server-side, advisory)
+ *   - access_denied: user denied
+ *   - expired_token: code expired
+ *   - 200 + { access_token, token_type, expires_in }: approved
+ */
+export async function POST(request: Request) {
+  let deviceCode: string;
+
+  try {
+    const body = await request.json();
+    deviceCode = body.device_code;
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "Missing device_code" },
+      { status: 400 }
+    );
+  }
+
+  if (!deviceCode) {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "Missing device_code" },
+      { status: 400 }
+    );
+  }
+
+  const [record] = await db
+    .select()
+    .from(deviceAuthCode)
+    .where(eq(deviceAuthCode.deviceCode, deviceCode))
+    .limit(1);
+
+  if (!record) {
+    return NextResponse.json(
+      { error: "invalid_grant", error_description: "Unknown device code" },
+      { status: 400 }
+    );
+  }
+
+  // Check expiration
+  if (new Date() > record.expiresAt) {
+    // Clean up expired record
+    await db
+      .update(deviceAuthCode)
+      .set({ status: "expired" })
+      .where(eq(deviceAuthCode.id, record.id));
+
+    return NextResponse.json(
+      { error: "expired_token", error_description: "Device code has expired" },
+      { status: 400 }
+    );
+  }
+
+  switch (record.status) {
+    case "pending":
+      return NextResponse.json(
+        {
+          error: "authorization_pending",
+          error_description: "User has not yet authorized",
+        },
+        { status: 400 }
+      );
+
+    case "denied":
+      // Clean up denied record
+      await db.delete(deviceAuthCode).where(eq(deviceAuthCode.id, record.id));
+
+      return NextResponse.json(
+        { error: "access_denied", error_description: "User denied authorization" },
+        { status: 400 }
+      );
+
+    case "approved": {
+      // Clean up used record
+      await db.delete(deviceAuthCode).where(eq(deviceAuthCode.id, record.id));
+
+      return NextResponse.json({
+        access_token: record.sessionToken,
+        token_type: "Bearer",
+        // Session tokens from Better Auth typically last 7 days
+        expires_in: 604800,
+      });
+    }
+
+    default:
+      return NextResponse.json(
+        { error: "server_error", error_description: "Unexpected state" },
+        { status: 500 }
+      );
+  }
+}

--- a/apps/chat/components/device-auth-form.tsx
+++ b/apps/chat/components/device-auth-form.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle, XCircle, Terminal, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+type Status = "idle" | "submitting" | "approved" | "denied" | "error";
+
+export function DeviceAuthForm({
+  prefillCode,
+  className,
+  ...props
+}: { prefillCode?: string } & React.ComponentPropsWithoutRef<"div">) {
+  const [code, setCode] = useState(prefillCode ?? "");
+  const [status, setStatus] = useState<Status>("idle");
+  const [clientId, setClientId] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  async function handleAction(action: "approve" | "deny") {
+    setStatus("submitting");
+    setErrorMsg("");
+
+    try {
+      const res = await fetch("/api/auth/device/authorize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ user_code: code.toUpperCase().trim(), action }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus("error");
+        setErrorMsg(data.error ?? "Something went wrong");
+        return;
+      }
+
+      if (action === "approve") {
+        setStatus("approved");
+        setClientId(data.client_id ?? "");
+      } else {
+        setStatus("denied");
+      }
+    } catch {
+      setStatus("error");
+      setErrorMsg("Network error. Please try again.");
+    }
+  }
+
+  if (status === "approved") {
+    return (
+      <div className={cn("flex flex-col gap-6", className)} {...props}>
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10">
+              <CheckCircle className="h-6 w-6 text-green-500" />
+            </div>
+            <CardTitle className="text-xl">Device Authorized</CardTitle>
+            <CardDescription>
+              {clientId
+                ? `"${clientId}" has been granted access.`
+                : "The device has been granted access."}
+              {" "}You can close this page and return to your terminal.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "denied") {
+    return (
+      <div className={cn("flex flex-col gap-6", className)} {...props}>
+        <Card>
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-red-500/10">
+              <XCircle className="h-6 w-6 text-red-500" />
+            </div>
+            <CardTitle className="text-xl">Authorization Denied</CardTitle>
+            <CardDescription>
+              The device login was denied. You can close this page.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+            <Terminal className="h-6 w-6 text-primary" />
+          </div>
+          <CardTitle className="text-xl">Authorize Device</CardTitle>
+          <CardDescription>
+            Enter the code shown in your terminal to authorize the device.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="user-code">Device Code</Label>
+              <Input
+                autoComplete="off"
+                className="text-center font-mono text-lg tracking-widest"
+                id="user-code"
+                maxLength={9}
+                onChange={(e) => setCode(e.target.value.toUpperCase())}
+                placeholder="ABCD-1234"
+                value={code}
+              />
+            </div>
+
+            {errorMsg ? (
+              <p className="text-destructive text-sm text-center">{errorMsg}</p>
+            ) : null}
+
+            <div className="flex gap-2">
+              <Button
+                className="flex-1"
+                disabled={!code.trim() || status === "submitting"}
+                onClick={() => handleAction("approve")}
+                type="button"
+              >
+                {status === "submitting" ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : null}
+                Approve
+              </Button>
+              <Button
+                className="flex-1"
+                disabled={!code.trim() || status === "submitting"}
+                onClick={() => handleAction("deny")}
+                type="button"
+                variant="outline"
+              >
+                Deny
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/chat/lib/db/migrations/0046_add_device_auth_code.sql
+++ b/apps/chat/lib/db/migrations/0046_add_device_auth_code.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "DeviceAuthCode" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "deviceCode" varchar(64) NOT NULL UNIQUE,
+  "userCode" varchar(12) NOT NULL UNIQUE,
+  "scope" text NOT NULL DEFAULT '',
+  "clientId" varchar(128) NOT NULL DEFAULT 'cli',
+  "status" varchar(16) NOT NULL DEFAULT 'pending',
+  "userId" text REFERENCES "user"("id") ON DELETE CASCADE,
+  "sessionToken" text,
+  "expiresAt" timestamp NOT NULL,
+  "pollingInterval" integer NOT NULL DEFAULT 5,
+  "createdAt" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "DeviceAuthCode_device_code_idx" ON "DeviceAuthCode" ("deviceCode");
+CREATE INDEX IF NOT EXISTS "DeviceAuthCode_user_code_idx" ON "DeviceAuthCode" ("userCode");

--- a/apps/chat/lib/db/migrations/meta/_journal.json
+++ b/apps/chat/lib/db/migrations/meta/_journal.json
@@ -316,6 +316,20 @@
       "when": 1773845026602,
       "tag": "0044_fearless_stick",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1774060800000,
+      "tag": "0045_add_prompt_slug_links_deleted",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1774147200000,
+      "tag": "0046_add_device_auth_code",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -463,4 +463,36 @@ export const userPrompt = pgTable(
 
 export type UserPrompt = InferSelectModel<typeof userPrompt>;
 
+export const deviceAuthCode = pgTable(
+  "DeviceAuthCode",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    deviceCode: varchar("deviceCode", { length: 64 }).notNull().unique(),
+    userCode: varchar("userCode", { length: 12 }).notNull().unique(),
+    /** Scopes requested (space-separated). Empty = full access. */
+    scope: text("scope").notNull().default(""),
+    /** Client identifier (e.g. "broomva-cli", "agent-browser") */
+    clientId: varchar("clientId", { length: 128 }).notNull().default("cli"),
+    /** pending | approved | denied | expired */
+    status: varchar("status", { length: 16 }).notNull().default("pending"),
+    /** Set when the user approves */
+    userId: text("userId").references(() => user.id, { onDelete: "cascade" }),
+    /** The session token issued on approval */
+    sessionToken: text("sessionToken"),
+    expiresAt: timestamp("expiresAt").notNull(),
+    pollingInterval: integer("pollingInterval").notNull().default(5),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+  },
+  (t) => ({
+    DeviceAuthCode_device_code_idx: index("DeviceAuthCode_device_code_idx").on(
+      t.deviceCode
+    ),
+    DeviceAuthCode_user_code_idx: index("DeviceAuthCode_user_code_idx").on(
+      t.userCode
+    ),
+  })
+);
+
+export type DeviceAuthCode = InferSelectModel<typeof deviceAuthCode>;
+
 export const schema = { user, session, account, verification };

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { resolveToken, storeToken, clearToken } from "../lib/auth-store.js";
 import { ApiClient } from "../lib/api-client.js";
 import { DEFAULT_API_BASE } from "../lib/constants.js";
-import { success, error as printError, info, warn, printJson } from "../lib/output.js";
+import { success, error as printError, info, warn, printJson, fmt } from "../lib/output.js";
 import { readConfig } from "../lib/config-store.js";
 
 export function authCommand(): Command {
@@ -12,36 +12,16 @@ export function authCommand(): Command {
   cmd
     .command("login")
     .description("Authenticate with broomva.tech")
-    .action(async () => {
+    .option("--manual", "Use manual token copy-paste instead of device flow")
+    .action(async (opts: { manual?: boolean }) => {
       const config = readConfig();
       const base = config.apiBase ?? DEFAULT_API_BASE;
 
-      info("1. Sign in at broomva.tech (email, Google, or GitHub)\n");
-      info("   Accounts with the same email are automatically linked.\n");
-      info("2. Open this URL to get your API token:\n");
-      console.log(`   ${base}/api/auth/api-token\n`);
-      info("3. Copy the \"token\" value and paste it below.\n");
-
-      const rl = createInterface({ input: process.stdin, output: process.stdout });
-      const token = (await rl.question("Token: ")).trim();
-      rl.close();
-
-      if (!token) {
-        printError("No token provided.");
-        process.exit(1);
+      if (opts.manual) {
+        await manualLogin(base);
+      } else {
+        await deviceLogin(base);
       }
-
-      info("Validating token...");
-      const client = new ApiClient({ apiBase: base, token });
-      const result = await client.validateToken();
-
-      if (!result.valid) {
-        printError("Token is invalid or expired.");
-        process.exit(1);
-      }
-
-      storeToken(token);
-      success("Authenticated successfully. Token stored in ~/.broomva/config.json");
     });
 
   cmd
@@ -102,4 +82,152 @@ export function authCommand(): Command {
     });
 
   return cmd;
+}
+
+/**
+ * Device Authorization Grant (RFC 8628).
+ * 1. Request a device code from the server.
+ * 2. Show the user a URL + code to open in the browser.
+ * 3. Poll until the user approves, denies, or the code expires.
+ */
+async function deviceLogin(base: string): Promise<void> {
+  info("Requesting device authorization...\n");
+
+  let deviceResponse: {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    verification_uri_complete: string;
+    expires_in: number;
+    interval: number;
+  };
+
+  try {
+    const res = await fetch(`${base}/api/auth/device/code`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: "broomva-cli" }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      printError(`Failed to request device code: ${res.status} ${text}`);
+      info("Falling back to manual login...\n");
+      await manualLogin(base);
+      return;
+    }
+
+    deviceResponse = await res.json();
+  } catch (err) {
+    printError(`Could not reach ${base}: ${err instanceof Error ? err.message : err}`);
+    info("Falling back to manual login...\n");
+    await manualLogin(base);
+    return;
+  }
+
+  console.log("");
+  console.log(fmt.bold("  Open this URL in your browser:"));
+  console.log(`  ${fmt.cyan(deviceResponse.verification_uri)}\n`);
+  console.log(fmt.bold("  Then enter this code:"));
+  console.log(`  ${fmt.bold(fmt.green(deviceResponse.user_code))}\n`);
+  console.log(
+    fmt.dim(`  Or open the direct link:\n  ${deviceResponse.verification_uri_complete}\n`)
+  );
+  info("Waiting for authorization...\n");
+
+  const interval = (deviceResponse.interval ?? 5) * 1000;
+  const deadline = Date.now() + deviceResponse.expires_in * 1000;
+
+  while (Date.now() < deadline) {
+    await sleep(interval);
+
+    try {
+      const res = await fetch(`${base}/api/auth/device/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          device_code: deviceResponse.device_code,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      });
+
+      const data = await res.json();
+
+      if (res.ok && data.access_token) {
+        storeToken(data.access_token);
+        console.log("");
+        success("Authenticated successfully! Token stored in ~/.broomva/config.json");
+        return;
+      }
+
+      if (data.error === "authorization_pending") {
+        // Keep polling
+        continue;
+      }
+
+      if (data.error === "slow_down") {
+        // Back off
+        await sleep(5000);
+        continue;
+      }
+
+      if (data.error === "access_denied") {
+        console.log("");
+        printError("Authorization denied by user.");
+        process.exit(1);
+      }
+
+      if (data.error === "expired_token") {
+        console.log("");
+        printError("Device code expired. Please try again.");
+        process.exit(1);
+      }
+
+      // Unknown error
+      printError(`Unexpected response: ${JSON.stringify(data)}`);
+      process.exit(1);
+    } catch (err) {
+      // Network glitch — keep trying
+      warn(`Polling error: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  printError("Device code expired. Please try again.");
+  process.exit(1);
+}
+
+/**
+ * Legacy manual token login (copy from browser).
+ */
+async function manualLogin(base: string): Promise<void> {
+  info("1. Sign in at broomva.tech (email, Google, or GitHub)\n");
+  info("   Accounts with the same email are automatically linked.\n");
+  info("2. Open this URL to get your API token:\n");
+  console.log(`   ${base}/api/auth/api-token\n`);
+  info("3. Copy the \"token\" value and paste it below.\n");
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const token = (await rl.question("Token: ")).trim();
+  rl.close();
+
+  if (!token) {
+    printError("No token provided.");
+    process.exit(1);
+  }
+
+  info("Validating token...");
+  const client = new ApiClient({ apiBase: base, token });
+  const result = await client.validateToken();
+
+  if (!result.valid) {
+    printError("Token is invalid or expired.");
+    process.exit(1);
+  }
+
+  storeToken(token);
+  success("Authenticated successfully. Token stored in ~/.broomva/config.json");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## Summary
- Implements OAuth 2.0 Device Authorization Grant (RFC 8628) for CLI and agent-browser authentication
- New `DeviceAuthCode` DB table + API routes (`/api/auth/device/code`, `/token`, `/authorize`)
- `/device` page where logged-in users approve/deny device login requests
- CLI `broomva auth login` now uses device flow by default (automatic polling, no manual copy-paste)
- Falls back to manual token flow if server is unreachable; `--manual` flag for legacy flow

## Test plan
- [x] TypeScript compiles clean (both chat app and CLI)
- [x] CLI builds successfully with `tsup`
- [x] `POST /api/auth/device/code` returns device_code + user_code + verification URLs
- [x] `POST /api/auth/device/token` returns `authorization_pending` for pending codes
- [x] `POST /api/auth/device/token` returns `invalid_grant` for unknown codes
- [x] `POST /api/auth/device/authorize` returns 401 without session
- [x] `/device` page redirects to login when unauthenticated
- [x] `broomva auth login --help` shows new `--manual` flag
- [ ] Full e2e with live user approval (requires deployed session)
- [ ] Run migration on prod DB after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)