### PR TITLE
feat: Lago-backed context engine — user memory vault + dual-vault search

### DIFF
--- a/apps/chat/app/api/auth/api-token/route.ts
+++ b/apps/chat/app/api/auth/api-token/route.ts
@@ -4,6 +4,7 @@ import { getSafeSession } from "@/lib/auth";
 import { db } from "@/lib/db/client";
 import { session } from "@/lib/db/schema";
 import { eq, and, gt, desc } from "drizzle-orm";
+import { signLagoJWT } from "@/lib/ai/vault/jwt";
 
 /**
  * GET /api/auth/api-token
@@ -46,13 +47,25 @@ export async function GET() {
     );
   }
 
+  // Sign a JWT for Lago auth (shared secret with lagod)
+  let lagoToken: string | undefined;
+  try {
+    lagoToken = await signLagoJWT({
+      id: sessionData.user.id,
+      email: sessionData.user.email ?? "",
+    });
+  } catch {
+    // Non-fatal — Lago JWT is optional
+  }
+
   return NextResponse.json({
     token: activeSession.token,
+    ...(lagoToken ? { lagoToken } : {}),
     expiresAt: activeSession.expiresAt.toISOString(),
     usage: {
       header: `Authorization: Bearer ${activeSession.token}`,
-      env: `export BROOMVA_API_TOKEN="${activeSession.token}"`,
-      cli: `prompt-sync.py remote-push --token "${activeSession.token}" ...`,
+      env: `export BROOMVA_API_TOKEN="${lagoToken ?? activeSession.token}"`,
+      cli: `lago memory search "query" --token "${lagoToken ?? activeSession.token}"`,
     },
   });
 }

--- a/apps/chat/app/api/memory/files/[...path]/route.ts
+++ b/apps/chat/app/api/memory/files/[...path]/route.ts
@@ -1,0 +1,108 @@
+/**
+ * /api/memory/files/[...path] — proxy GET/PUT/DELETE to lagod /v1/memory/files/*
+ */
+
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { getSafeSession } from "@/lib/auth";
+import { signLagoJWT } from "@/lib/ai/vault/jwt";
+
+async function getAuthContext() {
+  const { data: sessionData } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!sessionData?.user?.id) {
+    return { error: "Not authenticated" as const };
+  }
+
+  const lagoUrl = process.env.LAGO_URL;
+  if (!lagoUrl) {
+    return { error: "Lago not configured" as const };
+  }
+
+  const token = await signLagoJWT({
+    id: sessionData.user.id,
+    email: sessionData.user.email ?? "",
+  });
+
+  return { lagoUrl, token };
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const ctx = await getAuthContext();
+  if ("error" in ctx) {
+    return NextResponse.json(
+      { error: ctx.error },
+      { status: ctx.error === "Not authenticated" ? 401 : 503 }
+    );
+  }
+
+  const { path } = await params;
+  const filePath = `/${path.join("/")}`;
+  const encoded = encodeURIComponent(filePath);
+
+  const res = await fetch(`${ctx.lagoUrl}/v1/memory/files/${encoded}`, {
+    headers: { Authorization: `Bearer ${ctx.token}` },
+  });
+
+  const text = await res.text();
+  return new NextResponse(text, {
+    status: res.status,
+    headers: { "Content-Type": res.headers.get("content-type") ?? "text/plain" },
+  });
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const ctx = await getAuthContext();
+  if ("error" in ctx) {
+    return NextResponse.json(
+      { error: ctx.error },
+      { status: ctx.error === "Not authenticated" ? 401 : 503 }
+    );
+  }
+
+  const { path } = await params;
+  const filePath = `/${path.join("/")}`;
+  const encoded = encodeURIComponent(filePath);
+  const body = await request.text();
+
+  const res = await fetch(`${ctx.lagoUrl}/v1/memory/files/${encoded}`, {
+    method: "PUT",
+    headers: { Authorization: `Bearer ${ctx.token}` },
+    body,
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const ctx = await getAuthContext();
+  if ("error" in ctx) {
+    return NextResponse.json(
+      { error: ctx.error },
+      { status: ctx.error === "Not authenticated" ? 401 : 503 }
+    );
+  }
+
+  const { path } = await params;
+  const filePath = `/${path.join("/")}`;
+  const encoded = encodeURIComponent(filePath);
+
+  const res = await fetch(`${ctx.lagoUrl}/v1/memory/files/${encoded}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${ctx.token}` },
+  });
+
+  return new NextResponse(null, { status: res.status });
+}

