### PR TITLE
fix(arcan): use aios-protocol capability strings in buildArcanPolicy

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -72,6 +72,7 @@ import {
   getClientIP,
 } from "@/lib/utils/rate-limit";
 import { executeViaArcan, resolveArcanUrl } from "@/lib/arcan";
+import type { ArcanPolicySet } from "@/lib/arcan/execute";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 
@@ -821,6 +822,38 @@ async function finalizeMessageAndCredits({
   }
 }
 
+/**
+ * Maps a subscription plan tier to an arcand PolicySet.
+ * anonymous: heavily gated — no side-effecting capabilities, 5 events/turn
+ * free:      read + search only, 15 events/turn
+ * pro+:      full access, 50 events/turn
+ */
+function buildArcanPolicy(plan: string): ArcanPolicySet {
+  if (plan === "anonymous") {
+    return {
+      allow_capabilities: ["fs:read:/session/**"],
+      gate_capabilities: ["fs:write:**", "exec:cmd:*", "net:egress:*", "secrets:read:*"],
+      max_events_per_turn: 5,
+      max_tool_runtime_secs: 30,
+    };
+  }
+  if (plan === "free") {
+    return {
+      allow_capabilities: ["fs:read:/session/**", "net:egress:*"],
+      gate_capabilities: ["fs:write:**", "exec:cmd:*", "secrets:read:*"],
+      max_events_per_turn: 15,
+      max_tool_runtime_secs: 30,
+    };
+  }
+  // pro / enterprise / any paid tier
+  return {
+    allow_capabilities: ["*"],
+    gate_capabilities: [],
+    max_events_per_turn: 50,
+    max_tool_runtime_secs: 60,
+  };
+}
+
 export async function POST(request: NextRequest) {
   const log = createModuleLogger("api:chat");
   try {
@@ -862,6 +895,8 @@ export async function POST(request: NextRequest) {
       sessionSetup;
 
     // ---- Tier-based model & credit gate (authenticated users only) ----
+    // userPlan is hoisted so the arcan block can build a tier-appropriate policy
+    let userPlan = "anonymous";
     if (userId && !isAnonymous) {
       // Lightweight single-row lookup for org plan + credits
       const [orgRow] = await tierDb
@@ -877,7 +912,7 @@ export async function POST(request: NextRequest) {
         .where(eq(organizationMember.userId, userId))
         .limit(1);
 
-      const userPlan = orgRow?.plan ?? "free";
+      userPlan = orgRow?.plan ?? "free";
 
       if (!isModelAllowed(userPlan, selectedModelId)) {
         return Response.json(
@@ -995,6 +1030,7 @@ export async function POST(request: NextRequest) {
             arcanUrl: endpoints.arcanUrl,
             userEmail: arcanEmail,
             abortSignal: abortController.signal,
+            policy: buildArcanPolicy(userPlan),
           });
 
           if (arcanResponse) {

--- a/apps/chat/lib/arcan/client.ts
+++ b/apps/chat/lib/arcan/client.ts
@@ -10,6 +10,7 @@
 import "server-only";
 
 import { SignJWT } from "jose";
+import type { ArcanPolicySet } from "./execute";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -19,7 +20,7 @@ export interface ArcanSessionManifest {
   created_at: string;
   workspace_root: string;
   model_routing: Record<string, unknown>;
-  policy: Record<string, unknown>;
+  policy: ArcanPolicySet;
 }
 
 export interface ArcanRunResponse {
@@ -52,7 +53,7 @@ export interface BudgetState {
 export interface CreateSessionOptions {
   sessionId?: string;
   owner?: string;
-  policy?: Record<string, unknown>;
+  policy?: ArcanPolicySet;
   modelRouting?: Record<string, unknown>;
 }
 

--- a/apps/chat/lib/arcan/client.ts
+++ b/apps/chat/lib/arcan/client.ts
@@ -70,6 +70,10 @@ export interface StreamOptions {
   branch?: string;
   cursor?: number;
   replayLimit?: number;
+  /** Unique ID for this assistant message — used as `messageId` in the Vercel
+   *  AI SDK v6 `start` frame. Pass a fresh UUID per chat turn so React has a
+   *  unique key for each assistant message within the same session. */
+  messageId?: string;
 }
 
 // ─── Client ─────────────────────────────────────────────────────────────────
@@ -191,6 +195,7 @@ export class ArcanClient {
     if (opts.cursor != null) params.set("cursor", String(opts.cursor));
     if (opts.replayLimit != null)
       params.set("replay_limit", String(opts.replayLimit));
+    if (opts.messageId) params.set("message_id", opts.messageId);
 
     const url = `${this.baseUrl}/sessions/${sessionId}/events/stream?${params}`;
     const res = await fetch(url, {

--- a/apps/chat/lib/arcan/execute.ts
+++ b/apps/chat/lib/arcan/execute.ts
@@ -15,6 +15,7 @@ import "server-only";
 import { after } from "next/server";
 import { ArcanClient, ArcanError } from "./client";
 import { createModuleLogger } from "@/lib/logger";
+import { generateUUID } from "@/lib/utils";
 import type { ChatMessage } from "@/lib/ai/types";
 
 const log = createModuleLogger("arcan:execute");
@@ -95,15 +96,19 @@ export async function executeViaArcan(
       log.error({ error: e }, "Arcan run failed");
     });
 
-  // Start streaming events immediately
-  // The cursor picks up from where the client last saw events,
-  // or 0 for a fresh session
+  // Start streaming events immediately.
+  // A fresh UUID per turn ensures each assistant message gets a unique React
+  // key — avoids duplicate key warnings when the same session handles multiple
+  // turns (previously messageId was always the session_id).
+  const messageId = generateUUID();
+
   try {
     const sseStream = await client.streamEvents(
       chatId,
       {
         cursor: lastSequence ?? 0,
         replayLimit: 512,
+        messageId,
       },
       abortSignal
     );

--- a/apps/chat/lib/arcan/execute.ts
+++ b/apps/chat/lib/arcan/execute.ts
@@ -136,15 +136,60 @@ export async function executeViaArcan(
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 /**
- * Extract a plain-text objective from the ChatMessage structure.
- * Arcan expects a string objective, not the full message parts.
+ * Build the objective string sent to arcand's POST /sessions/{id}/runs.
+ *
+ * Arcand accepts only a single `objective: string` — no structured messages
+ * array. To preserve multi-turn context we encode conversation history into
+ * the objective string itself, prefixed before the current user message.
+ *
+ * Format (XML-tagged so arcand's LLM can cleanly distinguish speakers):
+ *
+ *   <conversation_history>
+ *   User: <text of turn N-k>
+ *   Assistant: <text of turn N-k+1>
+ *   ...
+ *   </conversation_history>
+ *
+ *   Current request:
+ *   <user_message>
+ *   <text of current user message>
+ *   </user_message>
+ *
+ * When there is no prior history the <conversation_history> block is omitted
+ * so single-turn requests stay compact.
  */
 function extractObjective(
   userMessage: ChatMessage,
   previousMessages: ChatMessage[]
 ): string {
-  // Extract text content from the user message parts
-  const textParts = userMessage.parts
+  const currentText = extractMessageText(userMessage);
+
+  // Cap at last 20 messages regardless of what the caller trimmed.
+  const history = previousMessages.slice(-20);
+
+  if (history.length === 0) {
+    return currentText;
+  }
+
+  const historyLines = history
+    .map((msg) => {
+      const speaker = msg.role === "assistant" ? "Assistant" : "User";
+      return `${speaker}: ${extractMessageText(msg)}`;
+    })
+    .join("\n");
+
+  return (
+    `<conversation_history>\n${historyLines}\n</conversation_history>\n\n` +
+    `Current request:\n<user_message>\n${currentText}\n</user_message>`
+  );
+}
+
+/**
+ * Extract plain text from a single ChatMessage.
+ * Handles UIMessage v6 parts[] and the legacy content string fallback.
+ */
+function extractMessageText(msg: ChatMessage): string {
+  const textParts = msg.parts
     ?.filter((p: { type: string }) => p.type === "text")
     .map((p: { type: string; text?: string }) => p.text ?? "")
     .filter(Boolean);
@@ -153,10 +198,10 @@ function extractObjective(
     return textParts.join("\n\n");
   }
 
-  // Fallback: check for content field (older message format)
-  if ("content" in userMessage && typeof userMessage.content === "string") {
-    return userMessage.content;
+  // Legacy fallback: pre-v6 messages stored in DB with a content string
+  if ("content" in msg && typeof (msg as { content?: unknown }).content === "string") {
+    return (msg as { content: string }).content;
   }
 
-  return "Continue the conversation.";
+  return "(empty)";
 }

--- a/apps/chat/lib/arcan/execute.ts
+++ b/apps/chat/lib/arcan/execute.ts
@@ -20,6 +20,18 @@ import type { ChatMessage } from "@/lib/ai/types";
 
 const log = createModuleLogger("arcan:execute");
 
+/** Mirrors aios-protocol's PolicySet — capability strings must use the aios-protocol format */
+export interface ArcanPolicySet {
+  /** Capabilities allowed without approval. Use aios-protocol format: "fs:read:**", "net:egress:*", "*" */
+  allow_capabilities?: string[];
+  /** Capabilities requiring human approval before execution */
+  gate_capabilities?: string[];
+  /** Max wall-clock seconds for a single tool invocation (default: 30) */
+  max_tool_runtime_secs?: number;
+  /** Max agent events per turn before the run is interrupted (default: 256) */
+  max_events_per_turn?: number;
+}
+
 export interface ArcanExecuteOptions {
   chatId: string;
   userMessage: ChatMessage;
@@ -30,6 +42,8 @@ export interface ArcanExecuteOptions {
   /** Last known event sequence for cursor-based replay */
   lastSequence?: number;
   abortSignal?: AbortSignal;
+  /** Tier-based capability policy for the arcand session */
+  policy?: ArcanPolicySet;
 }
 
 /**
@@ -49,6 +63,7 @@ export async function executeViaArcan(
     userEmail,
     lastSequence,
     abortSignal,
+    policy,
   } = opts;
 
   let client: ArcanClient;
@@ -76,6 +91,7 @@ export async function executeViaArcan(
       await client.createSession({
         sessionId: chatId,
         owner: userId,
+        policy,
       });
       log.info({ chatId }, "Created new Arcan session");
     }


### PR DESCRIPTION
## Summary

Fixes the capability string format in `buildArcanPolicy()` so the Rust `SessionPolicyEngine` actually enforces tier-based access control.

Previously, strings like `"file_write"` and `"shell_exec"` never matched any `Capability` patterns in arcand, making the policy a no-op.

## Changes

- **execute.ts**: Add `ArcanPolicySet` TypeScript interface matching aios-protocol `PolicySet` struct
- **client.ts**: Propagate `ArcanPolicySet` into `CreateSessionOptions.policy` and `ArcanSessionManifest.policy`, replacing the loose `Record<string, unknown>` types
- **route.ts**: Fix `buildArcanPolicy()` to use proper aios-protocol format capability strings; import `ArcanPolicySet` type

## Tier policies

| Tier | Allow | Gate | Events/turn |
|------|-------|------|-------------|
| Anonymous | `fs:read:/session/**` | `fs:write:**`, `exec:cmd:*`, `net:egress:*`, `secrets:read:*` | 5 |
| Free | `fs:read:/session/**`, `net:egress:*` | `fs:write:**`, `exec:cmd:*`, `secrets:read:*` | 15 |
| Pro+ | `*` (all) | — | 50 |

Part of BRO-211/BRO-212.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced chat API to enforce tier-specific capabilities and rate limits for anonymous, free, and premium users.
  * Improved conversation context preservation by including full chat history in request processing.
  * Strengthened message tracking and session management for more reliable chat operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->