### PR TITLE
feat: add broomva console CLI commands

### DIFF
--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -185,6 +185,24 @@ impl BroomvaClient {
         Ok(body)
     }
 
+    // ── Console ──
+
+    pub async fn get_console_health(&self) -> BroomvaResult<ConsoleHealth> {
+        let resp = self.request(Method::GET, "/api/console/health").send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    pub async fn list_agent_sessions(&self) -> BroomvaResult<Vec<AgentSession>> {
+        let resp = self
+            .request(Method::GET, "/api/agent/sessions")
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        let body: ApiListResponse<AgentSession> = resp.json().await?;
+        Ok(body.data.unwrap_or_default())
+    }
+
     // ── Auth validation ──
 
     pub async fn validate_token(&self) -> BroomvaResult<bool> {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -156,6 +156,35 @@ pub struct DeviceTokenError {
     pub error_description: Option<String>,
 }
 
+// ── Console ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceHealth {
+    pub status: String,
+    pub latency_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConsoleHealth {
+    pub arcan: ServiceHealth,
+    pub lago: ServiceHealth,
+    pub autonomic: ServiceHealth,
+    pub haima: ServiceHealth,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSession {
+    pub id: String,
+    pub status: Option<String>,
+    pub agent: Option<String>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+}
+
 // ── API Wrapper ──
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/broomva-cli/src/cli/console.rs
+++ b/crates/broomva-cli/src/cli/console.rs
@@ -1,0 +1,112 @@
+use std::process::Command as ProcessCommand;
+
+use crate::api::BroomvaClient;
+use crate::cli::output::{OutputFormat, print_json, print_table};
+use crate::error::BroomvaResult;
+
+const CONSOLE_URL: &str = "https://broomva.tech/console";
+
+pub async fn handle_console_open() -> BroomvaResult<()> {
+    println!("  Opening {CONSOLE_URL} ...");
+
+    let result = if cfg!(target_os = "macos") {
+        ProcessCommand::new("open").arg(CONSOLE_URL).status()
+    } else {
+        ProcessCommand::new("xdg-open").arg(CONSOLE_URL).status()
+    };
+
+    match result {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => {
+            eprintln!("  Browser exited with status: {status}");
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("  Failed to open browser: {e}");
+            eprintln!("  Visit {CONSOLE_URL} manually.");
+            Ok(())
+        }
+    }
+}
+
+pub async fn handle_console_status(
+    client: &BroomvaClient,
+    format: OutputFormat,
+) -> BroomvaResult<()> {
+    let health = client.get_console_health().await?;
+
+    if format == OutputFormat::Json {
+        print_json(&health);
+        return Ok(());
+    }
+
+    let services = [
+        ("arcan", &health.arcan),
+        ("lago", &health.lago),
+        ("autonomic", &health.autonomic),
+        ("haima", &health.haima),
+    ];
+
+    let rows: Vec<Vec<String>> = services
+        .iter()
+        .map(|(name, svc)| {
+            vec![
+                name.to_string(),
+                format_status(&svc.status),
+                svc.latency_ms
+                    .map(|ms| format!("{ms}ms"))
+                    .unwrap_or_else(|| "-".into()),
+            ]
+        })
+        .collect();
+
+    print_table(&["service", "status", "latency"], &rows, format);
+
+    if let Some(ref ts) = health.timestamp {
+        println!();
+        println!("  Last checked: {ts}");
+    }
+
+    Ok(())
+}
+
+pub async fn handle_console_sessions(
+    client: &BroomvaClient,
+    format: OutputFormat,
+) -> BroomvaResult<()> {
+    let sessions = client.list_agent_sessions().await?;
+
+    if format == OutputFormat::Json {
+        print_json(&sessions);
+        return Ok(());
+    }
+
+    let rows: Vec<Vec<String>> = sessions
+        .iter()
+        .map(|s| {
+            vec![
+                s.id.clone(),
+                s.status.clone().unwrap_or_default(),
+                s.agent.clone().unwrap_or_default(),
+                s.started_at.clone().unwrap_or_default(),
+                s.ended_at.clone().unwrap_or_default(),
+            ]
+        })
+        .collect();
+
+    print_table(
+        &["id", "status", "agent", "started", "ended"],
+        &rows,
+        format,
+    );
+    Ok(())
+}
+
+fn format_status(status: &str) -> String {
+    match status.to_lowercase().as_str() {
+        "healthy" | "ok" | "up" => format!("\x1b[32m{status}\x1b[0m"),
+        "degraded" | "slow" => format!("\x1b[33m{status}\x1b[0m"),
+        "down" | "error" | "unhealthy" => format!("\x1b[31m{status}\x1b[0m"),
+        _ => status.to_string(),
+    }
+}

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod config_cmd;
+pub mod console;
 pub mod context;
 pub mod daemon_cmd;
 pub mod output;
@@ -71,6 +72,11 @@ pub enum Command {
     Daemon {
         #[command(subcommand)]
         action: DaemonCommand,
+    },
+    /// Console — open dashboard, check service health, view sessions.
+    Console {
+        #[command(subcommand)]
+        command: Option<ConsoleCommand>,
     },
 }
 
@@ -262,6 +268,18 @@ pub enum DaemonCommand {
     },
 }
 
+// ── Console ──
+
+#[derive(Subcommand, Debug)]
+pub enum ConsoleCommand {
+    /// Show service health status.
+    Status,
+    /// List agent sessions.
+    Sessions,
+    /// Show service health (alias for status).
+    Health,
+}
+
 // ── Dispatch ──
 
 pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
@@ -369,6 +387,15 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
             ConfigCommand::Set { key, value } => config_cmd::handle_set(&key, &value).await,
             ConfigCommand::Get { key } => config_cmd::handle_get(key.as_deref(), format).await,
             ConfigCommand::Reset => config_cmd::handle_reset().await,
+        },
+        Command::Console { command } => match command {
+            None => console::handle_console_open().await,
+            Some(ConsoleCommand::Status) | Some(ConsoleCommand::Health) => {
+                console::handle_console_status(&client, format).await
+            }
+            Some(ConsoleCommand::Sessions) => {
+                console::handle_console_sessions(&client, format).await
+            }
         },
         Command::Daemon { action } => match action {
             DaemonCommand::Start {


### PR DESCRIPTION
## Summary
- Add `broomva console` command with subcommands: `status`, `health`, `sessions`
- Default (no subcommand) opens the browser to `https://broomva.tech/console`
- `console status` / `console health`: fetches `GET /api/console/health` and displays service health as a colored table (green=healthy, yellow=degraded, red=down)
- `console sessions`: fetches `GET /api/agent/sessions` and displays agent sessions in tabular format
- New API types: `ServiceHealth`, `ConsoleHealth`, `AgentSession`
- Cross-platform browser open using `std::process::Command` (macOS `open` / Linux `xdg-open`)

## Files changed
- `crates/broomva-cli/src/api/types.rs` — new console + session types
- `crates/broomva-cli/src/api/mod.rs` — `get_console_health()` and `list_agent_sessions()` methods
- `crates/broomva-cli/src/cli/console.rs` — new command handler module
- `crates/broomva-cli/src/cli/mod.rs` — `Console` variant + `ConsoleCommand` enum + dispatch

## Test plan
- [x] `cargo check -p broomva` passes
- [ ] `broomva console` opens browser
- [ ] `broomva console status` displays health table
- [ ] `broomva console sessions` displays sessions table
- [ ] `broomva console status --format json` outputs JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added console commands: view console health status across all services with latency metrics, open the Broomva console in your browser, and list active agent sessions.
  * Health status includes colored status indicators and optional timestamps.
  * Agent session listings display session details including status and timing information.
  * Both commands support JSON output format for programmatic use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->