--- a/apps/chat/app/api/memory/search/route.ts
+++ b/apps/chat/app/api/memory/search/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/memory/search — proxy to lagod /v1/memory/search
+ *
+ * Server-side scored search with optional graph traversal.
+ */
+
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { getSafeSession } from "@/lib/auth";
+import { signLagoJWT } from "@/lib/ai/vault/jwt";
+
+export async function POST(request: Request) {
+  const { data: sessionData } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!sessionData?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const lagoUrl = process.env.LAGO_URL;
+  if (!lagoUrl) {
+    return NextResponse.json(
+      { error: "Lago not configured" },
+      { status: 503 }
+    );
+  }
+
+  const token = await signLagoJWT({
+    id: sessionData.user.id,
+    email: sessionData.user.email ?? "",
+  });
+
+  const body = await request.json();
+
+  const res = await fetch(`${lagoUrl}/v1/memory/search`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/chat/app/api/memory/traverse/route.ts
+++ b/apps/chat/app/api/memory/traverse/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/memory/traverse — proxy to lagod /v1/memory/traverse
+ *
+ * BFS graph traversal over wikilink edges.
+ */
+
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { getSafeSession } from "@/lib/auth";
+import { signLagoJWT } from "@/lib/ai/vault/jwt";
+
+export async function POST(request: Request) {
+  const { data: sessionData } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!sessionData?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const lagoUrl = process.env.LAGO_URL;
+  if (!lagoUrl) {
+    return NextResponse.json(
+      { error: "Lago not configured" },
+      { status: 503 }
+    );
+  }
+
+  const token = await signLagoJWT({
+    id: sessionData.user.id,
+    email: sessionData.user.email ?? "",
+  });
+
+  const body = await request.json();
+
+  const res = await fetch(`${lagoUrl}/v1/memory/traverse`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/chat/app/api/memory/vault/route.ts
+++ b/apps/chat/app/api/memory/vault/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /api/memory/vault — proxy to lagod /v1/memory/manifest
+ *
+ * Lists all files in the authenticated user's Lago vault.
+ */
+
+import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { getSafeSession } from "@/lib/auth";
+import { signLagoJWT } from "@/lib/ai/vault/jwt";
+
+export async function GET() {
+  const { data: sessionData } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!sessionData?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const lagoUrl = process.env.LAGO_URL;
+  if (!lagoUrl) {
+    return NextResponse.json(
+      { error: "Lago not configured" },
+      { status: 503 }
+    );
+  }
+
+  const token = await signLagoJWT({
+    id: sessionData.user.id,
+    email: sessionData.user.email ?? "",
+  });
+
+  const res = await fetch(`${lagoUrl}/v1/memory/manifest`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/chat/chat.config.ts
+++ b/apps/chat/chat.config.ts
@@ -54,6 +54,7 @@ const config = {
     attachments: true, // Requires BLOB_READ_WRITE_TOKEN
     followupSuggestions: true,
     knowledgeGraph: true, // Requires VAULT_PATH
+    memoryVault: false, // Requires LAGO_URL
   },
   legal: {
     minimumAge: 13,

--- a/apps/chat/lib/ai/tools/knowledge-graph.ts
+++ b/apps/chat/lib/ai/tools/knowledge-graph.ts
@@ -1,11 +1,15 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { createModuleLogger } from "@/lib/logger";
+import { config } from "@/lib/config";
 import {
   extractWikilinks,
   resolveWikilink,
   searchVault,
 } from "../vault/reader";
+import { LagoVaultBackend } from "../vault/lago-backend";
+import { signLagoJWT } from "../vault/jwt";
+import type { ToolSession } from "./types";
 
 const log = createModuleLogger("tools/knowledge-graph");
 
@@ -23,65 +27,179 @@ function truncateBody(body: string, maxChars = 3000): string {
   return `${body.slice(0, maxChars)}\n\n… (truncated, ${body.length} chars total)`;
 }
 
-export const searchKnowledge = tool({
-  description: `Search the Broomva knowledge graph — an Obsidian vault containing architecture docs, project state, decisions, conventions, governance policies, and conversation history across all projects (Life/aiOS, Symphony, ChatOS, Control Kernel).
+/** Get a LagoVaultBackend for the authenticated user, if configured. */
+async function getUserLagoBackend(
+  session: ToolSession
+): Promise<LagoVaultBackend | null> {
+  if (!config.features.memoryVault) return null;
+
+  const lagoUrl = process.env.LAGO_URL;
+  if (!lagoUrl) return null;
+
+  const userId = session.user?.id;
+  const email = session.user?.email;
+  if (!userId || !email) return null;
+
+  try {
+    const token = await signLagoJWT({ id: userId, email });
+    return new LagoVaultBackend(lagoUrl, token);
+  } catch {
+    return null;
+  }
+}
+
+/** Merge and rank results from multiple sources, deduplicating by path. */
+function mergeAndRank(
+  results: Array<{
+    name: string;
+    path: string;
+    frontmatter: Record<string, unknown>;
+    excerpts: string[];
+    outgoingLinks: string[];
+    score: number;
+    source: string;
+  }>,
+  maxResults: number
+): typeof results {
+  const seen = new Set<string>();
+  const deduped: typeof results = [];
+
+  // Sort by score descending
+  results.sort((a, b) => b.score - a.score);
+
+  for (const r of results) {
+    const key = `${r.source}:${r.path}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(r);
+    }
+  }
+
+  return deduped.slice(0, maxResults);
+}
+
+/**
+ * Factory: searchKnowledge tool with dual-vault search.
+ *
+ * Searches both the server vault (VAULT_PATH) and the user's
+ * Lago vault (if memoryVault feature is enabled).
+ */
+export function searchKnowledgeTool({ session }: { session: ToolSession }) {
+  return tool({
+    description: `Search the Broomva knowledge graph — an Obsidian vault containing architecture docs, project state, decisions, conventions, governance policies, and conversation history across all projects (Life/aiOS, Symphony, ChatOS, Control Kernel).
+
+Also searches the user's personal memory vault (if configured) for user-specific notes and context.
 
 Use for:
 - Finding project architecture, design decisions, or conventions
 - Understanding cross-project relationships and dependencies
 - Retrieving governance policies or control metalayer rules
 - Looking up past decisions or session history
+- Searching user's personal memory and notes
 - Navigating the knowledge graph via wikilinks
 
 Returns matching notes with frontmatter metadata, relevant excerpts, and outgoing wikilinks for further exploration.`,
-  inputSchema: z.object({
-    query: z
-      .string()
-      .describe(
-        "Search query — keywords, project names, concepts, or note titles"
-      ),
-    followLinks: z
-      .boolean()
-      .default(false)
-      .describe(
-        "If true, follow wikilinks from top results to include connected notes (graph traversal, 1 hop)"
-      ),
-    maxResults: z
-      .number()
-      .int()
-      .min(1)
-      .max(20)
-      .default(8)
-      .describe("Maximum number of notes to return"),
-  }),
-  execute: async ({
-    query,
-    followLinks,
-    maxResults,
-  }: {
-    query: string;
-    followLinks: boolean;
-    maxResults: number;
-  }) => {
-    const vaultPath = getVaultPath();
-    if (!vaultPath) {
-      return {
-        error:
-          "Knowledge graph not configured. Set VAULT_PATH environment variable to the Obsidian vault directory.",
-      };
-    }
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe(
+          "Search query — keywords, project names, concepts, or note titles"
+        ),
+      followLinks: z
+        .boolean()
+        .default(false)
+        .describe(
+          "If true, follow wikilinks from top results to include connected notes (graph traversal, 1 hop)"
+        ),
+      maxResults: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .default(8)
+        .describe("Maximum number of notes to return"),
+    }),
+    execute: async ({
+      query,
+      followLinks,
+      maxResults,
+    }: {
+      query: string;
+      followLinks: boolean;
+      maxResults: number;
+    }) => {
+      const allResults: Array<{
+        name: string;
+        path: string;
+        frontmatter: Record<string, unknown>;
+        excerpts: string[];
+        outgoingLinks: string[];
+        score: number;
+        source: string;
+      }> = [];
 
-    try {
-      const results = searchVault(query, vaultPath, { maxResults });
+      // 1. Server vault (VAULT_PATH — local filesystem)
+      const vaultPath = getVaultPath();
+      if (vaultPath) {
+        try {
+          const results = searchVault(query, vaultPath, { maxResults });
+          for (const r of results) {
+            allResults.push({
+              name: r.note.name,
+              path: r.note.relativePath,
+              frontmatter: r.note.frontmatter,
+              excerpts: r.excerpts,
+              outgoingLinks: r.links,
+              score: r.excerpts.length + (r.links.length > 0 ? 1 : 0),
+              source: "server",
+            });
+          }
+        } catch (error) {
+          log.error({ err: error, query }, "Server vault search error");
+        }
+      }
 
-      if (results.length === 0) {
+      // 2. User vault (lagod — remote, server-side search)
+      const lagoBackend = await getUserLagoBackend(session);
+      if (lagoBackend) {
+        try {
+          const lagoResults = await lagoBackend.search(query, {
+            maxResults,
+            followLinks,
+          });
+          for (const r of lagoResults) {
+            allResults.push({
+              name: r.name,
+              path: r.path,
+              frontmatter: r.frontmatter,
+              excerpts: r.excerpts,
+              outgoingLinks: r.links,
+              score: r.score,
+              source: "user",
+            });
+          }
+        } catch (error) {
+          log.error({ err: error, query }, "Lago vault search error");
+        }
+      }
+
+      if (allResults.length === 0) {
+        if (!vaultPath && !lagoBackend) {
+          return {
+            error:
+              "Knowledge graph not configured. Set VAULT_PATH or enable memoryVault with LAGO_URL.",
+          };
+        }
         return {
           results: [],
           message: `No notes found matching "${query}".`,
         };
       }
 
-      // Optionally follow wikilinks from top results
+      // Merge, rank, deduplicate
+      const merged = mergeAndRank(allResults, maxResults);
+
+      // Optionally follow wikilinks (server vault only — Lago handles this server-side)
       let linkedNotes: {
         name: string;
         relativePath: string;
@@ -89,9 +207,11 @@ Returns matching notes with frontmatter metadata, relevant excerpts, and outgoin
         excerpt: string;
       }[] = [];
 
-      if (followLinks) {
-        const seenPaths = new Set(results.map((r) => r.note.relativePath));
-        const allLinkedTargets = results.flatMap((r) => r.links);
+      if (followLinks && vaultPath) {
+        const seenPaths = new Set(merged.map((r) => r.path));
+        const allLinkedTargets = merged
+          .filter((r) => r.source === "server")
+          .flatMap((r) => r.outgoingLinks);
         const uniqueTargets = [...new Set(allLinkedTargets)].filter(
           (t) => !seenPaths.has(t)
         );
@@ -111,58 +231,113 @@ Returns matching notes with frontmatter metadata, relevant excerpts, and outgoin
       }
 
       return {
-        results: results.map((r) => ({
-          name: r.note.name,
-          path: r.note.relativePath,
-          frontmatter: r.note.frontmatter,
+        results: merged.map((r) => ({
+          name: r.name,
+          path: r.path,
+          frontmatter: r.frontmatter,
           excerpts: r.excerpts,
-          outgoingLinks: r.links,
+          outgoingLinks: r.outgoingLinks,
+          source: r.source,
         })),
         ...(linkedNotes.length > 0 ? { linkedNotes } : {}),
       };
-    } catch (error) {
-      log.error({ err: error, query }, "Knowledge graph search error");
-      return { error: "Failed to search knowledge graph" };
-    }
-  },
-});
+    },
+  });
+}
 
-export const readKnowledgeNote = tool({
-  description: `Read a specific note from the Broomva knowledge graph by name or path. Use after searchKnowledge to dive deeper into a specific note, or when you know the exact note name (e.g. "Consciousness", "Control Dashboard", "Broomva Index").
+/**
+ * Factory: readKnowledgeNote tool with dual-vault resolution.
+ */
+export function readKnowledgeNoteTool({ session }: { session: ToolSession }) {
+  return tool({
+    description: `Read a specific note from the Broomva knowledge graph by name or path. Use after searchKnowledge to dive deeper into a specific note, or when you know the exact note name (e.g. "Consciousness", "Control Dashboard", "Broomva Index").
 
 Returns the full note content with frontmatter and outgoing wikilinks.`,
-  inputSchema: z.object({
-    name: z
-      .string()
-      .describe(
-        'Note name or relative path — e.g. "Consciousness", "00-Index/Projects", "02-Symphony/Symphony Index"'
-      ),
-    includeLinkedNotes: z
-      .boolean()
-      .default(false)
-      .describe(
-        "If true, also return summaries of notes linked via wikilinks (1 hop)"
-      ),
-  }),
-  execute: async ({
-    name,
-    includeLinkedNotes,
-  }: {
-    name: string;
-    includeLinkedNotes: boolean;
-  }) => {
-    const vaultPath = getVaultPath();
-    if (!vaultPath) {
-      return {
-        error:
-          "Knowledge graph not configured. Set VAULT_PATH environment variable.",
-      };
-    }
+    inputSchema: z.object({
+      name: z
+        .string()
+        .describe(
+          'Note name or relative path — e.g. "Consciousness", "00-Index/Projects", "02-Symphony/Symphony Index"'
+        ),
+      includeLinkedNotes: z
+        .boolean()
+        .default(false)
+        .describe(
+          "If true, also return summaries of notes linked via wikilinks (1 hop)"
+        ),
+    }),
+    execute: async ({
+      name,
+      includeLinkedNotes,
+    }: {
+      name: string;
+      includeLinkedNotes: boolean;
+    }) => {
+      // Try server vault first
+      const vaultPath = getVaultPath();
+      if (vaultPath) {
+        try {
+          const note = resolveWikilink(name, vaultPath);
+          if (note) {
+            const links = extractWikilinks(note.body);
+            let linkedSummaries: {
+              name: string;
+              path: string;
+              excerpt: string;
+            }[] = [];
 
-    try {
-      const note = resolveWikilink(name, vaultPath);
-      if (!note) {
-        // Try a search as fallback
+            if (includeLinkedNotes) {
+              for (const target of links.slice(0, 10)) {
+                const linked = resolveWikilink(target, vaultPath);
+                if (linked) {
+                  linkedSummaries.push({
+                    name: linked.name,
+                    path: linked.relativePath,
+                    excerpt: truncateBody(linked.body, 300),
+                  });
+                }
+              }
+            }
+
+            return {
+              name: note.name,
+              path: note.relativePath,
+              frontmatter: note.frontmatter,
+              content: truncateBody(note.body, 6000),
+              outgoingLinks: links,
+              source: "server",
+              ...(linkedSummaries.length > 0
+                ? { linkedNotes: linkedSummaries }
+                : {}),
+            };
+          }
+        } catch (error) {
+          log.error({ err: error, name }, "Server vault read error");
+        }
+      }
+
+      // Try user vault via Lago
+      const lagoBackend = await getUserLagoBackend(session);
+      if (lagoBackend) {
+        try {
+          const note = await lagoBackend.readNote(name);
+          if (note) {
+            return {
+              name: note.name,
+              path: note.path,
+              frontmatter: note.frontmatter,
+              content: truncateBody(note.body, 6000),
+              outgoingLinks: note.links,
+              source: "user",
+            };
+          }
+        } catch (error) {
+          log.error({ err: error, name }, "Lago vault read error");
+        }
+      }
+
+      // Neither vault had the note — try search as fallback
+      if (vaultPath) {
         const searchResults = searchVault(name, vaultPath, { maxResults: 3 });
         if (searchResults.length > 0) {
           return {
@@ -173,41 +348,24 @@ Returns the full note content with frontmatter and outgoing wikilinks.`,
             })),
           };
         }
-        return { error: `Note "${name}" not found in the knowledge graph.` };
       }
 
-      const links = extractWikilinks(note.body);
-
-      let linkedSummaries: {
-        name: string;
-        path: string;
-        excerpt: string;
-      }[] = [];
-
-      if (includeLinkedNotes) {
-        for (const target of links.slice(0, 10)) {
-          const linked = resolveWikilink(target, vaultPath);
-          if (linked) {
-            linkedSummaries.push({
-              name: linked.name,
-              path: linked.relativePath,
-              excerpt: truncateBody(linked.body, 300),
-            });
-          }
-        }
+      if (!vaultPath && !lagoBackend) {
+        return {
+          error:
+            "Knowledge graph not configured. Set VAULT_PATH or enable memoryVault with LAGO_URL.",
+        };
       }
 
-      return {
-        name: note.name,
-        path: note.relativePath,
-        frontmatter: note.frontmatter,
-        content: truncateBody(note.body, 6000),
-        outgoingLinks: links,
-        ...(linkedSummaries.length > 0 ? { linkedNotes: linkedSummaries } : {}),
-      };
-    } catch (error) {
-      log.error({ err: error, name }, "Knowledge graph read error");
-      return { error: "Failed to read note from knowledge graph" };
-    }
-  },
+      return { error: `Note "${name}" not found in the knowledge graph.` };
+    },
+  });
+}
+
+// Backward-compatible exports for cases where tools.ts imports directly
+export const searchKnowledge = searchKnowledgeTool({
+  session: { user: undefined },
+});
+export const readKnowledgeNote = readKnowledgeNoteTool({
+  session: { user: undefined },
 });

