### PR TITLE
feat(cli): add broomvad runtime daemon

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { promptsCommand } from "./commands/prompts.js";
 import { skillsCommand } from "./commands/skills.js";
 import { contextCommand } from "./commands/context.js";
 import { configCommand } from "./commands/config.js";
+import { daemonCommand } from "./commands/daemon.js";
 import { setNoColor, error as printError } from "./lib/output.js";
 import { CliError } from "./lib/errors.js";
 import { readConfig } from "./lib/config-store.js";
@@ -36,6 +37,7 @@ export function createProgram(): Command {
   program.addCommand(skillsCommand());
   program.addCommand(contextCommand());
   program.addCommand(configCommand());
+  program.addCommand(daemonCommand());
 
   return program;
 }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,9 +1,38 @@
 import { Command } from "commander";
-import { readConfig, resetConfig, setConfigValue, getConfigValue } from "../lib/config-store.js";
+import { readConfig, resetConfig, setConfigValue, getConfigValue, updateConfig } from "../lib/config-store.js";
 import { printJson, success, info, error as printError } from "../lib/output.js";
-import type { CliConfig } from "../types/config.js";
+import type { CliConfig, DaemonConfig } from "../types/config.js";
 
 const VALID_KEYS: (keyof CliConfig)[] = ["apiBase", "defaultFormat"];
