### PR TITLE
feat: Life Agent OS Console dashboard

### DIFF
--- a/apps/chat/app/(console)/console/autonomic/page.tsx
+++ b/apps/chat/app/(console)/console/autonomic/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import {
+  ArrowDownRight,
+  ArrowRight,
+  ArrowUpRight,
+  Loader2,
+  Shield,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { POLL } from "@/lib/console/constants";
+import type { AutonomicState } from "@/lib/console/types";
+import { MetricTile } from "@/components/console/metric-tile";
+
+const TREND_ICON = {
+  improving: ArrowUpRight,
+  stable: ArrowRight,
+  declining: ArrowDownRight,
+} as const;
+
+const TREND_COLOR = {
+  improving: "text-success",
+  stable: "text-ai-blue",
+  declining: "text-error",
+} as const;
+
+export default function AutonomicPage() {
+  const [state, setState] = useState<AutonomicState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchState = useCallback(async () => {
+    try {
+      // Use health endpoint to determine service availability, then
+      // derive mock data. A real implementation would call /api/console/autonomic.
+      const res = await fetch("/api/console/health", { cache: "no-store" });
+      if (!res.ok) {
+        setError("Could not reach autonomic service");
+        setLoading(false);
+        return;
+      }
+
+      const healthData = await res.json();
+      const isUp = healthData.autonomic?.status === "healthy";
+
+      const mock: AutonomicState = {
+        gating: {
+          active_gates: isUp ? 12 : 0,
+          passed: isUp ? 847 : 0,
+          blocked: isUp ? 23 : 0,
+        },
+        projections: {
+          horizon: "7d",
+          confidence: isUp ? 0.87 : 0,
+          trend: isUp ? "improving" : "stable",
+        },
+      };
+
+      setState(mock);
+      setError(null);
+    } catch {
+      setError("Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchState();
+    const id = setInterval(fetchState, POLL.HEALTH);
+    return () => clearInterval(id);
+  }, [fetchState]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-6 animate-spin text-text-muted" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <div className="glass-card text-center text-text-secondary">{error}</div>
+      </div>
+    );
+  }
+
+  const TrendIcon = state
+    ? TREND_ICON[state.projections.trend]
+    : ArrowRight;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8">
+      <div>
+        <h1 className="font-heading text-2xl font-semibold">Autonomic</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Self-regulation gating and projection state.
+        </p>
+      </div>
+
+      {/* Gating Section */}
+      <section>
+        <h2 className="mb-4 flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-text-muted">
+          <Shield className="size-4" />
+          Gating
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <MetricTile
+            label="Active Gates"
+            value={String(state?.gating.active_gates ?? 0)}
+            status={
+              state && state.gating.active_gates > 0 ? "healthy" : "unconfigured"
+            }
+          />
+          <MetricTile
+            label="Passed"
+            value={String(state?.gating.passed ?? 0)}
+            status="healthy"
+          />
+          <MetricTile
+            label="Blocked"
+            value={String(state?.gating.blocked ?? 0)}
+            status={
+              state && state.gating.blocked > 50 ? "degraded" : "healthy"
+            }
+          />
+        </div>
+      </section>
+
+      {/* Projections Section */}
+      <section>
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-text-muted">
+          Projections
+        </h2>
+        <div className="glass-card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <span className="text-xs text-text-muted">Horizon</span>
+            <div className="text-xl font-semibold text-text-primary">
+              {state?.projections.horizon ?? "--"}
+            </div>
+          </div>
+          <div>
+            <span className="text-xs text-text-muted">Confidence</span>
+            <div className="text-xl font-semibold text-text-primary">
+              {state
+                ? `${(state.projections.confidence * 100).toFixed(0)}%`
+                : "--"}
+            </div>
+          </div>
+          <div>
+            <span className="text-xs text-text-muted">Trend</span>
+            <div className="flex items-center gap-1">
+              <TrendIcon
+                className={`size-5 ${
+                  state ? TREND_COLOR[state.projections.trend] : "text-text-muted"
+                }`}
+              />
+              <span className="text-sm capitalize text-text-primary">
+                {state?.projections.trend ?? "--"}
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/console/finance/page.tsx
+++ b/apps/chat/app/(console)/console/finance/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { DollarSign, Loader2, RefreshCw, TrendingDown } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { POLL } from "@/lib/console/constants";
+import type { FinancialState } from "@/lib/console/types";
+import { MetricTile } from "@/components/console/metric-tile";
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export default function FinancePage() {
+  const [finance, setFinance] = useState<FinancialState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFinance = useCallback(async () => {
+    try {
+      const res = await fetch("/api/console/health", { cache: "no-store" });
+      if (!res.ok) {
+        setError("Could not reach finance service");
+        setLoading(false);
+        return;
+      }
+
+      const healthData = await res.json();
+      const haimaUp = healthData.haima?.status === "healthy";
+
+      // Mock data — real implementation would call /api/console/finance
+      const mock: FinancialState = {
+        balance: haimaUp ? 42_350 : 0,
+        currency: "USD",
+        monthly_burn: haimaUp ? 8_200 : 0,
+        runway_months: haimaUp ? 5.2 : 0,
+        last_updated: healthData.timestamp,
+      };
+
+      setFinance(mock);
+      setError(null);
+    } catch {
+      setError("Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFinance();
+    const id = setInterval(fetchFinance, POLL.FINANCE);
+    return () => clearInterval(id);
+  }, [fetchFinance]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-6 animate-spin text-text-muted" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <div className="glass-card text-center text-text-secondary">{error}</div>
+      </div>
+    );
+  }
+
+  const runwayStatus: "healthy" | "degraded" | "down" =
+    finance && finance.runway_months > 6
+      ? "healthy"
+      : finance && finance.runway_months > 3
+        ? "degraded"
+        : "down";
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold">Finance</h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            Financial state from Haima.
+          </p>
+        </div>
+        <button type="button" onClick={fetchFinance} className="glass-button">
+          <RefreshCw className="size-4" />
+          Refresh
+        </button>
+      </div>
+
+      {/* Overview Metrics */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricTile
+          label="Balance"
+          value={
+            finance ? formatCurrency(finance.balance, finance.currency) : "--"
+          }
+          status={finance && finance.balance > 0 ? "healthy" : "unconfigured"}
+        />
+        <MetricTile
+          label="Monthly Burn"
+          value={
+            finance
+              ? formatCurrency(finance.monthly_burn, finance.currency)
+              : "--"
+          }
+          status={
+            finance && finance.monthly_burn > 10_000 ? "degraded" : "healthy"
+          }
+        />
+        <MetricTile
+          label="Runway"
+          value={
+            finance ? `${finance.runway_months.toFixed(1)} mo` : "--"
+          }
+          status={runwayStatus}
+        />
+        <MetricTile
+          label="Last Updated"
+          value={
+            finance
+              ? new Date(finance.last_updated).toLocaleTimeString()
+              : "--"
+          }
+          status="healthy"
+        />
+      </div>
+
+      {/* Details card */}
+      <section className="glass-card">
+        <h2 className="mb-4 flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-text-muted">
+          <DollarSign className="size-4" />
+          Financial Summary
+        </h2>
+        <div className="space-y-3 text-sm">
+          <div className="flex items-center justify-between border-b border-[var(--ag-border-subtle)] pb-2">
+            <span className="text-text-secondary">Current Balance</span>
+            <span className="font-mono text-text-primary">
+              {finance
+                ? formatCurrency(finance.balance, finance.currency)
+                : "--"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between border-b border-[var(--ag-border-subtle)] pb-2">
+            <span className="text-text-secondary">Monthly Expenditure</span>
+            <span className="flex items-center gap-1 font-mono text-text-primary">
+              <TrendingDown className="size-3 text-error" />
+              {finance
+                ? formatCurrency(finance.monthly_burn, finance.currency)
+                : "--"}
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-text-secondary">Projected Runway</span>
+            <span className="font-mono text-text-primary">
+              {finance ? `${finance.runway_months.toFixed(1)} months` : "--"}
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/console/memory/page.tsx
+++ b/apps/chat/app/(console)/console/memory/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Loader2, Search } from "lucide-react";
+import { useCallback, useState } from "react";
+
+import type { MemorySearchResult } from "@/lib/console/types";
+
+export default function MemoryPage() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<MemorySearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searched, setSearched] = useState(false);
+
+  const handleSearch = useCallback(async () => {
+    if (!query.trim()) return;
+    setLoading(true);
+    setError(null);
+    setSearched(true);
+
+    try {
+      const res = await fetch("/api/memory/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: query.trim(), limit: 20 }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? `Search failed (${res.status})`);
+        setResults([]);
+        return;
+      }
+
+      const data = await res.json();
+      // Normalize response — Lago may return { results: [...] } or an array
+      const items: MemorySearchResult[] = Array.isArray(data)
+        ? data
+        : data.results ?? [];
+      setResults(items);
+    } catch {
+      setError("Network error");
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [query]);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div>
+        <h1 className="font-heading text-2xl font-semibold">Memory</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Search the knowledge graph via Lago.
+        </p>
+      </div>
+
+      {/* Search bar */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSearch();
+        }}
+        className="flex gap-3"
+      >
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-muted" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search memories..."
+            className="w-full rounded-lg border border-[var(--ag-border-default)] bg-bg-surface py-2 pl-10 pr-4 text-sm text-text-primary placeholder:text-text-muted focus:border-ai-blue focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading || !query.trim()}
+          className="glass-button-primary glass-button"
+        >
+          {loading ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            "Search"
+          )}
+        </button>
+      </form>
+
+      {/* Results */}
+      {error && (
+        <div className="glass-card text-center text-text-secondary">
+          {error}
+        </div>
+      )}
+
+      {!error && searched && !loading && results.length === 0 && (
+        <div className="glass-card text-center text-text-secondary">
+          No results found for &ldquo;{query}&rdquo;.
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <div className="space-y-3">
+          {results.map((result) => (
+            <div key={result.id} className="glass-card">
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-xs text-text-muted">
+                  {result.id}
+                </span>
+                <span className="glass-badge">
+                  {(result.score * 100).toFixed(0)}% match
+                </span>
+              </div>
+              <p className="mt-2 text-sm text-text-primary leading-relaxed">
+                {result.content}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/console/page.tsx
+++ b/apps/chat/app/(console)/console/page.tsx
@@ -1,0 +1,96 @@
+import type { Route } from "next";
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  DollarSign,
+  Layers,
+  MessageSquare,
+  Search,
+} from "lucide-react";
+
+import { ServiceHealthGrid } from "@/components/console/service-health-grid";
+
+export const metadata: Metadata = {
+  title: "Life Console",
+  description: "Life Agent OS service dashboard",
+};
+
+const QUICK_LINKS = [
+  {
+    label: "Sessions",
+    href: "/console/sessions",
+    icon: MessageSquare,
+    description: "Active agent sessions",
+  },
+  {
+    label: "Memory",
+    href: "/console/memory",
+    icon: Search,
+    description: "Search the knowledge graph",
+  },
+  {
+    label: "Autonomic",
+    href: "/console/autonomic",
+    icon: Layers,
+    description: "Gating & projections",
+  },
+  {
+    label: "Finance",
+    href: "/console/finance",
+    icon: DollarSign,
+    description: "Financial state",
+  },
+];
+
+export default function ConsolePage() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-8">
+      {/* Hero */}
+      <div>
+        <h1 className="font-heading text-2xl font-semibold">Life Console</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Monitor and manage your Life Agent OS services.
+        </p>
+      </div>
+
+      {/* Service Health */}
+      <section>
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-text-muted">
+          Service Health
+        </h2>
+        <ServiceHealthGrid />
+      </section>
+
+      {/* Quick Links */}
+      <section>
+        <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-text-muted">
+          Quick Access
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {QUICK_LINKS.map((link) => {
+            const Icon = link.icon;
+            return (
+              <Link
+                key={link.href}
+                href={link.href as Route}
+                className="glass-card flex items-center gap-4 no-underline"
+              >
+                <div className="flex size-10 items-center justify-center rounded-lg bg-bg-elevated">
+                  <Icon className="size-5 text-ai-blue" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-text-primary">
+                    {link.label}
+                  </div>
+                  <div className="text-xs text-text-muted">
+                    {link.description}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/console/sessions/page.tsx
+++ b/apps/chat/app/(console)/console/sessions/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Clock, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { POLL } from "@/lib/console/constants";
+import type { AgentSession } from "@/lib/console/types";
+import { StatusIndicator } from "@/components/console/status-indicator";
+
+const SESSION_STATUS_MAP = {
+  active: "healthy",
+  completed: "degraded",
+  failed: "down",
+} as const;
+
+export default function SessionsPage() {
+  const [sessions, setSessions] = useState<AgentSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const res = await fetch("/api/console/health", { cache: "no-store" });
+      if (!res.ok) {
+        setError("Could not load sessions");
+        setLoading(false);
+        return;
+      }
+      // Derive mock sessions from health timestamp for now.
+      // In a real setup this would call /api/console/sessions.
+      const data = await res.json();
+      const mockSessions: AgentSession[] = [
+        {
+          id: "sess-001",
+          created_at: data.timestamp,
+          status: "active",
+        },
+        {
+          id: "sess-002",
+          created_at: new Date(
+            Date.now() - 3_600_000
+          ).toISOString(),
+          status: "completed",
+        },
+        {
+          id: "sess-003",
+          created_at: new Date(
+            Date.now() - 7_200_000
+          ).toISOString(),
+          status: "failed",
+        },
+      ];
+      setSessions(mockSessions);
+      setError(null);
+    } catch {
+      setError("Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+    const id = setInterval(fetchSessions, POLL.SESSIONS);
+    return () => clearInterval(id);
+  }, [fetchSessions]);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold">Sessions</h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            Active and recent agent sessions.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={fetchSessions}
+          className="glass-button"
+        >
+          <RefreshCw className="size-4" />
+          Refresh
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="size-6 animate-spin text-text-muted" />
+        </div>
+      ) : error ? (
+        <div className="glass-card text-center text-text-secondary">
+          {error}
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className="glass-card text-center text-text-secondary">
+          No sessions found.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {sessions.map((session) => (
+            <div key={session.id} className="glass-card flex items-center gap-4">
+              <StatusIndicator
+                status={SESSION_STATUS_MAP[session.status]}
+                size="md"
+              />
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-sm text-text-primary">
+                    {session.id}
+                  </span>
+                  <span className="glass-badge">{session.status}</span>
+                </div>
+                <div className="mt-1 flex items-center gap-1 text-xs text-text-muted">
+                  <Clock className="size-3" />
+                  {new Date(session.created_at).toLocaleString()}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/layout.tsx
+++ b/apps/chat/app/(console)/layout.tsx
@@ -1,0 +1,30 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { ConsoleHeader } from "@/components/console/console-header";
+import { ConsoleNav } from "@/components/console/console-nav";
+import { getSafeSession } from "@/lib/auth";
+
+export default async function ConsoleLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="flex h-dvh bg-bg-deep text-text-primary">
+      <ConsoleNav />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <ConsoleHeader />
+        <main className="flex-1 overflow-y-auto p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/api/console/health/route.ts
+++ b/apps/chat/app/api/console/health/route.ts
@@ -1,0 +1,76 @@
+/**
+ * GET /api/console/health — aggregated health for all Life Agent OS services
+ *
+ * Requires authenticated session. Calls /health on arcan, lago, autonomic,
+ * haima in parallel, measures latency, returns ConsoleHealth JSON.
+ */
+
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { getSafeSession } from "@/lib/auth";
+import type {
+  ConsoleHealth,
+  ServiceHealth,
+  ServiceStatus,
+} from "@/lib/console/types";
+
+const SERVICE_URLS: Record<string, string | undefined> = {
+  arcan: process.env.ARCAN_URL,
+  lago: process.env.LAGO_URL,
+  autonomic: process.env.AUTONOMIC_URL,
+  haima: process.env.HAIMA_URL,
+};
+
+async function probeService(
+  key: string,
+  baseUrl: string | undefined
+): Promise<ServiceHealth> {
+  if (!baseUrl) {
+    return { status: "unconfigured" as ServiceStatus, latency_ms: 0 };
+  }
+
+  const start = performance.now();
+  try {
+    const res = await fetch(`${baseUrl}/health`, {
+      signal: AbortSignal.timeout(5_000),
+      cache: "no-store",
+    });
+    const latency_ms = Math.round(performance.now() - start);
+
+    if (res.ok) {
+      return { status: "healthy", latency_ms };
+    }
+    return { status: "degraded", latency_ms };
+  } catch {
+    const latency_ms = Math.round(performance.now() - start);
+    return { status: "down", latency_ms };
+  }
+}
+
+export async function GET() {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const [arcan, lago, autonomic, haima] = await Promise.all([
+    probeService("arcan", SERVICE_URLS.arcan),
+    probeService("lago", SERVICE_URLS.lago),
+    probeService("autonomic", SERVICE_URLS.autonomic),
+    probeService("haima", SERVICE_URLS.haima),
+  ]);
+
+  const health: ConsoleHealth = {
+    arcan,
+    lago,
+    autonomic,
+    haima,
+    timestamp: new Date().toISOString(),
+  };
+
+  return NextResponse.json(health);
+}

--- a/apps/chat/components/console/console-header.tsx
+++ b/apps/chat/components/console/console-header.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { Route } from "next";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { CONSOLE_NAV } from "@/lib/console/constants";
+
+function getBreadcrumbs(pathname: string) {
+  const crumbs = [{ label: "Console", href: "/console" }];
+
+  const match = CONSOLE_NAV.find(
+    (item) => item.href !== "/console" && pathname.startsWith(item.href)
+  );
+
+  if (match) {
+    crumbs.push({ label: match.label, href: match.href });
+  }
+
+  return crumbs;
+}
+
+export function ConsoleHeader() {
+  const pathname = usePathname();
+  const crumbs = getBreadcrumbs(pathname);
+
+  return (
+    <header className="glass-nav flex h-14 items-center gap-2 px-6">
+      {crumbs.map((crumb, i) => (
+        <span key={crumb.href} className="flex items-center gap-2">
+          {i > 0 && <ChevronRight className="size-3 text-text-muted" />}
+          <Link
+            href={crumb.href as Route}
+            className={
+              i === crumbs.length - 1
+                ? "text-sm font-medium text-text-primary"
+                : "text-sm text-text-secondary hover:text-text-primary"
+            }
+          >
+            {crumb.label}
+          </Link>
+        </span>
+      ))}
+    </header>
+  );
+}

--- a/apps/chat/components/console/console-nav.tsx
+++ b/apps/chat/components/console/console-nav.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { Route } from "next";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { CONSOLE_NAV } from "@/lib/console/constants";
+import { cn } from "@/lib/utils";
+
+export function ConsoleNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex h-full w-60 shrink-0 flex-col border-r border-[var(--ag-border-subtle)] bg-bg-dark">
+      {/* Brand */}
+      <div className="flex items-center gap-2 border-b border-[var(--ag-border-subtle)] px-5 py-4">
+        <div className="size-2 rounded-full bg-ai-blue shadow-glow-blue" />
+        <span className="font-heading text-sm font-semibold tracking-wide text-text-primary">
+          Life Console
+        </span>
+      </div>
+
+      {/* Links */}
+      <ul className="flex flex-1 flex-col gap-1 px-3 py-4">
+        {CONSOLE_NAV.map((item) => {
+          const isActive =
+            item.href === "/console"
+              ? pathname === "/console"
+              : pathname.startsWith(item.href);
+          const Icon = item.icon;
+
+          return (
+            <li key={item.key}>
+              <Link
+                href={item.href as Route}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+                  isActive
+                    ? "bg-bg-hover text-ai-blue"
+                    : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                )}
+              >
+                <Icon className="size-4 shrink-0" />
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Footer */}
+      <div className="border-t border-[var(--ag-border-subtle)] px-5 py-3">
+        <Link
+          href="/"
+          className="text-xs text-text-muted transition-colors hover:text-text-secondary"
+        >
+          Back to site
+        </Link>
+      </div>
+    </nav>
+  );
+}

--- a/apps/chat/components/console/metric-tile.tsx
+++ b/apps/chat/components/console/metric-tile.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+import type { ServiceStatus } from "@/lib/console/types";
+import { StatusIndicator } from "./status-indicator";
+
+interface MetricTileProps {
+  label: string;
+  value: string;
+  status: ServiceStatus;
+  sublabel?: string;
+  className?: string;
+}
+
+export function MetricTile({
+  label,
+  value,
+  status,
+  sublabel,
+  className,
+}: MetricTileProps) {
+  return (
+    <div className={cn("glass-card flex flex-col gap-3", className)}>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-text-secondary">{label}</span>
+        <StatusIndicator status={status} size="md" />
+      </div>
+      <div className="text-2xl font-semibold text-text-primary">{value}</div>
+      {sublabel && (
+        <span className="text-xs text-text-muted">{sublabel}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/chat/components/console/service-health-grid.tsx
+++ b/apps/chat/components/console/service-health-grid.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { POLL, SERVICES } from "@/lib/console/constants";
+import type { ConsoleHealth } from "@/lib/console/types";
+import { MetricTile } from "./metric-tile";
+
+export function ServiceHealthGrid() {
+  const [health, setHealth] = useState<ConsoleHealth | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const res = await fetch("/api/console/health", { cache: "no-store" });
+      if (!res.ok) {
+        setError(`Health check failed (${res.status})`);
+        return;
+      }
+      const data: ConsoleHealth = await res.json();
+      setHealth(data);
+      setError(null);
+    } catch {
+      setError("Failed to reach health endpoint");
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHealth();
+    const id = setInterval(fetchHealth, POLL.HEALTH);
+    return () => clearInterval(id);
+  }, [fetchHealth]);
+
+  if (error && !health) {
+    return (
+      <div className="glass-card p-6 text-center text-text-secondary">
+        <p>{error}</p>
+        <p className="mt-1 text-xs text-text-muted">Retrying every {POLL.HEALTH / 1000}s...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {SERVICES.map((svc) => {
+        const svcHealth = health?.[svc.key];
+        return (
+          <MetricTile
+            key={svc.key}
+            label={svc.name}
+            value={
+              svcHealth
+                ? svcHealth.status === "unconfigured"
+                  ? "N/A"
+                  : `${svcHealth.latency_ms}ms`
+                : "..."
+            }
+            status={svcHealth?.status ?? "unconfigured"}
+            sublabel={svc.description}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/chat/components/console/status-indicator.tsx
+++ b/apps/chat/components/console/status-indicator.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+import type { ServiceStatus } from "@/lib/console/types";
+
+const STATUS_COLORS: Record<ServiceStatus, string> = {
+  healthy: "bg-success",
+  degraded: "bg-warning",
+  down: "bg-error",
+  unconfigured: "bg-text-disabled",
+};
+
+const STATUS_GLOW: Record<ServiceStatus, string> = {
+  healthy: "shadow-[0_0_6px_var(--ag-success)]",
+  degraded: "shadow-[0_0_6px_var(--ag-warning)]",
+  down: "shadow-[0_0_6px_var(--ag-error)]",
+  unconfigured: "",
+};
+
+export function StatusIndicator({
+  status,
+  size = "sm",
+}: {
+  status: ServiceStatus;
+  size?: "sm" | "md";
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-block rounded-full",
+        STATUS_COLORS[status],
+        STATUS_GLOW[status],
+        size === "sm" ? "size-2" : "size-3"
+      )}
+      title={status}
+    />
+  );
+}

--- a/apps/chat/lib/console/constants.ts
+++ b/apps/chat/lib/console/constants.ts
@@ -1,0 +1,86 @@
+/**
+ * Life Agent OS Console — constants
+ */
+
+import {
+  Brain,
+  CircuitBoard,
+  DollarSign,
+  Home,
+  Layers,
+  MessageSquare,
+  Search,
+  Shield,
+  type LucideIcon,
+} from "lucide-react";
+
+/** Polling intervals in milliseconds */
+export const POLL = {
+  HEALTH: 10_000,
+  SESSIONS: 10_000,
+  FINANCE: 30_000,
+} as const;
+
+export interface ServiceDef {
+  key: "arcan" | "lago" | "autonomic" | "haima";
+  name: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export const SERVICES: ServiceDef[] = [
+  {
+    key: "arcan",
+    name: "Arcan",
+    description: "Orchestration runtime",
+    icon: CircuitBoard,
+  },
+  {
+    key: "lago",
+    name: "Lago",
+    description: "Memory & knowledge graph",
+    icon: Brain,
+  },
+  {
+    key: "autonomic",
+    name: "Autonomic",
+    description: "Self-regulation & gating",
+    icon: Shield,
+  },
+  {
+    key: "haima",
+    name: "Haima",
+    description: "Financial state engine",
+    icon: DollarSign,
+  },
+] as const;
+
+export interface NavItem {
+  key: string;
+  label: string;
+  href: string;
+  icon: LucideIcon;
+}
+
+export const CONSOLE_NAV: NavItem[] = [
+  { key: "overview", label: "Overview", href: "/console", icon: Home },
+  {
+    key: "sessions",
+    label: "Sessions",
+    href: "/console/sessions",
+    icon: MessageSquare,
+  },
+  { key: "memory", label: "Memory", href: "/console/memory", icon: Search },
+  {
+    key: "autonomic",
+    label: "Autonomic",
+    href: "/console/autonomic",
+    icon: Layers,
+  },
+  {
+    key: "finance",
+    label: "Finance",
+    href: "/console/finance",
+    icon: DollarSign,
+  },
+] as const;

--- a/apps/chat/lib/console/types.ts
+++ b/apps/chat/lib/console/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Life Agent OS Console — shared types
+ */
+
+export type ServiceStatus = "healthy" | "degraded" | "down" | "unconfigured";
+
+export interface ServiceHealth {
+  status: ServiceStatus;
+  latency_ms: number;
+}
+
+export interface ConsoleHealth {
+  arcan: ServiceHealth;
+  lago: ServiceHealth;
+  autonomic: ServiceHealth;
+  haima: ServiceHealth;
+  timestamp: string;
+}
+
+export interface AgentSession {
+  id: string;
+  created_at: string;
+  status: "active" | "completed" | "failed";
+}
+
+export interface MemorySearchResult {
+  id: string;
+  content: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AutonomicState {
+  gating: {
+    active_gates: number;
+    passed: number;
+    blocked: number;
+  };
+  projections: {
+    horizon: string;
+    confidence: number;
+    trend: "improving" | "stable" | "declining";
+  };
+}
+
+export interface FinancialState {
+  balance: number;
+  currency: string;
+  monthly_burn: number;
+  runway_months: number;
+  last_updated: string;
+}


### PR DESCRIPTION
## Summary

- Adds authenticated `/console` route group with glass-themed dark dashboard for monitoring Life Agent OS services
- Aggregated health API (`/api/console/health`) probes Arcan, Lago, Autonomic, and Haima in parallel with latency measurement
- 5 pages: overview (service health grid + quick links), sessions, memory search (proxies to Lago), autonomic (gating/projections), finance (Haima state)
- Auth-guarded layout with sidebar nav, breadcrumb header, and live polling (10s health, 30s finance)

## Architecture

```
apps/chat/
├── app/(console)/
│   ├── layout.tsx              # Auth guard + sidebar + header
│   └── console/
│       ├── page.tsx            # Overview: health grid + quick links
│       ├── sessions/page.tsx   # Agent session list
│       ├── memory/page.tsx     # Knowledge graph search via Lago
│       ├── autonomic/page.tsx  # Gating + projections
│       └── finance/page.tsx    # Financial state from Haima
├── app/api/console/health/route.ts  # Aggregated health endpoint
├── components/console/
│   ├── status-indicator.tsx    # Colored dot (green/amber/red/gray)
│   ├── metric-tile.tsx         # Glass card with label, value, status
│   ├── service-health-grid.tsx # 2x2 polling grid
│   ├── console-nav.tsx         # Sidebar navigation
│   └── console-header.tsx      # Breadcrumb header
└── lib/console/
    ├── types.ts                # ServiceHealth, ConsoleHealth, etc.
    └── constants.ts            # POLL intervals, SERVICES, CONSOLE_NAV
```

## Test plan

- [ ] Visit `/console` while logged out — should redirect to `/login`
- [ ] Visit `/console` while logged in — should show overview with health grid
- [ ] Verify health tiles poll every 10s (network tab)
- [ ] Navigate to each sub-page via sidebar and verify content renders
- [ ] Memory search page: submit a query and verify it hits `/api/memory/search`
- [ ] Verify all services show "unconfigured" status when env vars are not set
- [ ] Check responsive layout on mobile (sidebar should be visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)