--- a/apps/chat/lib/ai/tools/tools.ts
+++ b/apps/chat/lib/ai/tools/tools.ts
@@ -13,8 +13,8 @@ import { generateImageTool } from "@/lib/ai/tools/generate-image";
 import { getWeather } from "@/lib/ai/tools/get-weather";
 import { readDocument } from "@/lib/ai/tools/read-document";
 import {
-  searchKnowledge,
-  readKnowledgeNote,
+  searchKnowledgeTool,
+  readKnowledgeNoteTool,
 } from "@/lib/ai/tools/knowledge-graph";
 import { retrieveUrl } from "@/lib/ai/tools/retrieve-url";
 import { tavilyWebSearch } from "@/lib/ai/tools/web-search";
@@ -108,7 +108,10 @@ export function getTools({
         }
       : {}),
     ...(config.features.knowledgeGraph
-      ? { searchKnowledge, readKnowledgeNote }
+      ? {
+          searchKnowledge: searchKnowledgeTool({ session }),
+          readKnowledgeNote: readKnowledgeNoteTool({ session }),
+        }
       : {}),
     listPrompts: listPromptsTool({ session }),
     getPrompt: getPromptTool(),

--- a/apps/chat/lib/ai/tools/types.ts
+++ b/apps/chat/lib/ai/tools/types.ts
@@ -4,5 +4,5 @@ type SessionUser = NonNullable<Session["user"]>;
 
 // Minimal session slice for tools - derived from Better Auth Session to avoid drift
 export type ToolSession = {
-  user?: Pick<SessionUser, "id">;
+  user?: Pick<SessionUser, "id"> & { email?: string };
 };