+
+const VALID_DAEMON_KEYS: (keyof DaemonConfig)[] = [
+  "heartbeatIntervalMs",
+  "dashboardPort",
+  "symphonyUrl",
+  "arcanUrl",
+  "lagoUrl",
+  "autonomicUrl",
+  "incidentThreshold",
+];
+
+const NUMERIC_DAEMON_KEYS: (keyof DaemonConfig)[] = [
+  "heartbeatIntervalMs",
+  "dashboardPort",
+  "incidentThreshold",
+];
+
+function setDaemonConfigValue(key: string, value: string): boolean {
+  if (!VALID_DAEMON_KEYS.includes(key as keyof DaemonConfig)) return false;
+  const config = readConfig();
+  const daemon = config.daemon ?? {};
+  if (NUMERIC_DAEMON_KEYS.includes(key as keyof DaemonConfig)) {
+    (daemon as Record<string, unknown>)[key] = Number.parseInt(value, 10);
+  } else {
+    (daemon as Record<string, unknown>)[key] = value;
+  }
+  updateConfig({ daemon });
+  return true;
+}
 
 export function configCommand(): Command {
   const cmd = new Command("config").description("Manage CLI configuration");
@@ -11,11 +40,24 @@ export function configCommand(): Command {
   cmd
     .command("set")
     .description("Set a config value")
-    .argument("<key>", `Config key (${VALID_KEYS.join(", ")})`)
+    .argument("<key>", `Config key (${VALID_KEYS.join(", ")}, daemon.<key>)`)
     .argument("<value>", "Config value")
     .action((key: string, value: string) => {
+      // Handle daemon.* nested keys
+      if (key.startsWith("daemon.")) {
+        const daemonKey = key.slice("daemon.".length);
+        if (setDaemonConfigValue(daemonKey, value)) {
+          success(`Set ${key} = ${value}`);
+          return;
+        }
+        printError(
+          `Invalid daemon key "${daemonKey}". Valid keys: ${VALID_DAEMON_KEYS.join(", ")}`,
+        );
+        process.exit(1);
+      }
+
       if (!VALID_KEYS.includes(key as keyof CliConfig)) {
-        printError(`Invalid key "${key}". Valid keys: ${VALID_KEYS.join(", ")}`);
+        printError(`Invalid key "${key}". Valid keys: ${VALID_KEYS.join(", ")}, daemon.<key>`);
         process.exit(1);
       }
       setConfigValue(key as keyof CliConfig, value as never);

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,0 +1,404 @@
+import { Command } from "commander";
+import { readConfig } from "../lib/config-store.js";
+import { resolveToken } from "../lib/auth-store.js";
+import {
+	DEFAULT_API_BASE,
+	DEFAULT_DASHBOARD_PORT,
+	DEFAULT_HEARTBEAT_INTERVAL_MS,
+	DAEMON_STATE_FILE,
+} from "../lib/constants.js";
+import {
+	info,
+	success,
+	warn,
+	error as printError,
+	printJson,
+	fmt,
+} from "../lib/output.js";
+import {
+	isDaemonRunning,
+	stopDaemon,
+	writePidFile,
+	removePidFile,
+} from "../daemon/process.js";
+import { DaemonLogger } from "../daemon/logger.js";
+import { HeartbeatLoop } from "../daemon/heartbeat.js";
+import { Dashboard } from "../daemon/dashboard.js";
+import { SymphonyHttpClient } from "../daemon/symphony-client.js";
+import { registerSensor, getSensors, clearSensors } from "../daemon/sensors/index.js";
+import { SiteHealthSensor } from "../daemon/sensors/site-health.js";
+import { ApiHealthSensor } from "../daemon/sensors/api-health.js";
+import { createRailwaySensors } from "../daemon/sensors/railway-health.js";
+import type { DaemonConfig } from "../types/config.js";
+import { existsSync, readFileSync } from "node:fs";
+
+// Default local ports for services
+const LOCAL_DEFAULTS: Record<string, string> = {
+	symphonyUrl: "http://localhost:8080",
+	arcanUrl: "http://localhost:8081",
+	lagoUrl: "http://localhost:8082",
+	autonomicUrl: "http://localhost:8083",
+};
+
+function resolveDaemonConfig(opts: {
+	env?: string;
+	port?: string;
+	interval?: string;
+	symphonyUrl?: string;
+	arcanUrl?: string;
+	lagoUrl?: string;
+	autonomicUrl?: string;
+}): { daemonConfig: DaemonConfig; apiBase: string; envLabel: string } {
+	const config = readConfig();
+	const savedDaemon = config.daemon ?? {};
+	const isLocal = opts.env === "local";
+	const envLabel = isLocal ? "local" : "railway";
+
+	const daemonConfig: DaemonConfig = {
+		heartbeatIntervalMs: opts.interval
+			? Number.parseInt(opts.interval, 10)
+			: (savedDaemon.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS),
+		dashboardPort: opts.port
+			? Number.parseInt(opts.port, 10)
+			: (savedDaemon.dashboardPort ?? DEFAULT_DASHBOARD_PORT),
+		incidentThreshold: savedDaemon.incidentThreshold,
+		symphonyUrl:
+			opts.symphonyUrl ??
+			(isLocal ? LOCAL_DEFAULTS.symphonyUrl : savedDaemon.symphonyUrl),
+		arcanUrl:
+			opts.arcanUrl ??
+			(isLocal ? LOCAL_DEFAULTS.arcanUrl : savedDaemon.arcanUrl),
+		lagoUrl:
+			opts.lagoUrl ??
+			(isLocal ? LOCAL_DEFAULTS.lagoUrl : savedDaemon.lagoUrl),
+		autonomicUrl:
+			opts.autonomicUrl ??
+			(isLocal ? LOCAL_DEFAULTS.autonomicUrl : savedDaemon.autonomicUrl),
+	};
+
+	const apiBase = isLocal
+		? "http://localhost:3000"
+		: (config.apiBase ?? DEFAULT_API_BASE);
+
+	return { daemonConfig, apiBase, envLabel };
+}
+
+export function daemonCommand(): Command {
+	const cmd = new Command("daemon").description(
+		"Manage the broomvad runtime daemon",
+	);
+
+	cmd
+		.command("start")
+		.description("Start the broomvad daemon")
+		.option(
+			"--env <environment>",
+			"Target environment: local or railway",
+			"railway",
+		)
+		.option("--port <port>", "Dashboard port")
+		.option("--interval <ms>", "Heartbeat interval in milliseconds")
+		.option("--symphony-url <url>", "Symphony service URL override")
+		.option("--arcan-url <url>", "Arcan service URL override")
+		.option("--lago-url <url>", "Lago service URL override")
+		.option("--autonomic-url <url>", "Autonomic service URL override")
+		.action(async (opts) => {
+			const { running, pid } = isDaemonRunning();
+			if (running) {
+				printError(`Daemon already running (PID ${pid})`);
+				process.exit(1);
+			}
+
+			const { daemonConfig, apiBase, envLabel } = resolveDaemonConfig(opts);
+			const logger = new DaemonLogger();
+			const tokenInfo = resolveToken();
+
+			info(
+				`Starting broomvad (env: ${fmt.cyan(envLabel)}, api: ${fmt.dim(apiBase)})`,
+			);
+
+			if (!tokenInfo) {
+				warn(
+					"No auth token found. Authenticated sensors will be limited.",
+				);
+				warn("Run `broomva auth login` for full monitoring.");
+			}
+
+			// Register sensors
+			clearSensors();
+			registerSensor(new SiteHealthSensor());
+			registerSensor(new ApiHealthSensor());
+			for (const s of createRailwaySensors()) {
+				registerSensor(s);
+			}
+
+			// Symphony client
+			let symphonyClient: SymphonyHttpClient | null = null;
+			if (daemonConfig.symphonyUrl) {
+				symphonyClient = new SymphonyHttpClient(
+					daemonConfig.symphonyUrl,
+					tokenInfo?.token ?? null,
+				);
+			}
+
+			// Heartbeat loop
+			const heartbeat = new HeartbeatLoop({
+				sensors: getSensors(),
+				config: daemonConfig,
+				apiBase,
+				logger,
+				onTick: (state) => {
+					const sensorSummary = Object.values(state.sensors)
+						.map((s) => {
+							const icon =
+								s.status === "healthy"
+									? fmt.green("●")
+									: s.status === "degraded"
+										? fmt.yellow("●")
+										: fmt.red("●");
+							return `${icon} ${s.sensorId}`;
+						})
+						.join("  ");
+
+					const openIncidents = state.incidents.filter(
+						(i) => i.status === "open",
+					).length;
+
+					console.log(
+						`${fmt.dim(`[${state.lastTickAt}]`)} tick #${state.tickCount}  ${sensorSummary}${openIncidents > 0 ? fmt.red(`  ${openIncidents} incident(s)`) : ""}`,
+					);
+				},
+			});
+
+			// Dashboard
+			const dashboard = new Dashboard({
+				port: daemonConfig.dashboardPort ?? DEFAULT_DASHBOARD_PORT,
+				logger,
+				getState: () => heartbeat.getState(),
+				symphonyClient,
+			});
+
+			// Write PID and start
+			writePidFile(process.pid);
+			logger.info("Daemon started", {
+				pid: process.pid,
+				env: envLabel,
+				apiBase,
+				dashboardPort: daemonConfig.dashboardPort,
+			});
+
+			// Graceful shutdown
+			const shutdown = () => {
+				info("\nShutting down broomvad...");
+				heartbeat.stop();
+				dashboard.stop();
+				removePidFile();
+				logger.info("Daemon stopped");
+				process.exit(0);
+			};
+
+			process.on("SIGINT", shutdown);
+			process.on("SIGTERM", shutdown);
+
+			try {
+				await dashboard.start();
+				success(
+					`Dashboard at http://localhost:${daemonConfig.dashboardPort ?? DEFAULT_DASHBOARD_PORT}`,
+				);
+			} catch (err) {
+				printError(
+					`Failed to start dashboard: ${err instanceof Error ? err.message : String(err)}`,
+				);
+				removePidFile();
+				process.exit(1);
+			}
+
+			heartbeat.start();
+
+			info(
+				`broomvad running (PID ${process.pid}, env: ${envLabel}). Press Ctrl+C to stop.`,
+			);
+
+			// Keep alive
+			await new Promise(() => {});
+		});
+
+	cmd
+		.command("stop")
+		.description("Stop the broomvad daemon")
+		.action(() => {
+			const { stopped, pid } = stopDaemon();
+			if (stopped) {
+				success(`Daemon stopped (PID ${pid})`);
+			} else {
+				warn("No running daemon found.");
+			}
+		});
+
+	cmd
+		.command("status")
+		.description("Show daemon status")
+		.option("--json", "Output as JSON")
+		.action((opts) => {
+			const { running, pid } = isDaemonRunning();
+
+			// Read persisted state
+			let state = null;
+			if (existsSync(DAEMON_STATE_FILE)) {
+				try {
+					state = JSON.parse(
+						readFileSync(DAEMON_STATE_FILE, "utf-8"),
+					);
+				} catch {
+					// ignore
+				}
+			}
+
+			if (opts.json) {
+				printJson({ running, pid, state });
+				return;
+			}
+
+			if (!running) {
+				warn("Daemon is not running.");
+				if (state) {
+					info(
+						`Last active: ${state.lastTickAt ?? "unknown"} (${state.tickCount} ticks)`,
+					);
+				}
+				return;
+			}
+
+			success(`Daemon running (PID ${pid})`);
+			if (state) {
+				info(`Started: ${state.startedAt}`);
+				info(`Last tick: ${state.lastTickAt} (#${state.tickCount})`);
+				info(
+					`Symphony: ${state.symphonyConnected ? fmt.green("connected") : fmt.red("disconnected")}`,
+				);
+
+				console.log("");
+				info(fmt.bold("Sensors:"));
+				for (const s of Object.values(
+					state.sensors as Record<string, { sensorId: string; status: string; message: string; latencyMs?: number }>,
+				)) {
+					const icon =
+						s.status === "healthy"
+							? fmt.green("●")
+							: s.status === "degraded"
+								? fmt.yellow("●")
+								: s.status === "down"
+									? fmt.red("●")
+									: fmt.dim("●");
+					const latency =
+						s.latencyMs !== undefined ? ` (${s.latencyMs}ms)` : "";
+					console.log(
+						`  ${icon} ${s.sensorId}: ${s.message}${latency}`,
+					);
+				}
+
+				const openIncidents = (
+					state.incidents as Array<{ status: string }>
+				).filter((i) => i.status === "open");
+				if (openIncidents.length > 0) {
+					console.log("");
+					warn(`${openIncidents.length} open incident(s)`);
+				}
+			}
+		});
+
+	cmd
+		.command("logs")
+		.description("View daemon logs")
+		.option("--lines <n>", "Number of lines to show", "20")
+		.option("--level <level>", "Filter by level (debug, info, warn, error)")
+		.option("--json", "Output as JSON")
+		.action((opts) => {
+			const logger = new DaemonLogger();
+			const entries = logger.readLines({
+				lines: Number.parseInt(opts.lines, 10),
+				level: opts.level,
+			});
+
+			if (entries.length === 0) {
+				info("No log entries found.");
+				return;
+			}
+
+			if (opts.json) {
+				printJson(entries);
+				return;
+			}
+
+			for (const entry of entries) {
+				const levelColor =
+					entry.level === "error"
+						? fmt.red
+						: entry.level === "warn"
+							? fmt.yellow
+							: entry.level === "info"
+								? fmt.cyan
+								: fmt.dim;
+				const ts = fmt.dim(entry.timestamp);
+				const lvl = levelColor(entry.level.toUpperCase().padEnd(5));
+				const data = entry.data
+					? fmt.dim(` ${JSON.stringify(entry.data)}`)
+					: "";
+				console.log(`${ts} ${lvl} ${entry.message}${data}`);
+			}
+		});
+
+	cmd
+		.command("tasks")
+		.description("Show active incidents")
+		.option("--json", "Output as JSON")
+		.option("--all", "Include resolved incidents")
+		.action((opts) => {
+			if (!existsSync(DAEMON_STATE_FILE)) {
+				info("No daemon state found. Start the daemon first.");
+				return;
+			}
+
+			let state;
+			try {
+				state = JSON.parse(
+					readFileSync(DAEMON_STATE_FILE, "utf-8"),
+				);
+			} catch {
+				printError("Failed to read daemon state.");
+				return;
+			}
+
+			let incidents = state.incidents ?? [];
+			if (!opts.all) {
+				incidents = incidents.filter(
+					(i: { status: string }) => i.status === "open",
+				);
+			}
+
+			if (opts.json) {
+				printJson(incidents);
+				return;
+			}
+
+			if (incidents.length === 0) {
+				success("No active incidents.");
+				return;
+			}
+
+			for (const i of incidents) {
+				const statusIcon =
+					i.status === "open" ? fmt.red("OPEN") : fmt.green("RESOLVED");
+				console.log(
+					`${statusIcon} ${fmt.bold(i.id)} [${i.sensorId}]`,
+				);
+				console.log(`  ${i.message}`);
+				console.log(
+					`  Opened: ${i.openedAt}${i.resolvedAt ? ` | Resolved: ${i.resolvedAt}` : ""} | Failures: ${i.consecutiveFailures}`,
+				);
+				console.log("");
+			}
+		});
+
+	return cmd;
+}

--- a/packages/cli/src/daemon/dashboard.ts
+++ b/packages/cli/src/daemon/dashboard.ts
@@ -1,0 +1,194 @@
+import { createServer, type Server } from "node:http";
+import type { HeartbeatState } from "../types/daemon.js";
+import type { SymphonyHttpClient } from "./symphony-client.js";
+import { DaemonLogger } from "./logger.js";
+
+export class Dashboard {
+	private server: Server | null = null;
+	private port: number;
+	private logger: DaemonLogger;
+	private getState: () => HeartbeatState;
+	private symphonyClient: SymphonyHttpClient | null;
+
+	constructor(opts: {
+		port: number;
+		logger: DaemonLogger;
+		getState: () => HeartbeatState;
+		symphonyClient: SymphonyHttpClient | null;
+	}) {
+		this.port = opts.port;
+		this.logger = opts.logger;
+		this.getState = opts.getState;
+		this.symphonyClient = opts.symphonyClient;
+	}
+
+	start(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			this.server = createServer(async (req, res) => {
+				const url = new URL(
+					req.url ?? "/",
+					`http://localhost:${this.port}`,
+				);
+
+				try {
+					if (url.pathname === "/healthz") {
+						res.writeHead(200, { "Content-Type": "text/plain" });
+						res.end("OK");
+					} else if (url.pathname === "/api/health") {
+						const state = this.getState();
+						res.writeHead(200, {
+							"Content-Type": "application/json",
+						});
+						res.end(JSON.stringify(state, null, 2));
+					} else if (url.pathname === "/api/symphony") {
+						if (!this.symphonyClient) {
+							res.writeHead(503, {
+								"Content-Type": "application/json",
+							});
+							res.end(
+								JSON.stringify({
+									error: "Symphony not configured",
+								}),
+							);
+							return;
+						}
+						const state = await this.symphonyClient.getState();
+						res.writeHead(state ? 200 : 503, {
+							"Content-Type": "application/json",
+						});
+						res.end(
+							JSON.stringify(
+								state ?? { error: "Symphony unreachable" },
+								null,
+								2,
+							),
+						);
+					} else if (url.pathname === "/") {
+						const state = this.getState();
+						res.writeHead(200, { "Content-Type": "text/html" });
+						res.end(renderDashboard(state));
+					} else {
+						res.writeHead(404, {
+							"Content-Type": "text/plain",
+						});
+						res.end("Not found");
+					}
+				} catch (err) {
+					this.logger.error("Dashboard request error", {
+						path: url.pathname,
+						error:
+							err instanceof Error
+								? err.message
+								: String(err),
+					});
+					res.writeHead(500, {
+						"Content-Type": "text/plain",
+					});
+					res.end("Internal error");
+				}
+			});
+
+			this.server.on("error", (err) => {
+				this.logger.error("Dashboard server error", {
+					error: err.message,
+				});
+				reject(err);
+			});
+
+			this.server.listen(this.port, () => {
+				this.logger.info(`Dashboard listening on port ${this.port}`);
+				resolve();
+			});
+		});
+	}
+
+	stop(): void {
+		if (this.server) {
+			this.server.close();
+			this.server = null;
+		}
+	}
+}
+
+function renderDashboard(state: HeartbeatState): string {
+	const sensorRows = Object.values(state.sensors)
+		.map((s) => {
+			const color =
+				s.status === "healthy"
+					? "#22c55e"
+					: s.status === "degraded"
+						? "#eab308"
+						: s.status === "down"
+							? "#ef4444"
+							: "#6b7280";
+			const latency =
+				s.latencyMs !== undefined ? `${s.latencyMs}ms` : "—";
+			return `<tr>
+				<td><span style="color:${color}; font-weight:bold;">${s.status.toUpperCase()}</span></td>
+				<td>${s.sensorId}</td>
+				<td>${s.message}</td>
+				<td>${latency}</td>
+				<td>${s.timestamp}</td>
+			</tr>`;
+		})
+		.join("\n");
+
+	const openIncidents = state.incidents.filter((i) => i.status === "open");
+	const incidentRows =
+		openIncidents.length > 0
+			? openIncidents
+					.map(
+						(i) => `<tr>
+				<td>${i.id}</td>
+				<td>${i.sensorId}</td>
+				<td>${i.message}</td>
+				<td>${i.consecutiveFailures}</td>
+				<td>${i.openedAt}</td>
+			</tr>`,
+					)
+					.join("\n")
+			: '<tr><td colspan="5" style="text-align:center; color:#6b7280;">No open incidents</td></tr>';
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="refresh" content="10">
+<title>broomvad — Dashboard</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+         background: #0a0a0a; color: #e5e5e5; padding: 2rem; }
+  h1 { font-size: 1.5rem; margin-bottom: 0.5rem; color: #fff; }
+  .meta { color: #6b7280; font-size: 0.85rem; margin-bottom: 2rem; }
+  h2 { font-size: 1.1rem; margin: 1.5rem 0 0.5rem; color: #d1d5db; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 1rem; }
+  th, td { text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #1f1f1f; }
+  th { color: #9ca3af; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  .symphony { padding: 0.5rem 0.75rem; background: #111; border-radius: 4px; }
+  .symphony.connected { border-left: 3px solid #22c55e; }
+  .symphony.disconnected { border-left: 3px solid #ef4444; }
+</style>
+</head>
+<body>
+<h1>broomvad</h1>
+<div class="meta">
+  Started: ${state.startedAt} | Last tick: ${state.lastTickAt ?? "—"} | Ticks: ${state.tickCount}
+  | Symphony: <span style="color:${state.symphonyConnected ? "#22c55e" : "#ef4444"}">${state.symphonyConnected ? "connected" : "disconnected"}</span>
+</div>
+
+<h2>Sensors</h2>
+<table>
+<tr><th>Status</th><th>Sensor</th><th>Message</th><th>Latency</th><th>Checked</th></tr>
+${sensorRows || '<tr><td colspan="5" style="text-align:center; color:#6b7280;">No sensor data yet</td></tr>'}
+</table>
+
+<h2>Open Incidents</h2>
+<table>
+<tr><th>ID</th><th>Sensor</th><th>Message</th><th>Failures</th><th>Opened</th></tr>
+${incidentRows}
+</table>
+</body>
+</html>`;
+}

--- a/packages/cli/src/daemon/heartbeat.ts
+++ b/packages/cli/src/daemon/heartbeat.ts
@@ -1,0 +1,223 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	DAEMON_STATE_FILE,
+	DEFAULT_HEARTBEAT_INTERVAL_MS,
+	DEFAULT_INCIDENT_THRESHOLD,
+} from "../lib/constants.js";
+import { resolveToken } from "../lib/auth-store.js";
+import type { DaemonConfig } from "../types/config.js";
+import type { HeartbeatState, Incident } from "../types/daemon.js";
+import type { Sensor, SensorContext } from "./sensors/index.js";
+import { DaemonLogger } from "./logger.js";
+
+export class HeartbeatLoop {
+	private sensors: Sensor[];
+	private config: DaemonConfig;
+	private apiBase: string;
+	private logger: DaemonLogger;
+	private intervalId: ReturnType<typeof setInterval> | null = null;
+	private failureCounts: Map<string, number> = new Map();
+	private state: HeartbeatState;
+	private onTick?: (state: HeartbeatState) => void;
+
+	constructor(opts: {
+		sensors: Sensor[];
+		config: DaemonConfig;
+		apiBase: string;
+		logger: DaemonLogger;
+		onTick?: (state: HeartbeatState) => void;
+	}) {
+		this.sensors = opts.sensors;
+		this.config = opts.config;
+		this.apiBase = opts.apiBase;
+		this.logger = opts.logger;
+		this.onTick = opts.onTick;
+
+		// Try to restore state from disk
+		this.state = this.loadState() ?? {
+			startedAt: new Date().toISOString(),
+			lastTickAt: null,
+			tickCount: 0,
+			sensors: {},
+			incidents: [],
+			symphonyConnected: false,
+		};
+	}
+
+	getState(): HeartbeatState {
+		return this.state;
+	}
+
+	start(): void {
+		if (this.intervalId) return;
+
+		const interval =
+			this.config.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+
+		this.logger.info("Heartbeat loop starting", {
+			intervalMs: interval,
+			sensorCount: this.sensors.length,
+		});
+
+		// Run immediately, then on interval
+		this.tick();
+		this.intervalId = setInterval(() => this.tick(), interval);
+	}
+
+	stop(): void {
+		if (this.intervalId) {
+			clearInterval(this.intervalId);
+			this.intervalId = null;
+			this.logger.info("Heartbeat loop stopped");
+		}
+	}
+
+	private async tick(): Promise<void> {
+		// Re-resolve token on each tick (handles rotation)
+		const tokenInfo = resolveToken();
+		const token = tokenInfo?.token ?? null;
+
+		const ctx: SensorContext = {
+			token,
+			config: this.config,
+			apiBase: this.apiBase,
+		};
+
+		const threshold =
+			this.config.incidentThreshold ?? DEFAULT_INCIDENT_THRESHOLD;
+
+		for (const sensor of this.sensors) {
+			try {
+				const result = await sensor.run(ctx);
+				this.state.sensors[sensor.id] = result;
+
+				if (result.status === "healthy") {
+					// Reset failure count on recovery
+					const prevCount = this.failureCounts.get(sensor.id) ?? 0;
+					this.failureCounts.set(sensor.id, 0);
+
+					// Resolve open incident if any
+					if (prevCount >= threshold) {
+						this.resolveIncident(sensor.id);
+					}
+				} else if (
+					result.status === "down" ||
+					result.status === "degraded"
+				) {
+					const count =
+						(this.failureCounts.get(sensor.id) ?? 0) + 1;
+					this.failureCounts.set(sensor.id, count);
+
+					if (count >= threshold) {
+						this.openIncident(sensor.id, result.message, count);
+					}
+
+					this.logger.warn(`Sensor ${sensor.id}: ${result.status}`, {
+						message: result.message,
+						consecutiveFailures: count,
+					});
+				}
+			} catch (err) {
+				const msg =
+					err instanceof Error ? err.message : String(err);
+				this.logger.error(`Sensor ${sensor.id} threw`, {
+					error: msg,
+				});
+				this.state.sensors[sensor.id] = {
+					sensorId: sensor.id,
+					status: "down",
+					message: `Sensor error: ${msg}`,
+					timestamp: new Date().toISOString(),
+				};
+
+				const count =
+					(this.failureCounts.get(sensor.id) ?? 0) + 1;
+				this.failureCounts.set(sensor.id, count);
+
+				if (count >= threshold) {
+					this.openIncident(sensor.id, msg, count);
+				}
+			}
+		}
+
+		// Check Symphony connectivity
+		this.state.symphonyConnected = Boolean(
+			this.state.sensors["railway-symphony"]?.status === "healthy",
+		);
+
+		this.state.lastTickAt = new Date().toISOString();
+		this.state.tickCount++;
+
+		this.persistState();
+		this.onTick?.(this.state);
+	}
+
+	private openIncident(
+		sensorId: string,
+		message: string,
+		failures: number,
+	): void {
+		// Don't duplicate open incidents for the same sensor
+		const existing = this.state.incidents.find(
+			(i) => i.sensorId === sensorId && i.status === "open",
+		);
+		if (existing) {
+			existing.consecutiveFailures = failures;
+			existing.message = message;
+			return;
+		}
+
+		const incident: Incident = {
+			id: `inc-${sensorId}-${Date.now()}`,
+			sensorId,
+			status: "open",
+			message,
+			openedAt: new Date().toISOString(),
+			consecutiveFailures: failures,
+		};
+
+		this.state.incidents.push(incident);
+		this.logger.error("Incident opened", {
+			incidentId: incident.id,
+			sensorId,
+			message,
+		});
+	}
+
+	private resolveIncident(sensorId: string): void {
+		for (const incident of this.state.incidents) {
+			if (incident.sensorId === sensorId && incident.status === "open") {
+				incident.status = "resolved";
+				incident.resolvedAt = new Date().toISOString();
+				this.logger.info("Incident resolved", {
+					incidentId: incident.id,
+					sensorId,
+				});
+			}
+		}
+	}
+
+	private persistState(): void {
+		try {
+			writeFileSync(
+				DAEMON_STATE_FILE,
+				JSON.stringify(this.state, null, 2) + "\n",
+				{ mode: 0o600 },
+			);
+		} catch (err) {
+			this.logger.error("Failed to persist state", {
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	private loadState(): HeartbeatState | null {
+		if (!existsSync(DAEMON_STATE_FILE)) return null;
+		try {
+			const raw = readFileSync(DAEMON_STATE_FILE, "utf-8");
+			return JSON.parse(raw) as HeartbeatState;
+		} catch {
+			return null;
+		}
+	}
+}

--- a/packages/cli/src/daemon/logger.ts
+++ b/packages/cli/src/daemon/logger.ts
@@ -1,0 +1,81 @@
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { DAEMON_LOG_FILE } from "../lib/constants.js";
+import type { DaemonLogEntry } from "../types/daemon.js";
+
+export class DaemonLogger {
+	private filePath: string;
+
+	constructor(filePath: string = DAEMON_LOG_FILE) {
+		this.filePath = filePath;
+		const dir = dirname(this.filePath);
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true, mode: 0o700 });
+		}
+	}
+
+	private write(
+		level: DaemonLogEntry["level"],
+		message: string,
+		data?: Record<string, unknown>,
+	): void {
+		const entry: DaemonLogEntry = {
+			timestamp: new Date().toISOString(),
+			level,
+			message,
+			...(data ? { data } : {}),
+		};
+		appendFileSync(this.filePath, JSON.stringify(entry) + "\n");
+	}
+
+	debug(message: string, data?: Record<string, unknown>): void {
+		this.write("debug", message, data);
+	}
+
+	info(message: string, data?: Record<string, unknown>): void {
+		this.write("info", message, data);
+	}
+
+	warn(message: string, data?: Record<string, unknown>): void {
+		this.write("warn", message, data);
+	}
+
+	error(message: string, data?: Record<string, unknown>): void {
+		this.write("error", message, data);
+	}
+
+	readLines(opts?: {
+		lines?: number;
+		level?: string;
+	}): DaemonLogEntry[] {
+		if (!existsSync(this.filePath)) return [];
+		const raw = readFileSync(this.filePath, "utf-8").trim();
+		if (!raw) return [];
+
+		let entries = raw
+			.split("\n")
+			.map((line) => {
+				try {
+					return JSON.parse(line) as DaemonLogEntry;
+				} catch {
+					return null;
+				}
+			})
+			.filter((e): e is DaemonLogEntry => e !== null);
+
+		if (opts?.level) {
+			entries = entries.filter((e) => e.level === opts.level);
+		}
+
+		if (opts?.lines) {
+			entries = entries.slice(-opts.lines);
+		}
+
+		return entries;
+	}
+}

--- a/packages/cli/src/daemon/process.ts
+++ b/packages/cli/src/daemon/process.ts
@@ -1,0 +1,64 @@
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { DAEMON_PID_FILE } from "../lib/constants.js";
+
+export function writePidFile(pid: number): void {
+	const dir = dirname(DAEMON_PID_FILE);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+	}
+	writeFileSync(DAEMON_PID_FILE, String(pid), { mode: 0o600 });
+}
+
+export function readPidFile(): number | null {
+	if (!existsSync(DAEMON_PID_FILE)) return null;
+	try {
+		const raw = readFileSync(DAEMON_PID_FILE, "utf-8").trim();
+		const pid = Number.parseInt(raw, 10);
+		return Number.isNaN(pid) ? null : pid;
+	} catch {
+		return null;
+	}
+}
+
+export function removePidFile(): void {
+	if (existsSync(DAEMON_PID_FILE)) {
+		unlinkSync(DAEMON_PID_FILE);
+	}
+}
+
+export function isDaemonRunning(): { running: boolean; pid: number | null } {
+	const pid = readPidFile();
+	if (pid === null) return { running: false, pid: null };
+
+	try {
+		process.kill(pid, 0);
+		return { running: true, pid };
+	} catch {
+		// Process doesn't exist — stale PID file
+		removePidFile();
+		return { running: false, pid: null };
+	}
+}
+
+export function stopDaemon(): { stopped: boolean; pid: number | null } {
+	const { running, pid } = isDaemonRunning();
+	if (!running || pid === null) {
+		return { stopped: false, pid: null };
+	}
+
+	try {
+		process.kill(pid, "SIGTERM");
+		removePidFile();
+		return { stopped: true, pid };
+	} catch {
+		removePidFile();
+		return { stopped: false, pid };
+	}
+}

--- a/packages/cli/src/daemon/sensors/api-health.ts
+++ b/packages/cli/src/daemon/sensors/api-health.ts
@@ -1,0 +1,77 @@
+import type { Sensor, SensorContext } from "./index.js";
+import type { SensorResult } from "../../types/daemon.js";
+
+export class ApiHealthSensor implements Sensor {
+	id = "api-health";
+	name = "API Health";
+
+	async run(ctx: SensorContext): Promise<SensorResult> {
+		const timestamp = new Date().toISOString();
+		const endpoints = [
+			{ label: "skills", path: "/api/skills", auth: false },
+			{ label: "context", path: "/api/context", auth: false },
+			{
+				label: "auth-device",
+				path: "/api/auth/device/code",
+				auth: false,
+				method: "OPTIONS",
+			},
+		];
+
+		if (ctx.token) {
+			endpoints.push({
+				label: "prompts-user",
+				path: "/api/prompts/user",
+				auth: true,
+				method: "GET",
+			});
+		}
+
+		const results: Record<string, unknown> = {};
+		let healthyCount = 0;
+
+		for (const ep of endpoints) {
+			const url = `${ctx.apiBase}${ep.path}`;
+			const start = Date.now();
+			try {
+				const headers: Record<string, string> = {};
+				if (ep.auth && ctx.token) {
+					headers.Authorization = `Bearer ${ctx.token}`;
+				}
+				const res = await fetch(url, {
+					method: (ep as { method?: string }).method ?? "GET",
+					headers,
+					signal: AbortSignal.timeout(10_000),
+				});
+				const latency = Date.now() - start;
+				const ok = res.status < 500;
+				if (ok) healthyCount++;
+				results[ep.label] = {
+					status: res.status,
+					latencyMs: latency,
+					ok,
+				};
+			} catch (err) {
+				const latency = Date.now() - start;
+				results[ep.label] = {
+					status: 0,
+					latencyMs: latency,
+					ok: false,
+					error: err instanceof Error ? err.message : String(err),
+				};
+			}
+		}
+
+		const total = endpoints.length;
+		const allOk = healthyCount === total;
+		const someOk = healthyCount > 0;
+
+		return {
+			sensorId: this.id,
+			status: allOk ? "healthy" : someOk ? "degraded" : "down",
+			message: `${healthyCount}/${total} API endpoints healthy`,
+			timestamp,
+			data: results,
+		};
+	}
+}

--- a/packages/cli/src/daemon/sensors/index.ts
+++ b/packages/cli/src/daemon/sensors/index.ts
@@ -1,0 +1,28 @@
+import type { DaemonConfig } from "../../types/config.js";
+import type { SensorResult } from "../../types/daemon.js";
+
+export interface SensorContext {
+	token: string | null;
+	config: DaemonConfig;
+	apiBase: string;
+}
+
+export interface Sensor {
+	id: string;
+	name: string;
+	run(ctx: SensorContext): Promise<SensorResult>;
+}
+
+const registry: Sensor[] = [];
+
+export function registerSensor(sensor: Sensor): void {
+	registry.push(sensor);
+}
+
+export function getSensors(): Sensor[] {
+	return [...registry];
+}
+
+export function clearSensors(): void {
+	registry.length = 0;
+}

--- a/packages/cli/src/daemon/sensors/railway-health.ts
+++ b/packages/cli/src/daemon/sensors/railway-health.ts
@@ -1,0 +1,127 @@
+import type { Sensor, SensorContext } from "./index.js";
+import type { SensorResult } from "../../types/daemon.js";
+
+export class RailwayHealthSensor implements Sensor {
+	id: string;
+	name: string;
+	private serviceKey: "symphonyUrl" | "arcanUrl" | "lagoUrl" | "autonomicUrl";
+
+	constructor(
+		serviceId: string,
+		serviceName: string,
+		serviceKey: "symphonyUrl" | "arcanUrl" | "lagoUrl" | "autonomicUrl",
+	) {
+		this.id = `railway-${serviceId}`;
+		this.name = `Railway ${serviceName}`;
+		this.serviceKey = serviceKey;
+	}
+
+	async run(ctx: SensorContext): Promise<SensorResult> {
+		const timestamp = new Date().toISOString();
+		const baseUrl = ctx.config[this.serviceKey];
+
+		if (!baseUrl) {
+			return {
+				sensorId: this.id,
+				status: "unknown",
+				message: `${this.name}: URL not configured (set daemon.${this.serviceKey})`,
+				timestamp,
+			};
+		}
+
+		const healthPaths = ["/healthz", "/health"];
+		const results: Record<string, unknown> = {};
+
+		for (const path of healthPaths) {
+			const url = `${baseUrl.replace(/\/$/, "")}${path}`;
+			const start = Date.now();
+			try {
+				const headers: Record<string, string> = {};
+				if (ctx.token) {
+					headers.Authorization = `Bearer ${ctx.token}`;
+				}
+				const res = await fetch(url, {
+					headers,
+					signal: AbortSignal.timeout(10_000),
+				});
+				const latency = Date.now() - start;
+
+				if (res.ok) {
+					results.health = {
+						path,
+						status: res.status,
+						latencyMs: latency,
+						ok: true,
+					};
+
+					// For Symphony, also try to get state
+					if (this.serviceKey === "symphonyUrl") {
+						await this.checkSymphonyState(baseUrl, ctx.token, results);
+					}
+
+					return {
+						sensorId: this.id,
+						status: "healthy",
+						message: `${this.name} responding on ${path}`,
+						latencyMs: latency,
+						timestamp,
+						data: results,
+					};
+				}
+
+				results[path] = { status: res.status, latencyMs: latency, ok: false };
+			} catch (err) {
+				const latency = Date.now() - start;
+				results[path] = {
+					status: 0,
+					latencyMs: latency,
+					ok: false,
+					error: err instanceof Error ? err.message : String(err),
+				};
+			}
+		}
+
+		return {
+			sensorId: this.id,
+			status: "down",
+			message: `${this.name} unreachable`,
+			timestamp,
+			data: results,
+		};
+	}
+
+	private async checkSymphonyState(
+		baseUrl: string,
+		token: string | null,
+		results: Record<string, unknown>,
+	): Promise<void> {
+		try {
+			const headers: Record<string, string> = {};
+			if (token) {
+				headers.Authorization = `Bearer ${token}`;
+			}
+			const res = await fetch(
+				`${baseUrl.replace(/\/$/, "")}/api/v1/state`,
+				{
+					headers,
+					signal: AbortSignal.timeout(10_000),
+				},
+			);
+			if (res.ok) {
+				const state = await res.json();
+				results.symphonyState = state;
+			}
+		} catch {
+			// Symphony state check is best-effort
+		}
+	}
+}
+
+export function createRailwaySensors(): RailwayHealthSensor[] {
+	return [
+		new RailwayHealthSensor("symphony", "Symphony", "symphonyUrl"),
+		new RailwayHealthSensor("arcan", "Arcan", "arcanUrl"),
+		new RailwayHealthSensor("lago", "Lago", "lagoUrl"),
+		new RailwayHealthSensor("autonomic", "Autonomic", "autonomicUrl"),
+	];
+}

--- a/packages/cli/src/daemon/sensors/site-health.ts
+++ b/packages/cli/src/daemon/sensors/site-health.ts
@@ -1,0 +1,58 @@
+import type { Sensor, SensorContext } from "./index.js";
+import type { SensorResult } from "../../types/daemon.js";
+
+export class SiteHealthSensor implements Sensor {
+	id = "site-health";
+	name = "Site Health";
+
+	async run(ctx: SensorContext): Promise<SensorResult> {
+		const timestamp = new Date().toISOString();
+		const urls = [
+			{ label: "homepage", path: "/" },
+			{ label: "prompts-api", path: "/api/prompts" },
+		];
+
+		const results: Record<string, unknown> = {};
+		let allOk = true;
+		let worstLatency = 0;
+
+		for (const { label, path } of urls) {
+			const url = `${ctx.apiBase}${path}`;
+			const start = Date.now();
+			try {
+				const res = await fetch(url, {
+					signal: AbortSignal.timeout(10_000),
+				});
+				const latency = Date.now() - start;
+				worstLatency = Math.max(worstLatency, latency);
+				results[label] = {
+					status: res.status,
+					latencyMs: latency,
+					ok: res.ok,
+				};
+				if (!res.ok) allOk = false;
+			} catch (err) {
+				const latency = Date.now() - start;
+				worstLatency = Math.max(worstLatency, latency);
+				allOk = false;
+				results[label] = {
+					status: 0,
+					latencyMs: latency,
+					ok: false,
+					error: err instanceof Error ? err.message : String(err),
+				};
+			}
+		}
+
+		return {
+			sensorId: this.id,
+			status: allOk ? "healthy" : "down",
+			message: allOk
+				? `All ${urls.length} endpoints responding`
+				: "One or more endpoints unreachable",
+			latencyMs: worstLatency,
+			timestamp,
+			data: results,
+		};
+	}
+}

--- a/packages/cli/src/daemon/symphony-client.ts
+++ b/packages/cli/src/daemon/symphony-client.ts
@@ -1,0 +1,73 @@
+import type { SymphonyState, SymphonyIssue } from "../types/daemon.js";
+
+export class SymphonyHttpClient {
+	private baseUrl: string;
+	private token: string | null;
+
+	constructor(baseUrl: string, token: string | null = null) {
+		this.baseUrl = baseUrl.replace(/\/$/, "");
+		this.token = token;
+	}
+
+	updateToken(token: string | null): void {
+		this.token = token;
+	}
+
+	private headers(): Record<string, string> {
+		const h: Record<string, string> = {
+			"Content-Type": "application/json",
+		};
+		if (this.token) {
+			h.Authorization = `Bearer ${this.token}`;
+		}
+		return h;
+	}
+
+	private async request<T>(
+		method: string,
+		path: string,
+	): Promise<T | null> {
+		try {
+			const res = await fetch(`${this.baseUrl}${path}`, {
+				method,
+				headers: this.headers(),
+				signal: AbortSignal.timeout(10_000),
+			});
+			if (!res.ok) return null;
+			return (await res.json()) as T;
+		} catch {
+			return null;
+		}
+	}
+
+	async isRunning(): Promise<boolean> {
+		try {
+			const res = await fetch(`${this.baseUrl}/healthz`, {
+				signal: AbortSignal.timeout(5_000),
+			});
+			return res.ok;
+		} catch {
+			return false;
+		}
+	}
+
+	async getState(): Promise<SymphonyState | null> {
+		return this.request<SymphonyState>("GET", "/api/v1/state");
+	}
+
+	async getIssue(id: string): Promise<SymphonyIssue | null> {
+		return this.request<SymphonyIssue>("GET", `/api/v1/issues/${id}`);
+	}
+
+	async refresh(): Promise<boolean> {
+		const result = await this.request<{ ok: boolean }>(
+			"POST",
+			"/api/v1/refresh",
+		);
+		return result?.ok ?? false;
+	}
+
+	async getMetrics(): Promise<Record<string, unknown> | null> {
+		return this.request<Record<string, unknown>>("GET", "/api/v1/metrics");
+	}
+}

--- a/packages/cli/src/lib/constants.ts
+++ b/packages/cli/src/lib/constants.ts
@@ -7,3 +7,11 @@ export const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 export const TOKEN_ENV_VAR = "BROOMVA_API_TOKEN";
 export const PACKAGE_NAME = "@broomva/cli";
 export const BIN_NAME = "broomva";
+
+// Daemon constants
+export const DAEMON_PID_FILE = join(CONFIG_DIR, "daemon.pid");
+export const DAEMON_LOG_FILE = join(CONFIG_DIR, "daemon.log");
+export const DAEMON_STATE_FILE = join(CONFIG_DIR, "daemon-state.json");
+export const DEFAULT_DASHBOARD_PORT = 7890;
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
+export const DEFAULT_INCIDENT_THRESHOLD = 3;

--- a/packages/cli/src/types/config.ts
+++ b/packages/cli/src/types/config.ts
@@ -1,6 +1,17 @@
+export interface DaemonConfig {
+  heartbeatIntervalMs?: number;
+  dashboardPort?: number;
+  symphonyUrl?: string;
+  arcanUrl?: string;
+  lagoUrl?: string;
+  autonomicUrl?: string;
+  incidentThreshold?: number;
+}
+
 export interface CliConfig {
   token?: string;
   tokenExpiresAt?: string;
   apiBase?: string;
   defaultFormat?: "table" | "json";
+  daemon?: DaemonConfig;
 }

--- a/packages/cli/src/types/daemon.ts
+++ b/packages/cli/src/types/daemon.ts
@@ -1,0 +1,50 @@
+export type SensorStatus = "healthy" | "degraded" | "down" | "unknown";
+
+export interface SensorResult {
+	sensorId: string;
+	status: SensorStatus;
+	message: string;
+	latencyMs?: number;
+	timestamp: string;
+	data?: Record<string, unknown>;
+}
+
+export interface Incident {
+	id: string;
+	sensorId: string;
+	status: "open" | "resolved";
+	message: string;
+	openedAt: string;
+	resolvedAt?: string;
+	consecutiveFailures: number;
+}
+
+export interface HeartbeatState {
+	startedAt: string;
+	lastTickAt: string | null;
+	tickCount: number;
+	sensors: Record<string, SensorResult>;
+	incidents: Incident[];
+	symphonyConnected: boolean;
+}
+
+export interface SymphonyState {
+	running: boolean;
+	issues?: SymphonyIssue[];
+	metrics?: Record<string, unknown>;
+}
+
+export interface SymphonyIssue {
+	id: string;
+	title: string;
+	status: string;
+	priority?: string;
+	createdAt?: string;
+}
+
+export interface DaemonLogEntry {
+	timestamp: string;
+	level: "debug" | "info" | "warn" | "error";
+	message: string;
+	data?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- Adds `broomva daemon` command with `start`, `stop`, `status`, `logs`, and `tasks` subcommands
- Implements health sensors (site, API, Railway) with heartbeat loop and incident tracking
- Includes local HTTP dashboard and Symphony client integration
- Extends `broomva config set` to support `daemon.*` nested keys

## Test plan
- [ ] `broomva daemon start` starts the daemon and displays dashboard URL
- [ ] `broomva daemon status` shows sensor health and incident counts
- [ ] `broomva daemon stop` gracefully shuts down
- [ ] `broomva daemon logs` displays structured log entries
- [ ] `broomva config set daemon.dashboardPort 8080` persists config
- [ ] Build passes with `bun run build` in packages/cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)