--- a/apps/chat/lib/ai/vault/backend.ts
+++ b/apps/chat/lib/ai/vault/backend.ts
@@ -1,0 +1,22 @@
+/**
+ * VaultBackend — pluggable storage backend for vault operations.
+ *
+ * Abstracts over local filesystem (server vault) and remote Lago
+ * (user vault) so VaultReader and tools can work with both.
+ */
+export interface VaultBackend {
+  /** List all file paths in the vault (relative paths). */
+  listFiles(): Promise<string[]>;
+
+  /** Read a file by relative path. Returns null if not found. */
+  readFile(relativePath: string): Promise<string | null>;
+
+  /** Write a file by relative path. */
+  writeFile(relativePath: string, content: string): Promise<void>;
+
+  /** Delete a file by relative path. */
+  deleteFile(relativePath: string): Promise<void>;
+
+  /** Unique cache key for this backend instance (for index caching). */
+  readonly cacheKey: string;
+}

--- a/apps/chat/lib/ai/vault/jwt.ts
+++ b/apps/chat/lib/ai/vault/jwt.ts
@@ -1,0 +1,30 @@
+/**
+ * JWT signing for Lago auth — signs tokens with AUTH_SECRET so lagod
+ * can validate them locally without a network round-trip.
+ */
+
+import { SignJWT } from "jose";
+
+const JWT_EXPIRY = "7d";
+
+/**
+ * Sign a JWT for a user, compatible with lagod's lago-auth middleware.
+ * Uses AUTH_SECRET as the shared HMAC key.
+ */
+export async function signLagoJWT(user: {
+  id: string;
+  email: string;
+}): Promise<string> {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) {
+    throw new Error("AUTH_SECRET is required for Lago JWT signing");
+  }
+
+  const jwt = await new SignJWT({ sub: user.id, email: user.email })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(JWT_EXPIRY)
+    .sign(new TextEncoder().encode(secret));
+
+  return jwt;
+}

--- a/apps/chat/lib/ai/vault/lago-backend.ts
+++ b/apps/chat/lib/ai/vault/lago-backend.ts
@@ -1,0 +1,159 @@
+/**
+ * LagoVaultBackend — stores/retrieves .md files via lagod's /v1/memory/* API.
+ *
+ * Uses inline fetch() — no separate lago-client-ts package needed.
+ * Also exposes server-side search and graph traversal.
+ */
+
+import type { VaultBackend } from "./backend";
+
+export type LagoSearchResult = {
+  path: string;
+  name: string;
+  frontmatter: Record<string, unknown>;
+  excerpts: string[];
+  links: string[];
+  score: number;
+};
+
+export type LagoTraversalNote = {
+  path: string;
+  name: string;
+  depth: number;
+  links: string[];
+};
+
+export class LagoVaultBackend implements VaultBackend {
+  readonly cacheKey: string;
+
+  constructor(
+    private readonly lagoUrl: string,
+    private readonly token: string
+  ) {
+    this.cacheKey = `lago:${lagoUrl}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  async listFiles(): Promise<string[]> {
+    const res = await fetch(`${this.lagoUrl}/v1/memory/manifest`, {
+      headers: this.headers(),
+    });
+
+    if (!res.ok) return [];
+
+    const data = (await res.json()) as {
+      entries: Array<{ path: string }>;
+    };
+    return data.entries.map((e) => e.path.replace(/^\//, ""));
+  }
+
+  async readFile(relativePath: string): Promise<string | null> {
+    const encoded = encodeURIComponent(
+      relativePath.startsWith("/") ? relativePath : `/${relativePath}`
+    );
+    const res = await fetch(
+      `${this.lagoUrl}/v1/memory/files/${encoded}`,
+      { headers: this.headers() }
+    );
+
+    if (!res.ok) return null;
+    return res.text();
+  }
+
+  async writeFile(relativePath: string, content: string): Promise<void> {
+    const path = relativePath.startsWith("/")
+      ? relativePath
+      : `/${relativePath}`;
+    const encoded = encodeURIComponent(path);
+    await fetch(`${this.lagoUrl}/v1/memory/files/${encoded}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: content,
+    });
+  }
+
+  async deleteFile(relativePath: string): Promise<void> {
+    const path = relativePath.startsWith("/")
+      ? relativePath
+      : `/${relativePath}`;
+    const encoded = encodeURIComponent(path);
+    await fetch(`${this.lagoUrl}/v1/memory/files/${encoded}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
+  }
+
+  /** Server-side scored search (bypasses client-side VaultReader.searchVault). */
+  async search(
+    query: string,
+    opts?: { maxResults?: number; followLinks?: boolean }
+  ): Promise<LagoSearchResult[]> {
+    const res = await fetch(`${this.lagoUrl}/v1/memory/search`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({
+        query,
+        max_results: opts?.maxResults,
+        follow_links: opts?.followLinks,
+      }),
+    });
+
+    if (!res.ok) return [];
+
+    const data = (await res.json()) as { results: LagoSearchResult[] };
+    return data.results;
+  }
+
+  /** Server-side BFS graph traversal. */
+  async traverse(
+    target: string,
+    opts?: { depth?: number; maxNotes?: number }
+  ): Promise<LagoTraversalNote[]> {
+    const res = await fetch(`${this.lagoUrl}/v1/memory/traverse`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({
+        target,
+        depth: opts?.depth,
+        max_notes: opts?.maxNotes,
+      }),
+    });
+
+    if (!res.ok) return [];
+
+    const data = (await res.json()) as { notes: LagoTraversalNote[] };
+    return data.notes;
+  }
+
+  /** Resolve a wikilink to a full note via lagod. */
+  async readNote(name: string): Promise<{
+    path: string;
+    name: string;
+    frontmatter: Record<string, unknown>;
+    body: string;
+    links: string[];
+  } | null> {
+    const encoded = encodeURIComponent(name);
+    const res = await fetch(
+      `${this.lagoUrl}/v1/memory/note/${encoded}`,
+      { headers: this.headers() }
+    );
+
+    if (!res.ok) return null;
+    return res.json() as Promise<{
+      path: string;
+      name: string;
+      frontmatter: Record<string, unknown>;
+      body: string;
+      links: string[];
+    }>;
+  }
+}

--- a/apps/chat/lib/ai/vault/local-backend.ts
+++ b/apps/chat/lib/ai/vault/local-backend.ts
@@ -1,0 +1,85 @@
+/**
+ * LocalVaultBackend — reads/writes .md files from the local filesystem.
+ *
+ * Wraps the existing `collectMarkdownFiles()` logic from reader.ts
+ * behind the VaultBackend interface.
+ */
+
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+  mkdirSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, extname, join, relative } from "node:path";
+import type { VaultBackend } from "./backend";
+
+/** Recursively collect all .md files, following symlinks. */
+function collectMarkdownFiles(dir: string, files: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return files;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".") || entry === "node_modules") continue;
+
+    const full = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+
+    if (stat.isDirectory()) {
+      collectMarkdownFiles(full, files);
+    } else if (stat.isFile() && extname(entry) === ".md") {
+      files.push(full);
+    }
+  }
+
+  return files;
+}
+
+export class LocalVaultBackend implements VaultBackend {
+  readonly cacheKey: string;
+
+  constructor(private readonly vaultPath: string) {
+    this.cacheKey = `local:${vaultPath}`;
+  }
+
+  async listFiles(): Promise<string[]> {
+    const files = collectMarkdownFiles(this.vaultPath);
+    return files.map((f) => relative(this.vaultPath, f));
+  }
+
+  async readFile(relativePath: string): Promise<string | null> {
+    try {
+      const fullPath = join(this.vaultPath, relativePath);
+      return readFileSync(fullPath, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  async writeFile(relativePath: string, content: string): Promise<void> {
+    const fullPath = join(this.vaultPath, relativePath);
+    const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(fullPath, content, "utf-8");
+  }
+
+  async deleteFile(relativePath: string): Promise<void> {
+    try {
+      const fullPath = join(this.vaultPath, relativePath);
+      unlinkSync(fullPath);
+    } catch {
+      // Ignore if file doesn't exist
+    }
+  }
+}

--- a/apps/chat/lib/config-schema.ts
+++ b/apps/chat/lib/config-schema.ts
@@ -249,6 +249,9 @@ export const featuresConfigSchema = z
     knowledgeGraph: z
       .boolean()
       .describe("Obsidian vault knowledge graph search (requires VAULT_PATH)"),
+    memoryVault: z
+      .boolean()
+      .describe("User memory vault via Lago (requires LAGO_URL)"),
   })
   .default({
     sandbox: false,
@@ -260,6 +263,7 @@ export const featuresConfigSchema = z
     attachments: false,
     followupSuggestions: false,
     knowledgeGraph: false,
+    memoryVault: false,
   });
 
 export const authenticationConfigSchema = z

--- a/apps/chat/lib/db/migrations/0047_cooing_gressill.sql
+++ b/apps/chat/lib/db/migrations/0047_cooing_gressill.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "DeviceAuthCode" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"deviceCode" varchar(64) NOT NULL,
+	"userCode" varchar(12) NOT NULL,
+	"scope" text DEFAULT '' NOT NULL,
+	"clientId" varchar(128) DEFAULT 'cli' NOT NULL,
+	"status" varchar(16) DEFAULT 'pending' NOT NULL,
+	"userId" text,
+	"sessionToken" text,
+	"expiresAt" timestamp NOT NULL,
+	"pollingInterval" integer DEFAULT 5 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "DeviceAuthCode_deviceCode_unique" UNIQUE("deviceCode"),
+	CONSTRAINT "DeviceAuthCode_userCode_unique" UNIQUE("userCode")
+);
+--> statement-breakpoint
+CREATE TABLE "UserVault" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" text NOT NULL,
+	"lagoSessionId" varchar(32) NOT NULL,
+	"name" varchar(256) DEFAULT 'default' NOT NULL,
+	"isPrimary" boolean DEFAULT true NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "UserPrompt" ADD COLUMN "slug" varchar(256) NOT NULL;--> statement-breakpoint
+ALTER TABLE "UserPrompt" ADD COLUMN "links" json;--> statement-breakpoint
+ALTER TABLE "UserPrompt" ADD COLUMN "deletedAt" timestamp;--> statement-breakpoint
+ALTER TABLE "DeviceAuthCode" ADD CONSTRAINT "DeviceAuthCode_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "UserVault" ADD CONSTRAINT "UserVault_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "DeviceAuthCode_device_code_idx" ON "DeviceAuthCode" USING btree ("deviceCode");--> statement-breakpoint
+CREATE INDEX "DeviceAuthCode_user_code_idx" ON "DeviceAuthCode" USING btree ("userCode");--> statement-breakpoint
+CREATE INDEX "UserVault_user_id_idx" ON "UserVault" USING btree ("userId");--> statement-breakpoint
+CREATE UNIQUE INDEX "UserVault_lago_session_unique" ON "UserVault" USING btree ("lagoSessionId");--> statement-breakpoint
+CREATE UNIQUE INDEX "UserPrompt_slug_unique" ON "UserPrompt" USING btree ("slug");

--- a/apps/chat/lib/db/migrations/meta/0047_snapshot.json
+++ b/apps/chat/lib/db/migrations/meta/0047_snapshot.json
@@ -1,0 +1,1974 @@
+{
+  "id": "f90758fc-44da-4a1f-9b73-091461146d7f",
+  "prevId": "08d935bb-caba-49f3-8e5d-6a4791d08c92",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_user_id_fk": {
+          "name": "Chat_userId_user_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_projectId_Project_id_fk": {
+          "name": "Chat_projectId_Project_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeviceAuthCode": {
+      "name": "DeviceAuthCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pollingInterval": {
+          "name": "pollingInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeviceAuthCode_device_code_idx": {
+          "name": "DeviceAuthCode_device_code_idx",
+          "columns": [
+            {
+              "expression": "deviceCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeviceAuthCode_user_code_idx": {
+          "name": "DeviceAuthCode_user_code_idx",
+          "columns": [
+            {
+              "expression": "userCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeviceAuthCode_userId_user_id_fk": {
+          "name": "DeviceAuthCode_userId_user_id_fk",
+          "tableFrom": "DeviceAuthCode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeviceAuthCode_deviceCode_unique": {
+          "name": "DeviceAuthCode_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCode"
+          ]
+        },
+        "DeviceAuthCode_userCode_unique": {
+          "name": "DeviceAuthCode_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Document_message_id_idx": {
+          "name": "Document_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_user_id_fk": {
+          "name": "Document_userId_user_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_messageId_Message_id_fk": {
+          "name": "Document_messageId_Message_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpConnector": {
+      "name": "McpConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameId": {
+          "name": "nameId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "oauthClientId": {
+          "name": "oauthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthClientSecret": {
+          "name": "oauthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpConnector_user_id_idx": {
+          "name": "McpConnector_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_idx": {
+          "name": "McpConnector_user_name_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_unique": {
+          "name": "McpConnector_user_name_id_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpConnector_userId_user_id_fk": {
+          "name": "McpConnector_userId_user_id_fk",
+          "tableFrom": "McpConnector",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpOAuthSession": {
+      "name": "McpOAuthSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcpConnectorId": {
+          "name": "mcpConnectorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientInfo": {
+          "name": "clientInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpOAuthSession_connector_idx": {
+          "name": "McpOAuthSession_connector_idx",
+          "columns": [
+            {
+              "expression": "mcpConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpOAuthSession_state_idx": {
+          "name": "McpOAuthSession_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpOAuthSession_mcpConnectorId_McpConnector_id_fk": {
+          "name": "McpOAuthSession_mcpConnectorId_McpConnector_id_fk",
+          "tableFrom": "McpOAuthSession",
+          "tableTo": "McpConnector",
+          "columnsFrom": [
+            "mcpConnectorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpOAuthSession_state_unique": {
+          "name": "McpOAuthSession_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModel": {
+          "name": "selectedModel",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "selectedTool": {
+          "name": "selectedTool",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeStreamId": {
+          "name": "activeStreamId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mediaType": {
+          "name": "file_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_filename": {
+          "name": "file_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_sourceId": {
+          "name": "source_url_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_url": {
+          "name": "source_url_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_title": {
+          "name": "source_url_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_sourceId": {
+          "name": "source_document_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_mediaType": {
+          "name": "source_document_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_title": {
+          "name": "source_document_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_filename": {
+          "name": "source_document_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_toolCallId": {
+          "name": "tool_toolCallId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_state": {
+          "name": "tool_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_errorText": {
+          "name": "tool_errorText",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_blob": {
+          "name": "data_blob",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Part_message_id_idx": {
+          "name": "Part_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Part_message_id_order_idx": {
+          "name": "Part_message_id_order_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_messageId_Message_id_fk": {
+          "name": "Part_messageId_Message_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Part_text_required_if_type_text": {
+          "name": "Part_text_required_if_type_text",
+          "value": "CASE WHEN \"Part\".\"type\" = 'text' THEN \"Part\".\"text_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_reasoning_required_if_type_reasoning": {
+          "name": "Part_reasoning_required_if_type_reasoning",
+          "value": "CASE WHEN \"Part\".\"type\" = 'reasoning' THEN \"Part\".\"reasoning_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_file_required_if_type_file": {
+          "name": "Part_file_required_if_type_file",
+          "value": "CASE WHEN \"Part\".\"type\" = 'file' THEN \"Part\".\"file_mediaType\" IS NOT NULL AND \"Part\".\"file_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_url_required_if_type_source_url": {
+          "name": "Part_source_url_required_if_type_source_url",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-url' THEN \"Part\".\"source_url_sourceId\" IS NOT NULL AND \"Part\".\"source_url_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_document_required_if_type_source_document": {
+          "name": "Part_source_document_required_if_type_source_document",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-document' THEN \"Part\".\"source_document_sourceId\" IS NOT NULL AND \"Part\".\"source_document_mediaType\" IS NOT NULL AND \"Part\".\"source_document_title\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_tool_required_if_type_tool": {
+          "name": "Part_tool_required_if_type_tool",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'tool-%' THEN \"Part\".\"tool_toolCallId\" IS NOT NULL AND \"Part\".\"tool_state\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_data_required_if_type_data": {
+          "name": "Part_data_required_if_type_data",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'data-%' THEN \"Part\".\"data_type\" IS NOT NULL ELSE TRUE END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "iconColor": {
+          "name": "iconColor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gray'"
+        }
+      },
+      "indexes": {
+        "Project_user_id_idx": {
+          "name": "Project_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_userId_user_id_fk": {
+          "name": "Project_userId_user_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_user_id_fk": {
+          "name": "Suggestion_userId_user_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserCredit": {
+      "name": "UserCredit",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserCredit_userId_user_id_fk": {
+          "name": "UserCredit_userId_user_id_fk",
+          "tableFrom": "UserCredit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserModelPreference": {
+      "name": "UserModelPreference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserModelPreference_user_id_idx": {
+          "name": "UserModelPreference_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserModelPreference_userId_user_id_fk": {
+          "name": "UserModelPreference_userId_user_id_fk",
+          "tableFrom": "UserModelPreference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UserModelPreference_userId_modelId_pk": {
+          "name": "UserModelPreference_userId_modelId_pk",
+          "columns": [
+            "userId",
+            "modelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserPrompt": {
+      "name": "UserPrompt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UserPrompt_user_id_idx": {
+          "name": "UserPrompt_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_visibility_idx": {
+          "name": "UserPrompt_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_slug_unique": {
+          "name": "UserPrompt_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserPrompt_userId_user_id_fk": {
+          "name": "UserPrompt_userId_user_id_fk",
+          "tableFrom": "UserPrompt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserVault": {
+      "name": "UserVault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lagoSessionId": {
+          "name": "lagoSessionId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserVault_user_id_idx": {
+          "name": "UserVault_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserVault_lago_session_unique": {
+          "name": "UserVault_lago_session_unique",
+          "columns": [
+            {
+              "expression": "lagoSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserVault_userId_user_id_fk": {
+          "name": "UserVault_userId_user_id_fk",
+          "tableFrom": "UserVault",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -495,4 +495,30 @@ export const deviceAuthCode = pgTable(
 
 export type DeviceAuthCode = InferSelectModel<typeof deviceAuthCode>;
 
+export const userVault = pgTable(
+  "UserVault",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    lagoSessionId: varchar("lagoSessionId", { length: 32 }).notNull(),
+    name: varchar("name", { length: 256 }).notNull().default("default"),
+    isPrimary: boolean("isPrimary").notNull().default(true),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    UserVault_user_id_idx: index("UserVault_user_id_idx").on(t.userId),
+    UserVault_lago_session_unique: uniqueIndex(
+      "UserVault_lago_session_unique"
+    ).on(t.lagoSessionId),
+  })
+);
+
+export type UserVault = InferSelectModel<typeof userVault>;
+
 export const schema = { user, session, account, verification };

--- a/apps/chat/lib/db/vault-queries.ts
+++ b/apps/chat/lib/db/vault-queries.ts
@@ -1,0 +1,47 @@
+/**
+ * UserVault database queries — maps authenticated users to Lago sessions.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { userVault } from "@/lib/db/schema";
+
+/** Get the primary vault for a user. */
+export async function getUserPrimaryVault(userId: string) {
+  const [vault] = await db
+    .select()
+    .from(userVault)
+    .where(eq(userVault.userId, userId))
+    .limit(1);
+
+  return vault ?? null;
+}
+
+/** Create a vault mapping for a user. */
+export async function createUserVault(params: {
+  userId: string;
+  lagoSessionId: string;
+  name?: string;
+}) {
+  const [vault] = await db
+    .insert(userVault)
+    .values({
+      userId: params.userId,
+      lagoSessionId: params.lagoSessionId,
+      name: params.name ?? "default",
+      isPrimary: true,
+    })
+    .returning();
+
+  return vault;
+}
+
+/** Get or create a vault for a user (idempotent). */
+export async function getOrCreateUserVault(params: {
+  userId: string;
+  lagoSessionId: string;
+}) {
+  const existing = await getUserPrimaryVault(params.userId);
+  if (existing) return existing;
+  return createUserVault(params);
+}

--- a/apps/chat/lib/env-schema.ts
+++ b/apps/chat/lib/env-schema.ts
@@ -120,6 +120,13 @@ export const serverEnvSchema = {
     .optional()
     .describe("Absolute path to the Obsidian vault directory"),
 
+  // Lago context engine
+  LAGO_URL: z
+    .string()
+    .url()
+    .optional()
+    .describe("Lago daemon URL for user memory vault (e.g. http://localhost:8080)"),
+
   // App URL (for non-Vercel deployments) - full URL including https://
   APP_URL: z
     .url()


### PR DESCRIPTION
## Summary
- **VaultBackend abstraction**: `VaultBackend` interface + `LocalVaultBackend` (filesystem) + `LagoVaultBackend` (lagod HTTP with search/traverse)
- **JWT auth**: `signLagoJWT()` via `jose` + `AUTH_SECRET` shared with lagod — `/api/auth/api-token` now returns `lagoToken`
- **Dual-vault knowledge-graph tools**: Factory functions search both server vault (`VAULT_PATH`) and user vault (`LAGO_URL`), merge + rank results
- **API proxy routes**: `/api/memory/{vault,search,traverse,files/*}` forward to lagod with user JWT
- **Database**: `UserVault` table + Drizzle migration (`0047`)
- **Config**: `memoryVault` feature flag + `LAGO_URL` env var

## Dependencies
- Requires [broomva/lago#5](https://github.com/broomva/lago/pull/5) (lago-knowledge + lago-auth crates, memory API routes)

## Test plan
- [x] `bun run build` — passes
- [x] `bun run test:types` — passes (TypeScript type check)
- [ ] CI workflow passes
- [ ] Run `db:push` to apply UserVault migration
- [ ] E2E: login → api-token → lago memory ingest → chat "search my memory"

🤖 Generated with [Claude Code](https://claude.com/claude-code)