### PR TITLE
feat(arcan): capability & permission system — BRO-212 through BRO-228

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -72,6 +72,7 @@ import {
   getClientIP,
 } from "@/lib/utils/rate-limit";
 import { executeViaArcan, resolveArcanUrl } from "@/lib/arcan";
+import type { ArcanPolicySet } from "@/lib/arcan/execute";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 
@@ -821,6 +822,38 @@ async function finalizeMessageAndCredits({
   }
 }
 
+/**
+ * Maps a subscription plan tier to an arcand PolicySet.
+ * anonymous: heavily gated — no side-effecting capabilities, 5 events/turn
+ * free:      read + search only, 15 events/turn
+ * pro+:      full access, 50 events/turn
+ */
+function buildArcanPolicy(plan: string): ArcanPolicySet {
+  if (plan === "anonymous") {
+    return {
+      allow_capabilities: ["fs:read:/session/**"],
+      gate_capabilities: ["fs:write:**", "exec:cmd:*", "net:egress:*", "secrets:read:*"],
+      max_events_per_turn: 5,
+      max_tool_runtime_secs: 30,
+    };
+  }
+  if (plan === "free") {
+    return {
+      allow_capabilities: ["fs:read:/session/**", "net:egress:*"],
+      gate_capabilities: ["fs:write:**", "exec:cmd:*", "secrets:read:*"],
+      max_events_per_turn: 15,
+      max_tool_runtime_secs: 30,
+    };
+  }
+  // pro / enterprise / any paid tier
+  return {
+    allow_capabilities: ["*"],
+    gate_capabilities: [],
+    max_events_per_turn: 50,
+    max_tool_runtime_secs: 60,
+  };
+}
+
 export async function POST(request: NextRequest) {
   const log = createModuleLogger("api:chat");
   try {
@@ -862,6 +895,8 @@ export async function POST(request: NextRequest) {
       sessionSetup;
 
     // ---- Tier-based model & credit gate (authenticated users only) ----
+    // userPlan is hoisted so the arcan block can build a tier-appropriate policy
+    let userPlan = "anonymous";
     if (userId && !isAnonymous) {
       // Lightweight single-row lookup for org plan + credits
       const [orgRow] = await tierDb
@@ -877,7 +912,7 @@ export async function POST(request: NextRequest) {
         .where(eq(organizationMember.userId, userId))
         .limit(1);
 
-      const userPlan = orgRow?.plan ?? "free";
+      userPlan = orgRow?.plan ?? "free";
 
       if (!isModelAllowed(userPlan, selectedModelId)) {
         return Response.json(
@@ -995,6 +1030,7 @@ export async function POST(request: NextRequest) {
             arcanUrl: endpoints.arcanUrl,
             userEmail: arcanEmail,
             abortSignal: abortController.signal,
+            policy: buildArcanPolicy(userPlan),
           });
 
           if (arcanResponse) {

--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -71,7 +71,11 @@ import {
   checkAuthenticatedRateLimit,
   getClientIP,
 } from "@/lib/utils/rate-limit";
-import { executeViaArcan, resolveArcanUrl } from "@/lib/arcan";
+import {
+  executeViaArcan,
+  resolveArcanEndpoints,
+  markInstanceDegraded,
+} from "@/lib/arcan";
 import type { ArcanPolicySet } from "@/lib/arcan/execute";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
@@ -994,11 +998,12 @@ export async function POST(request: NextRequest) {
 
     const { previousMessages, allowedTools } = contextResult;
 
-    // ── Arcan Agent Runtime ─────────────────────────────────────────
-    // Try routing through Arcan for both authenticated and anonymous users.
-    // Authenticated: org Life instance on Railway → ARCAN_URL env fallback.
-    // Anonymous: ARCAN_URL env only (no org lookup).
-    // Falls back to streamText if Arcan is unavailable.
+    // ── Arcan Agent Runtime (BRO-225) ──────────────────────────────
+    // Two-tier routing:
+    //   1. Dedicated Railway org instance (enterprise only)
+    //   2. Shared ARCAN_URL env instance (all tiers, fallback)
+    // If the dedicated instance fails health check → mark degraded, try shared.
+    // Anonymous users skip the org lookup and go straight to the shared instance.
     {
       const arcanOwnerId = userId ?? anonymousSession?.id ?? null;
       const arcanEmail = userId
@@ -1008,40 +1013,63 @@ export async function POST(request: NextRequest) {
         : `anon-${anonymousSession?.id?.slice(0, 8)}@guest.broomva.tech`;
 
       if (arcanOwnerId) {
-        // Authenticated users: check org Life instance first, then env
-        // Anonymous users: skip org lookup, only use ARCAN_URL env
-        const endpoints = userId
-          ? await resolveArcanUrl(userId)
-          : process.env.ARCAN_URL
-            ? { arcanUrl: process.env.ARCAN_URL, lagoUrl: process.env.LAGO_URL ?? null }
-            : null;
+        const { dedicated, shared } = userId
+          ? await resolveArcanEndpoints(userId)
+          : {
+              dedicated: null,
+              shared: process.env.ARCAN_URL
+                ? { arcanUrl: process.env.ARCAN_URL, lagoUrl: process.env.LAGO_URL ?? null, isDedicated: false, orgId: null }
+                : null,
+            };
 
-        if (endpoints) {
+        const endpointsToTry = dedicated
+          ? [dedicated, shared].filter(Boolean)
+          : [shared].filter(Boolean);
+
+        for (const endpoint of endpointsToTry) {
+          if (!endpoint) continue;
+
           const abortController = new AbortController();
-          const timeoutId = setTimeout(() => {
-            abortController.abort();
-          }, 290_000);
+          const timeoutId = setTimeout(() => abortController.abort(), 290_000);
+
+          // Degraded policy applied when falling back from a failed dedicated instance
+          const isDegradedFallback = endpoint === shared && dedicated !== null;
+          const policy = isDegradedFallback
+            ? { ...buildArcanPolicy(userPlan), max_events_per_turn: 10 }
+            : buildArcanPolicy(userPlan);
 
           const arcanResponse = await executeViaArcan({
             chatId,
             userMessage,
             previousMessages,
             userId: arcanOwnerId,
-            arcanUrl: endpoints.arcanUrl,
+            arcanUrl: endpoint.arcanUrl,
             userEmail: arcanEmail,
             abortSignal: abortController.signal,
-            policy: buildArcanPolicy(userPlan),
+            policy,
           });
 
+          clearTimeout(timeoutId);
+
           if (arcanResponse) {
-            clearTimeout(timeoutId);
-            log.info({ chatId, anonymous: isAnonymous }, "Routed to Arcan");
+            log.info(
+              { chatId, anonymous: isAnonymous, dedicated: endpoint.isDedicated, degraded: isDegradedFallback },
+              "Routed to Arcan"
+            );
             return arcanResponse;
           }
 
-          clearTimeout(timeoutId);
-          log.info("Arcan unavailable, falling back to streamText");
+          // Dedicated instance unreachable — mark degraded and try shared next
+          if (endpoint.isDedicated && endpoint.orgId) {
+            log.warn(
+              { chatId, orgId: endpoint.orgId, arcanUrl: endpoint.arcanUrl },
+              "Dedicated arcand unreachable — marking degraded, falling back to shared instance (BRO-225)"
+            );
+            await markInstanceDegraded(endpoint.orgId);
+          }
         }
+
+        log.info("Arcan unavailable, falling back to streamText");
       }
     }
 

--- a/apps/chat/app/(console)/console/arcan-admin/page.tsx
+++ b/apps/chat/app/(console)/console/arcan-admin/page.tsx
@@ -1,0 +1,879 @@
+"use client";
+
+/**
+ * Arcan Admin Portal — BRO-228
+ *
+ * Enterprise tenant admin self-service for:
+ *  1. Capability Policy — per-role Arcan capability matrix
+ *  2. Custom Skills     — TOML skill manifest upload and assignment
+ *  3. MCP Servers       — private MCP server registration (enterprise-only)
+ *  4. Usage & Audit     — per-user event consumption and admin audit log
+ *
+ * Access: only owner / admin org members. Non-enterprise tabs show upgrade CTAs.
+ */
+
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronUp,
+  Database,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Server,
+  Shield,
+  Trash2,
+  ToggleLeft,
+  ToggleRight,
+  Zap,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface OrgInfo {
+  id: string;
+  name: string;
+  plan: string;
+  role: string;
+}
+
+interface ArcanRole {
+  id: string;
+  roleName: string;
+  allowCapabilities: string[];
+  maxEventsPerTurn: number;
+}
+
+interface CustomSkill {
+  id: string;
+  name: string;
+  manifestToml: string;
+  assignedRoles: string[];
+  enabled: boolean;
+  updatedAt: string;
+}
+
+interface McpServer {
+  id: string;
+  name: string;
+  assignedRoles: string[];
+  enabled: boolean;
+  createdAt: string;
+}
+
+// ─── Shared helpers ───────────────────────────────────────────────────────────
+
+function Tag({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded bg-[var(--ag-border-subtle)] px-1.5 py-0.5 font-mono text-xs text-text-secondary">
+      {label}
+    </span>
+  );
+}
+
+function SectionHeader({ icon: Icon, title }: { icon: typeof Shield; title: string }) {
+  return (
+    <h2 className="mb-4 flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-text-muted">
+      <Icon className="size-4" />
+      {title}
+    </h2>
+  );
+}
+
+function EnterpriseBadge({ plan }: { plan: string }) {
+  if (plan === "enterprise") return null;
+  return (
+    <div className="rounded-md border border-[var(--ag-accent)]/30 bg-[var(--ag-accent)]/5 p-4 text-sm">
+      <p className="font-medium text-text-primary">Enterprise plan required</p>
+      <p className="mt-1 text-xs text-text-secondary">
+        Upgrade to Enterprise to unlock custom MCP server registration and
+        dedicated Life instance management.
+      </p>
+      <a href="/pricing" className="glass-button mt-3 inline-flex items-center gap-2 text-xs">
+        <Zap className="size-3.5" /> Upgrade
+      </a>
+    </div>
+  );
+}
+
+// ─── Tab: Capability Policy ───────────────────────────────────────────────────
+
+function CapabilityPolicyTab({ org }: { org: OrgInfo }) {
+  const [roles, setRoles] = useState<ArcanRole[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [roleName, setRoleName] = useState("member");
+  const [caps, setCaps] = useState("");
+  const [maxEvents, setMaxEvents] = useState(20);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tenant/arcan-roles?organizationId=${org.id}`);
+      const data = await res.json();
+      setRoles(data.roles ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [org.id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleSave = async () => {
+    setError(null); setSuccess(null);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/tenant/arcan-roles", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          organizationId: org.id,
+          roleName,
+          allowCapabilities: caps.split(",").map((c) => c.trim()).filter(Boolean),
+          maxEventsPerTurn: maxEvents,
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setError(d.error ?? "Save failed");
+      } else {
+        setSuccess("Policy saved");
+        await load();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    await fetch("/api/tenant/arcan-roles", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ organizationId: org.id, roleName: name }),
+    });
+    await load();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="glass-card">
+        <SectionHeader icon={Shield} title="Role Capability Matrix" />
+        <p className="mb-4 text-xs text-text-secondary">
+          Define which Arcan capability strings are granted to each org role.
+          Leave empty to inherit tier defaults. Use <Tag label="*" /> for full
+          access or comma-separated strings like{" "}
+          <Tag label="exec:cmd:ls,fs:read:**" />.
+        </p>
+
+        <div className="space-y-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <select
+              value={roleName}
+              onChange={(e) => setRoleName(e.target.value)}
+              className="rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+            >
+              {["owner", "admin", "member", "viewer"].map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+            <input
+              type="text"
+              value={caps}
+              onChange={(e) => setCaps(e.target.value)}
+              placeholder="*, exec:cmd:ls, fs:read:**"
+              className="flex-1 rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 font-mono text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+            />
+            <input
+              type="number"
+              value={maxEvents}
+              onChange={(e) => setMaxEvents(Number(e.target.value))}
+              min={1}
+              max={200}
+              className="w-24 rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              title="Max events/turn"
+            />
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="glass-button inline-flex items-center gap-1.5 text-xs"
+            >
+              {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+              Save
+            </button>
+          </div>
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          {success && <p className="text-xs text-green-400">{success}</p>}
+        </div>
+      </div>
+
+      <div className="glass-card">
+        <div className="mb-3 flex items-center justify-between">
+          <SectionHeader icon={Shield} title="Configured Roles" />
+          <button type="button" onClick={load} className="glass-button p-1.5">
+            <RefreshCw className="size-3.5" />
+          </button>
+        </div>
+        {loading ? (
+          <Loader2 className="size-5 animate-spin text-text-muted" />
+        ) : roles.length === 0 ? (
+          <p className="text-sm text-text-secondary">No overrides — tier defaults apply.</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--ag-border-subtle)] text-left text-xs uppercase tracking-wider text-text-muted">
+                <th className="pb-2 pr-4">Role</th>
+                <th className="pb-2 pr-4">Capabilities</th>
+                <th className="pb-2 pr-4">Max Events/Turn</th>
+                <th className="pb-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--ag-border-subtle)]">
+              {roles.map((r) => (
+                <tr key={r.id}>
+                  <td className="py-2.5 pr-4 font-medium capitalize text-text-primary">{r.roleName}</td>
+                  <td className="py-2.5 pr-4">
+                    <div className="flex flex-wrap gap-1">
+                      {r.allowCapabilities.map((c) => <Tag key={c} label={c} />)}
+                    </div>
+                  </td>
+                  <td className="py-2.5 pr-4 font-mono text-text-secondary">{r.maxEventsPerTurn}</td>
+                  <td className="py-2.5 text-right">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(r.roleName)}
+                      className="rounded p-1 text-text-muted hover:bg-red-500/10 hover:text-red-400"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Tab: Custom Skills ───────────────────────────────────────────────────────
+
+function CustomSkillsTab({ org }: { org: OrgInfo }) {
+  const [skills, setSkills] = useState<CustomSkill[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState("");
+  const [toml, setToml] = useState("");
+  const [roles, setRoles] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tenant/custom-skills?organizationId=${org.id}`);
+      const data = await res.json();
+      setSkills(data.skills ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [org.id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleSave = async () => {
+    setError(null);
+    if (!name.trim() || !toml.trim()) {
+      setError("Name and manifest TOML are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/tenant/custom-skills", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          organizationId: org.id,
+          name: name.trim(),
+          manifestToml: toml,
+          assignedRoles: roles.split(",").map((r) => r.trim()).filter(Boolean),
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setError(d.error ?? "Save failed");
+      } else {
+        setShowForm(false);
+        setName(""); setToml(""); setRoles("");
+        await load();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (skill: CustomSkill) => {
+    await fetch("/api/tenant/custom-skills", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: org.id,
+        skillId: skill.id,
+        enabled: !skill.enabled,
+      }),
+    });
+    await load();
+  };
+
+  const handleDelete = async (skillId: string) => {
+    await fetch("/api/tenant/custom-skills", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ organizationId: org.id, skillId }),
+    });
+    await load();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="glass-card">
+        <div className="mb-4 flex items-center justify-between">
+          <SectionHeader icon={BookOpen} title="Custom Skills" />
+          <button
+            type="button"
+            onClick={() => setShowForm(!showForm)}
+            className="glass-button inline-flex items-center gap-1.5 text-xs"
+          >
+            <Plus className="size-3.5" />
+            Upload Skill
+          </button>
+        </div>
+
+        {showForm && (
+          <div className="mb-4 space-y-3 rounded-md border border-[var(--ag-border-subtle)] p-4">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">Skill Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-custom-skill"
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">
+                Manifest TOML
+              </label>
+              <textarea
+                value={toml}
+                onChange={(e) => setToml(e.target.value)}
+                rows={8}
+                placeholder={'[skill]\nname = "my-skill"\ndescription = "..."\n\n[skill.metadata]\ntrigger = "when user asks about X"'}
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 font-mono text-xs text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">
+                Assigned Roles (comma-separated, empty = all)
+              </label>
+              <input
+                type="text"
+                value={roles}
+                onChange={(e) => setRoles(e.target.value)}
+                placeholder="admin, member"
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="glass-button inline-flex items-center gap-1.5 text-xs"
+              >
+                {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+                Save Skill
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowForm(false); setError(null); }}
+                className="glass-button text-xs text-text-muted"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <Loader2 className="size-5 animate-spin text-text-muted" />
+        ) : skills.length === 0 ? (
+          <p className="text-sm text-text-secondary">No custom skills uploaded yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {skills.map((skill) => (
+              <div
+                key={skill.id}
+                className="rounded-md border border-[var(--ag-border-subtle)] p-3"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-text-primary">{skill.name}</span>
+                    <span className={`glass-badge text-xs ${skill.enabled ? "text-green-400" : "text-text-muted"}`}>
+                      {skill.enabled ? "active" : "disabled"}
+                    </span>
+                    {skill.assignedRoles.map((r) => (
+                      <Tag key={r} label={r} />
+                    ))}
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => handleToggle(skill)}
+                      className="rounded p-1 text-text-muted hover:text-text-primary"
+                      title={skill.enabled ? "Disable" : "Enable"}
+                    >
+                      {skill.enabled
+                        ? <ToggleRight className="size-4 text-green-400" />
+                        : <ToggleLeft className="size-4" />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setExpanded(expanded === skill.id ? null : skill.id)}
+                      className="rounded p-1 text-text-muted hover:text-text-primary"
+                    >
+                      {expanded === skill.id
+                        ? <ChevronUp className="size-4" />
+                        : <ChevronDown className="size-4" />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(skill.id)}
+                      className="rounded p-1 text-text-muted hover:bg-red-500/10 hover:text-red-400"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </div>
+                </div>
+                {expanded === skill.id && (
+                  <pre className="mt-3 overflow-x-auto rounded bg-[var(--ag-bg-subtle)] p-3 font-mono text-xs text-text-secondary">
+                    {skill.manifestToml}
+                  </pre>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Tab: MCP Servers ─────────────────────────────────────────────────────────
+
+function McpServersTab({ org }: { org: OrgInfo }) {
+  const isEnterprise = org.plan === "enterprise";
+  const [servers, setServers] = useState<McpServer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [roles, setRoles] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!isEnterprise) { setLoading(false); return; }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tenant/mcp-servers?organizationId=${org.id}`);
+      const data = await res.json();
+      setServers(data.servers ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, [org.id, isEnterprise]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleSave = async () => {
+    setError(null);
+    if (!name.trim() || !url.trim()) {
+      setError("Name and URL are required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/tenant/mcp-servers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          organizationId: org.id,
+          name: name.trim(),
+          url: url.trim(),
+          bearerToken: token.trim() || undefined,
+          assignedRoles: roles.split(",").map((r) => r.trim()).filter(Boolean),
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json();
+        setError(d.error ?? "Save failed");
+      } else {
+        setShowForm(false);
+        setName(""); setUrl(""); setToken(""); setRoles("");
+        await load();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (server: McpServer) => {
+    await fetch("/api/tenant/mcp-servers", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        organizationId: org.id,
+        serverId: server.id,
+        enabled: !server.enabled,
+      }),
+    });
+    await load();
+  };
+
+  const handleDelete = async (serverId: string) => {
+    await fetch("/api/tenant/mcp-servers", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ organizationId: org.id, serverId }),
+    });
+    await load();
+  };
+
+  if (!isEnterprise) return <EnterpriseBadge plan={org.plan} />;
+
+  return (
+    <div className="glass-card space-y-4">
+      <div className="flex items-center justify-between">
+        <SectionHeader icon={Server} title="Private MCP Servers" />
+        <button
+          type="button"
+          onClick={() => setShowForm(!showForm)}
+          className="glass-button inline-flex items-center gap-1.5 text-xs"
+        >
+          <Plus className="size-3.5" /> Register Server
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="space-y-3 rounded-md border border-[var(--ag-border-subtle)] p-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">Server Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="internal-crm"
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">Server URL</label>
+              <input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://mcp.internal.company.com"
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">
+                Bearer Token <span className="text-text-muted">(encrypted at rest)</span>
+              </label>
+              <input
+                type="password"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="Optional"
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-text-secondary">
+                Assigned Roles (empty = all)
+              </label>
+              <input
+                type="text"
+                value={roles}
+                onChange={(e) => setRoles(e.target.value)}
+                placeholder="admin, member"
+                className="w-full rounded-md border border-[var(--ag-border-subtle)] bg-transparent px-3 py-2 text-sm text-text-primary focus:outline-none focus:ring-1 focus:ring-[var(--ag-accent)]"
+              />
+            </div>
+          </div>
+          {error && <p className="text-xs text-red-400">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="glass-button inline-flex items-center gap-1.5 text-xs"
+            >
+              {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Plus className="size-3.5" />}
+              Register
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowForm(false); setError(null); }}
+              className="glass-button text-xs text-text-muted"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <Loader2 className="size-5 animate-spin text-text-muted" />
+      ) : servers.length === 0 ? (
+        <p className="text-sm text-text-secondary">No private MCP servers registered.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-[var(--ag-border-subtle)] text-left text-xs uppercase tracking-wider text-text-muted">
+              <th className="pb-2 pr-4">Name</th>
+              <th className="pb-2 pr-4">Roles</th>
+              <th className="pb-2 pr-4">Status</th>
+              <th className="pb-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[var(--ag-border-subtle)]">
+            {servers.map((s) => (
+              <tr key={s.id}>
+                <td className="py-2.5 pr-4 font-mono text-text-primary">{s.name}</td>
+                <td className="py-2.5 pr-4">
+                  <div className="flex flex-wrap gap-1">
+                    {s.assignedRoles.length === 0
+                      ? <Tag label="all roles" />
+                      : s.assignedRoles.map((r) => <Tag key={r} label={r} />)}
+                  </div>
+                </td>
+                <td className="py-2.5 pr-4">
+                  <span className={`glass-badge text-xs ${s.enabled ? "text-green-400" : "text-text-muted"}`}>
+                    {s.enabled ? "active" : "disabled"}
+                  </span>
+                </td>
+                <td className="py-2.5 text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => handleToggle(s)}
+                      className="rounded p-1 text-text-muted hover:text-text-primary"
+                    >
+                      {s.enabled
+                        ? <ToggleRight className="size-4 text-green-400" />
+                        : <ToggleLeft className="size-4" />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(s.id)}
+                      className="rounded p-1 text-text-muted hover:bg-red-500/10 hover:text-red-400"
+                    >
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ─── Tab: Usage & Audit ───────────────────────────────────────────────────────
+
+function UsageAuditTab({ org }: { org: OrgInfo }) {
+  const [usageData, setUsageData] = useState<{
+    totalEvents: number;
+    periodStart: string | null;
+    creditsRemaining: number;
+    creditsMonthly: number;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/organization?includeUsage=true`);
+      const data = await res.json();
+      const o = data.organizations?.find((x: { id: string }) => x.id === org.id);
+      if (o) {
+        setUsageData({
+          totalEvents: 0, // Lago event counts fetched separately
+          periodStart: o.billingPeriodStart ?? null,
+          creditsRemaining: o.creditsRemaining,
+          creditsMonthly: o.creditsMonthly,
+        });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [org.id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="glass-card">
+        <SectionHeader icon={Database} title="Credit & Usage Summary" />
+        {loading ? (
+          <Loader2 className="size-5 animate-spin text-text-muted" />
+        ) : usageData ? (
+          <div className="space-y-3 text-sm">
+            <div className="flex items-center justify-between border-b border-[var(--ag-border-subtle)] pb-2">
+              <span className="text-text-secondary">Credits Remaining</span>
+              <span className="font-mono text-text-primary">
+                {usageData.creditsRemaining} / {usageData.creditsMonthly}
+              </span>
+            </div>
+            {usageData.periodStart && (
+              <div className="flex items-center justify-between border-b border-[var(--ag-border-subtle)] pb-2">
+                <span className="text-text-secondary">Period Start</span>
+                <span className="font-mono text-text-primary">
+                  {new Date(usageData.periodStart).toLocaleDateString()}
+                </span>
+              </div>
+            )}
+            <div className="flex items-center justify-between">
+              <span className="text-text-secondary">Plan</span>
+              <span className="glass-badge capitalize">{org.plan}</span>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-text-secondary">Could not load usage data.</p>
+        )}
+      </div>
+
+      <div className="glass-card">
+        <SectionHeader icon={Shield} title="Audit Log" />
+        <p className="text-sm text-text-secondary">
+          Admin actions (role changes, skill uploads, MCP server registrations)
+          are recorded in the platform audit log. Full log export is available
+          via{" "}
+          <a href="/console/lago" className="underline hover:text-text-primary">
+            the Lago console
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+type Tab = "policy" | "skills" | "mcp" | "usage";
+
+const TABS: { id: Tab; label: string; icon: typeof Shield }[] = [
+  { id: "policy", label: "Capability Policy", icon: Shield },
+  { id: "skills", label: "Custom Skills", icon: BookOpen },
+  { id: "mcp", label: "MCP Servers", icon: Server },
+  { id: "usage", label: "Usage & Audit", icon: Database },
+];
+
+export default function ArcanAdminPage() {
+  const [org, setOrg] = useState<OrgInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<Tab>("policy");
+  const [accessError, setAccessError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch("/api/organization");
+      const data = await res.json();
+      const first = data.organizations?.[0];
+      if (!first) {
+        setAccessError("No organization found.");
+        setLoading(false);
+        return;
+      }
+      if (first.role !== "owner" && first.role !== "admin") {
+        setAccessError("Access restricted to tenant admins.");
+        setLoading(false);
+        return;
+      }
+      setOrg({ id: first.id, name: first.name, plan: first.plan, role: first.role });
+      setLoading(false);
+    })();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="size-6 animate-spin text-text-muted" />
+      </div>
+    );
+  }
+
+  if (accessError || !org) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <div className="glass-card text-center text-text-secondary">
+          {accessError ?? "Organization not found."}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold">Arcan Admin</h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            {org.name} · <span className="capitalize">{org.plan}</span> plan ·{" "}
+            <span className="capitalize">{org.role}</span>
+          </p>
+        </div>
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b border-[var(--ag-border-subtle)]">
+        {TABS.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setTab(id)}
+            className={[
+              "inline-flex items-center gap-1.5 border-b-2 px-3 py-2 text-sm transition-colors",
+              tab === id
+                ? "border-[var(--ag-accent)] text-text-primary"
+                : "border-transparent text-text-secondary hover:text-text-primary",
+            ].join(" ")}
+          >
+            <Icon className="size-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {tab === "policy" && <CapabilityPolicyTab org={org} />}
+      {tab === "skills" && <CustomSkillsTab org={org} />}
+      {tab === "mcp" && <McpServersTab org={org} />}
+      {tab === "usage" && <UsageAuditTab org={org} />}
+    </div>
+  );
+}

--- a/apps/chat/app/api/auth/migrate-anonymous/route.ts
+++ b/apps/chat/app/api/auth/migrate-anonymous/route.ts
@@ -1,0 +1,134 @@
+/**
+ * POST /api/auth/migrate-anonymous — BRO-227
+ *
+ * When an anonymous user signs up mid-session, migrates their conversation
+ * history into the new authenticated account and upgrades the live Arcan
+ * session's PolicySet without requiring a session restart.
+ *
+ * Flow:
+ *  1. Verify the caller is now authenticated (Better Auth session).
+ *  2. Read the anonymous session cookie to confirm it belongs to this browser.
+ *  3. Save conversation messages to the Chat DB under the new user.
+ *  4. PATCH /sessions/{anonymous_session_id}/identity on arcand.
+ *  5. Clear the anonymous session cookie.
+ *  6. Return { saved: true, message: "..." }.
+ */
+
+import { cookies, headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { getSafeSession } from "@/lib/auth";
+import { ANONYMOUS_SESSION_COOKIES_KEY } from "@/lib/constants";
+import { saveChat, saveChatMessages } from "@/lib/db/queries";
+import { ArcanClient } from "@/lib/arcan/client";
+import { resolveArcanEndpoints } from "@/lib/arcan/resolve";
+import type { ChatMessage } from "@/lib/ai/types";
+
+interface MigrateRequest {
+  /** The Arcan session ID assigned to the anonymous session. */
+  anonymous_session_id: string;
+  /** Full message list from the anonymous context (client-side history). */
+  messages: ChatMessage[];
+  /** Chat title derived from the first user message. */
+  title?: string;
+  /** Optional project to attach the migrated chat to. */
+  project_id?: string;
+}
+
+export async function POST(request: NextRequest) {
+  // 1. Require authenticated session.
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // 2. Validate the anonymous session cookie is present (belongs to this browser).
+  const cookieStore = await cookies();
+  const anonCookie = cookieStore.get(ANONYMOUS_SESSION_COOKIES_KEY);
+  if (!anonCookie?.value) {
+    return NextResponse.json(
+      { error: "No anonymous session found for this browser" },
+      { status: 400 }
+    );
+  }
+
+  let body: MigrateRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { anonymous_session_id, messages, title, project_id } = body;
+
+  if (!anonymous_session_id) {
+    return NextResponse.json(
+      { error: "anonymous_session_id is required" },
+      { status: 400 }
+    );
+  }
+
+  // 3. Persist conversation to Chat DB under the new authenticated user.
+  const chatId = crypto.randomUUID();
+  const chatTitle = title ?? "Migrated conversation";
+
+  try {
+    await saveChat({
+      id: chatId,
+      userId,
+      title: chatTitle,
+      projectId: project_id,
+    });
+
+    if (messages.length > 0) {
+      const dbMessages = messages.map((msg) => ({
+        id: crypto.randomUUID(),
+        chatId,
+        message: msg,
+      }));
+      await saveChatMessages({ messages: dbMessages });
+    }
+  } catch (err) {
+    console.error("[migrate-anonymous] DB save failed:", err);
+    return NextResponse.json(
+      { error: "Failed to save conversation history" },
+      { status: 500 }
+    );
+  }
+
+  // 4. Upgrade the live Arcan session identity (best-effort — don't fail the
+  //    migration if Arcan is unreachable; the DB history is already saved).
+  try {
+    const { dedicated, shared } = await resolveArcanEndpoints(userId);
+    const endpoints = [dedicated, shared].filter(Boolean);
+
+    for (const ep of endpoints) {
+      if (!ep) continue;
+      try {
+        const client = await ArcanClient.forUser(ep.arcanUrl, {
+          id: userId,
+          email: session.user.email ?? `${userId}@guest`,
+        });
+        await client.upgradeIdentity(anonymous_session_id, userId);
+        break; // success — stop trying further endpoints
+      } catch {
+        // Try next endpoint
+      }
+    }
+  } catch (err) {
+    // Non-fatal: log and continue — the DB migration succeeded.
+    console.warn("[migrate-anonymous] Arcan identity upgrade failed:", err);
+  }
+
+  // 5. Clear the anonymous session cookie.
+  cookieStore.delete(ANONYMOUS_SESSION_COOKIES_KEY);
+
+  return NextResponse.json({
+    saved: true,
+    chat_id: chatId,
+    message: "Your conversation has been saved to your account",
+  });
+}

--- a/apps/chat/app/api/stripe/webhooks/route.ts
+++ b/apps/chat/app/api/stripe/webhooks/route.ts
@@ -1,9 +1,15 @@
+import { after } from "next/server";
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { logAudit } from "@/lib/db/audit";
 import { db } from "@/lib/db/client";
-import { organization } from "@/lib/db/schema";
+import { organization, organizationLifeInstance } from "@/lib/db/schema";
 import { updateOrganizationPlan } from "@/lib/db/organization";
+import {
+  deleteLifeInstance,
+  isRailwayConfigured,
+  provisionLifeInstance,
+} from "@/lib/railway";
 import { getStripe, PLAN_TIERS, tierFromPriceId, type PlanTier } from "@/lib/stripe";
 import type Stripe from "stripe";
 
@@ -45,6 +51,146 @@ async function replenishCredits(orgId: string, plan: PlanTier) {
       billingPeriodStart: new Date(),
     })
     .where(eq(organization.id, orgId));
+}
+
+// ---------------------------------------------------------------------------
+// Life instance auto-provisioning helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Provision a Railway Life stack for an enterprise org.
+ * Skips silently if Railway is not configured or an instance already exists.
+ * Intended to run as a background task via `after()`.
+ */
+async function autoProvisionLifeInstance(
+  orgId: string,
+  orgSlug: string,
+): Promise<void> {
+  if (!isRailwayConfigured()) return;
+
+  const [existing] = await db
+    .select({ id: organizationLifeInstance.id, status: organizationLifeInstance.status })
+    .from(organizationLifeInstance)
+    .where(eq(organizationLifeInstance.organizationId, orgId))
+    .limit(1);
+
+  // Already provisioned or in-flight — skip
+  if (existing && existing.status !== "failed") return;
+
+  // Upsert the record into "provisioning" state
+  const [instance] = existing
+    ? await db
+        .update(organizationLifeInstance)
+        .set({ status: "provisioning" })
+        .where(eq(organizationLifeInstance.id, existing.id))
+        .returning()
+    : await db
+        .insert(organizationLifeInstance)
+        .values({ organizationId: orgId, status: "provisioning" })
+        .returning();
+
+  logAudit({
+    organizationId: orgId,
+    actorId: "system",
+    action: "life_instance.provision.start",
+    resourceType: "life_instance",
+    resourceId: instance.id,
+    metadata: { trigger: "stripe_webhook" },
+  });
+
+  try {
+    const result = await provisionLifeInstance(orgSlug, orgId);
+
+    await db
+      .update(organizationLifeInstance)
+      .set({
+        railwayProjectId: result.railwayProjectId,
+        railwayEnvironmentId: result.railwayEnvironmentId,
+        arcanUrl: result.services.arcan.url,
+        lagoUrl: result.services.lago.url,
+        autonomicUrl: result.services.autonomic.url,
+        haimaUrl: result.services.haima.url,
+        status: "running",
+        lastHealthCheck: new Date(),
+      })
+      .where(eq(organizationLifeInstance.id, instance.id));
+
+    logAudit({
+      organizationId: orgId,
+      actorId: "system",
+      action: "life_instance.provision.complete",
+      resourceType: "life_instance",
+      resourceId: instance.id,
+      metadata: {
+        trigger: "stripe_webhook",
+        railwayProjectId: result.railwayProjectId,
+      },
+    });
+  } catch (err) {
+    await db
+      .update(organizationLifeInstance)
+      .set({ status: "failed" })
+      .where(eq(organizationLifeInstance.id, instance.id));
+
+    logAudit({
+      organizationId: orgId,
+      actorId: "system",
+      action: "life_instance.provision.failed",
+      resourceType: "life_instance",
+      resourceId: instance.id,
+      metadata: {
+        trigger: "stripe_webhook",
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}
+
+/**
+ * Deprovision the Railway Life stack for an org that downgraded from enterprise.
+ * Intended to run as a background task via `after()`.
+ */
+async function autoDeprovisionLifeInstance(orgId: string): Promise<void> {
+  if (!isRailwayConfigured()) return;
+
+  const [instance] = await db
+    .select()
+    .from(organizationLifeInstance)
+    .where(eq(organizationLifeInstance.organizationId, orgId))
+    .limit(1);
+
+  if (!instance || instance.status === "deprovisioning") return;
+
+  await db
+    .update(organizationLifeInstance)
+    .set({ status: "deprovisioning" })
+    .where(eq(organizationLifeInstance.id, instance.id));
+
+  try {
+    if (instance.railwayProjectId) {
+      await deleteLifeInstance(instance.railwayProjectId);
+    }
+
+    await db
+      .delete(organizationLifeInstance)
+      .where(eq(organizationLifeInstance.id, instance.id));
+
+    logAudit({
+      organizationId: orgId,
+      actorId: "system",
+      action: "life_instance.deprovision.complete",
+      resourceType: "life_instance",
+      resourceId: instance.id,
+      metadata: { trigger: "stripe_webhook" },
+    });
+  } catch (err) {
+    await db
+      .update(organizationLifeInstance)
+      .set({ status: "failed" })
+      .where(eq(organizationLifeInstance.id, instance.id));
+
+    console.error("[stripe] Life instance deprovisioning failed:", err);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -127,6 +273,19 @@ export async function POST(request: Request) {
           },
         });
 
+        // Auto-provision a Railway Life stack on enterprise activation
+        if (plan === "enterprise") {
+          const [org] = await db
+            .select({ slug: organization.slug })
+            .from(organization)
+            .where(eq(organization.id, orgId))
+            .limit(1);
+
+          if (org) {
+            after(autoProvisionLifeInstance(orgId, org.slug));
+          }
+        }
+
         break;
       }
 
@@ -150,6 +309,7 @@ export async function POST(request: Request) {
         const priceId = sub.items.data[0]?.price?.id;
         const plan: PlanTier = priceId ? tierFromPriceId(priceId) : "free";
 
+        const previousPlan = org.plan;
         await updateOrganizationPlan(org.id, plan, undefined, sub.id);
 
         logAudit({
@@ -160,10 +320,21 @@ export async function POST(request: Request) {
           resourceId: org.id,
           metadata: {
             plan,
+            previousPlan,
             stripeSubscriptionId: sub.id,
             status: sub.status,
           },
         });
+
+        // Enterprise upgrade → provision Life stack
+        if (previousPlan !== "enterprise" && plan === "enterprise") {
+          after(autoProvisionLifeInstance(org.id, org.slug));
+        }
+
+        // Enterprise downgrade → deprovision Life stack
+        if (previousPlan === "enterprise" && plan !== "enterprise") {
+          after(autoDeprovisionLifeInstance(org.id));
+        }
 
         break;
       }
@@ -185,6 +356,7 @@ export async function POST(request: Request) {
           break;
         }
 
+        const wasEnterprise = org.plan === "enterprise";
         await updateOrganizationPlan(org.id, "free", undefined, undefined);
 
         // Reset to free-tier credits
@@ -201,6 +373,11 @@ export async function POST(request: Request) {
             stripeSubscriptionId: sub.id,
           },
         });
+
+        // Deprovision Life stack if the org was on enterprise
+        if (wasEnterprise) {
+          after(autoDeprovisionLifeInstance(org.id));
+        }
 
         break;
       }

--- a/apps/chat/app/api/tenant/arcan-roles/route.ts
+++ b/apps/chat/app/api/tenant/arcan-roles/route.ts
@@ -1,0 +1,127 @@
+/**
+ * /api/tenant/arcan-roles — BRO-228
+ *
+ * Enterprise admins configure per-role Arcan capability overrides.
+ *
+ * GET  ?organizationId=<id>                    → list roles
+ * POST { organizationId, roleName, allowCapabilities, maxEventsPerTurn } → upsert
+ * DELETE { organizationId, roleName }           → remove
+ */
+
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { getSafeSession } from "@/lib/auth";
+import { getOrganizationMembers } from "@/lib/db/organization";
+import { db } from "@/lib/db/client";
+import { organizationArcanRole } from "@/lib/db/schema";
+
+async function requireAdmin(orgId: string, userId: string): Promise<boolean> {
+  const members = await getOrganizationMembers(orgId);
+  const actor = members.find((m) => m.userId === userId);
+  return actor?.role === "owner" || actor?.role === "admin";
+}
+
+export async function GET(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const orgId = request.nextUrl.searchParams.get("organizationId");
+  if (!orgId) {
+    return NextResponse.json({ error: "organizationId required" }, { status: 400 });
+  }
+
+  if (!(await requireAdmin(orgId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const roles = await db
+    .select()
+    .from(organizationArcanRole)
+    .where(eq(organizationArcanRole.organizationId, orgId));
+
+  return NextResponse.json({ roles });
+}
+
+export async function POST(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const {
+    organizationId,
+    roleName,
+    allowCapabilities,
+    maxEventsPerTurn,
+  } = await request.json();
+
+  if (!organizationId || !roleName) {
+    return NextResponse.json(
+      { error: "organizationId and roleName are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const [row] = await db
+    .insert(organizationArcanRole)
+    .values({
+      organizationId,
+      roleName,
+      allowCapabilities: allowCapabilities ?? [],
+      maxEventsPerTurn: maxEventsPerTurn ?? 20,
+    })
+    .onConflictDoUpdate({
+      target: [organizationArcanRole.organizationId, organizationArcanRole.roleName],
+      set: {
+        allowCapabilities: allowCapabilities ?? [],
+        maxEventsPerTurn: maxEventsPerTurn ?? 20,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  return NextResponse.json({ role: row });
+}
+
+export async function DELETE(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, roleName } = await request.json();
+  if (!organizationId || !roleName) {
+    return NextResponse.json(
+      { error: "organizationId and roleName are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await db
+    .delete(organizationArcanRole)
+    .where(
+      and(
+        eq(organizationArcanRole.organizationId, organizationId),
+        eq(organizationArcanRole.roleName, roleName),
+      )
+    );
+
+  return NextResponse.json({ deleted: true });
+}

--- a/apps/chat/app/api/tenant/custom-skills/route.ts
+++ b/apps/chat/app/api/tenant/custom-skills/route.ts
@@ -1,0 +1,164 @@
+/**
+ * /api/tenant/custom-skills — BRO-228
+ *
+ * Enterprise admins upload and manage custom SKILL.md manifests (TOML).
+ *
+ * GET  ?organizationId=<id>                       → list skills
+ * POST { organizationId, name, manifestToml, assignedRoles?, enabled? } → create/update
+ * DELETE { organizationId, skillId }              → remove
+ * PATCH { organizationId, skillId, enabled }      → toggle active state
+ */
+
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { getSafeSession } from "@/lib/auth";
+import { getOrganizationMembers } from "@/lib/db/organization";
+import { db } from "@/lib/db/client";
+import { organizationCustomSkill } from "@/lib/db/schema";
+
+async function requireAdmin(orgId: string, userId: string): Promise<boolean> {
+  const members = await getOrganizationMembers(orgId);
+  const actor = members.find((m) => m.userId === userId);
+  return actor?.role === "owner" || actor?.role === "admin";
+}
+
+export async function GET(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const orgId = request.nextUrl.searchParams.get("organizationId");
+  if (!orgId) {
+    return NextResponse.json({ error: "organizationId required" }, { status: 400 });
+  }
+
+  if (!(await requireAdmin(orgId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const skills = await db
+    .select()
+    .from(organizationCustomSkill)
+    .where(eq(organizationCustomSkill.organizationId, orgId));
+
+  return NextResponse.json({ skills });
+}
+
+export async function POST(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, name, manifestToml, assignedRoles, enabled } =
+    await request.json();
+
+  if (!organizationId || !name || !manifestToml) {
+    return NextResponse.json(
+      { error: "organizationId, name, and manifestToml are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const [row] = await db
+    .insert(organizationCustomSkill)
+    .values({
+      organizationId,
+      name,
+      manifestToml,
+      assignedRoles: assignedRoles ?? [],
+      enabled: enabled ?? true,
+    })
+    .onConflictDoUpdate({
+      target: [organizationCustomSkill.organizationId, organizationCustomSkill.name],
+      set: {
+        manifestToml,
+        assignedRoles: assignedRoles ?? [],
+        enabled: enabled ?? true,
+        updatedAt: new Date(),
+      },
+    })
+    .returning();
+
+  return NextResponse.json({ skill: row });
+}
+
+export async function PATCH(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, skillId, enabled } = await request.json();
+  if (!organizationId || !skillId || enabled === undefined) {
+    return NextResponse.json(
+      { error: "organizationId, skillId, and enabled are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const [row] = await db
+    .update(organizationCustomSkill)
+    .set({ enabled, updatedAt: new Date() })
+    .where(
+      and(
+        eq(organizationCustomSkill.id, skillId),
+        eq(organizationCustomSkill.organizationId, organizationId),
+      )
+    )
+    .returning();
+
+  if (!row) {
+    return NextResponse.json({ error: "Skill not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ skill: row });
+}
+
+export async function DELETE(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, skillId } = await request.json();
+  if (!organizationId || !skillId) {
+    return NextResponse.json(
+      { error: "organizationId and skillId are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await db
+    .delete(organizationCustomSkill)
+    .where(
+      and(
+        eq(organizationCustomSkill.id, skillId),
+        eq(organizationCustomSkill.organizationId, organizationId),
+      )
+    );
+
+  return NextResponse.json({ deleted: true });
+}

--- a/apps/chat/app/api/tenant/mcp-servers/route.ts
+++ b/apps/chat/app/api/tenant/mcp-servers/route.ts
@@ -1,0 +1,199 @@
+/**
+ * /api/tenant/mcp-servers — BRO-226 / BRO-228
+ *
+ * Enterprise admins register private MCP servers for their org.
+ * URL and bearer token are encrypted at rest via encryptedText columns.
+ *
+ * GET  ?organizationId=<id>                             → list servers
+ * POST { organizationId, name, url, bearerToken?, assignedRoles? } → create/update
+ * PATCH { organizationId, serverId, enabled }           → toggle
+ * DELETE { organizationId, serverId }                   → remove
+ */
+
+import { headers } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { getSafeSession } from "@/lib/auth";
+import { getOrganizationMembers } from "@/lib/db/organization";
+import { db } from "@/lib/db/client";
+import { organization, organizationMcpServer } from "@/lib/db/schema";
+
+async function requireAdmin(orgId: string, userId: string): Promise<boolean> {
+  const members = await getOrganizationMembers(orgId);
+  const actor = members.find((m) => m.userId === userId);
+  return actor?.role === "owner" || actor?.role === "admin";
+}
+
+async function requireEnterprise(orgId: string): Promise<boolean> {
+  const [org] = await db
+    .select({ plan: organization.plan })
+    .from(organization)
+    .where(eq(organization.id, orgId))
+    .limit(1);
+  return org?.plan === "enterprise";
+}
+
+export async function GET(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const orgId = request.nextUrl.searchParams.get("organizationId");
+  if (!orgId) {
+    return NextResponse.json({ error: "organizationId required" }, { status: 400 });
+  }
+
+  if (!(await requireAdmin(orgId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const servers = await db
+    .select({
+      id: organizationMcpServer.id,
+      name: organizationMcpServer.name,
+      // url and bearerToken intentionally omitted from list response
+      assignedRoles: organizationMcpServer.assignedRoles,
+      enabled: organizationMcpServer.enabled,
+      createdAt: organizationMcpServer.createdAt,
+      updatedAt: organizationMcpServer.updatedAt,
+    })
+    .from(organizationMcpServer)
+    .where(eq(organizationMcpServer.organizationId, orgId));
+
+  return NextResponse.json({ servers });
+}
+
+export async function POST(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, name, url, bearerToken, assignedRoles } =
+    await request.json();
+
+  if (!organizationId || !name || !url) {
+    return NextResponse.json(
+      { error: "organizationId, name, and url are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!(await requireEnterprise(organizationId))) {
+    return NextResponse.json(
+      { error: "Custom MCP servers require Enterprise plan" },
+      { status: 403 }
+    );
+  }
+
+  const [row] = await db
+    .insert(organizationMcpServer)
+    .values({
+      organizationId,
+      name,
+      url,
+      bearerToken: bearerToken ?? null,
+      assignedRoles: assignedRoles ?? [],
+    })
+    .onConflictDoUpdate({
+      target: [organizationMcpServer.organizationId, organizationMcpServer.name],
+      set: {
+        url,
+        bearerToken: bearerToken ?? null,
+        assignedRoles: assignedRoles ?? [],
+        updatedAt: new Date(),
+      },
+    })
+    .returning({
+      id: organizationMcpServer.id,
+      name: organizationMcpServer.name,
+      assignedRoles: organizationMcpServer.assignedRoles,
+      enabled: organizationMcpServer.enabled,
+      createdAt: organizationMcpServer.createdAt,
+    });
+
+  return NextResponse.json({ server: row });
+}
+
+export async function PATCH(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, serverId, enabled } = await request.json();
+  if (!organizationId || !serverId || enabled === undefined) {
+    return NextResponse.json(
+      { error: "organizationId, serverId, and enabled are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const [row] = await db
+    .update(organizationMcpServer)
+    .set({ enabled, updatedAt: new Date() })
+    .where(
+      and(
+        eq(organizationMcpServer.id, serverId),
+        eq(organizationMcpServer.organizationId, organizationId),
+      )
+    )
+    .returning({
+      id: organizationMcpServer.id,
+      name: organizationMcpServer.name,
+      enabled: organizationMcpServer.enabled,
+    });
+
+  if (!row) {
+    return NextResponse.json({ error: "Server not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ server: row });
+}
+
+export async function DELETE(request: NextRequest) {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { organizationId, serverId } = await request.json();
+  if (!organizationId || !serverId) {
+    return NextResponse.json(
+      { error: "organizationId and serverId are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!(await requireAdmin(organizationId, session.user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  await db
+    .delete(organizationMcpServer)
+    .where(
+      and(
+        eq(organizationMcpServer.id, serverId),
+        eq(organizationMcpServer.organizationId, organizationId),
+      )
+    );
+
+  return NextResponse.json({ deleted: true });
+}

--- a/apps/chat/lib/arcan/client.ts
+++ b/apps/chat/lib/arcan/client.ts
@@ -219,6 +219,19 @@ export class ArcanClient {
     return res.body;
   }
 
+  // ─── Identity upgrade (BRO-227) ─────────────────────────────────────
+
+  async upgradeIdentity(
+    sessionId: string,
+    userId: string,
+    identityToken?: string
+  ): Promise<{ session_id: string; new_owner: string; tier: string; capabilities_count: number }> {
+    return this.fetch(`/sessions/${sessionId}/identity`, {
+      method: "PATCH",
+      body: JSON.stringify({ user_id: userId, identity_token: identityToken }),
+    });
+  }
+
   // ─── Approvals ──────────────────────────────────────────────────────
 
   async resolveApproval(

--- a/apps/chat/lib/arcan/client.ts
+++ b/apps/chat/lib/arcan/client.ts
@@ -10,6 +10,7 @@
 import "server-only";
 
 import { SignJWT } from "jose";
+import type { ArcanPolicySet } from "./execute";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -19,7 +20,7 @@ export interface ArcanSessionManifest {
   created_at: string;
   workspace_root: string;
   model_routing: Record<string, unknown>;
-  policy: Record<string, unknown>;
+  policy: ArcanPolicySet;
 }
 
 export interface ArcanRunResponse {
@@ -52,7 +53,7 @@ export interface BudgetState {
 export interface CreateSessionOptions {
   sessionId?: string;
   owner?: string;
-  policy?: Record<string, unknown>;
+  policy?: ArcanPolicySet;
   modelRouting?: Record<string, unknown>;
 }
 

--- a/apps/chat/lib/arcan/client.ts
+++ b/apps/chat/lib/arcan/client.ts
@@ -70,6 +70,10 @@ export interface StreamOptions {
   branch?: string;
   cursor?: number;
   replayLimit?: number;
+  /** Unique ID for this assistant message — used as `messageId` in the Vercel
+   *  AI SDK v6 `start` frame. Pass a fresh UUID per chat turn so React has a
+   *  unique key for each assistant message within the same session. */
+  messageId?: string;
 }
 
 // ─── Client ─────────────────────────────────────────────────────────────────
@@ -191,6 +195,7 @@ export class ArcanClient {
     if (opts.cursor != null) params.set("cursor", String(opts.cursor));
     if (opts.replayLimit != null)
       params.set("replay_limit", String(opts.replayLimit));
+    if (opts.messageId) params.set("message_id", opts.messageId);
 
     const url = `${this.baseUrl}/sessions/${sessionId}/events/stream?${params}`;
     const res = await fetch(url, {

--- a/apps/chat/lib/arcan/execute.ts
+++ b/apps/chat/lib/arcan/execute.ts
@@ -15,6 +15,7 @@ import "server-only";
 import { after } from "next/server";
 import { ArcanClient, ArcanError } from "./client";
 import { createModuleLogger } from "@/lib/logger";
+import { generateUUID } from "@/lib/utils";
 import type { ChatMessage } from "@/lib/ai/types";
 
 const log = createModuleLogger("arcan:execute");
@@ -95,15 +96,19 @@ export async function executeViaArcan(
       log.error({ error: e }, "Arcan run failed");
     });
 
-  // Start streaming events immediately
-  // The cursor picks up from where the client last saw events,
-  // or 0 for a fresh session
+  // Start streaming events immediately.
+  // A fresh UUID per turn ensures each assistant message gets a unique React
+  // key — avoids duplicate key warnings when the same session handles multiple
+  // turns (previously messageId was always the session_id).
+  const messageId = generateUUID();
+
   try {
     const sseStream = await client.streamEvents(
       chatId,
       {
         cursor: lastSequence ?? 0,
         replayLimit: 512,
+        messageId,
       },
       abortSignal
     );

--- a/apps/chat/lib/arcan/execute.ts
+++ b/apps/chat/lib/arcan/execute.ts
@@ -136,15 +136,60 @@ export async function executeViaArcan(
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 /**
- * Extract a plain-text objective from the ChatMessage structure.
- * Arcan expects a string objective, not the full message parts.
+ * Build the objective string sent to arcand's POST /sessions/{id}/runs.
+ *
+ * Arcand accepts only a single `objective: string` — no structured messages
+ * array. To preserve multi-turn context we encode conversation history into
+ * the objective string itself, prefixed before the current user message.
+ *
+ * Format (XML-tagged so arcand's LLM can cleanly distinguish speakers):
+ *
+ *   <conversation_history>
+ *   User: <text of turn N-k>
+ *   Assistant: <text of turn N-k+1>
+ *   ...
+ *   </conversation_history>
+ *
+ *   Current request:
+ *   <user_message>
+ *   <text of current user message>
+ *   </user_message>
+ *
+ * When there is no prior history the <conversation_history> block is omitted
+ * so single-turn requests stay compact.
  */
 function extractObjective(
   userMessage: ChatMessage,
   previousMessages: ChatMessage[]
 ): string {
-  // Extract text content from the user message parts
-  const textParts = userMessage.parts
+  const currentText = extractMessageText(userMessage);
+
+  // Cap at last 20 messages regardless of what the caller trimmed.
+  const history = previousMessages.slice(-20);
+
+  if (history.length === 0) {
+    return currentText;
+  }
+
+  const historyLines = history
+    .map((msg) => {
+      const speaker = msg.role === "assistant" ? "Assistant" : "User";
+      return `${speaker}: ${extractMessageText(msg)}`;
+    })
+    .join("\n");
+
+  return (
+    `<conversation_history>\n${historyLines}\n</conversation_history>\n\n` +
+    `Current request:\n<user_message>\n${currentText}\n</user_message>`
+  );
+}
+
+/**
+ * Extract plain text from a single ChatMessage.
+ * Handles UIMessage v6 parts[] and the legacy content string fallback.
+ */
+function extractMessageText(msg: ChatMessage): string {
+  const textParts = msg.parts
     ?.filter((p: { type: string }) => p.type === "text")
     .map((p: { type: string; text?: string }) => p.text ?? "")
     .filter(Boolean);
@@ -153,10 +198,10 @@ function extractObjective(
     return textParts.join("\n\n");
   }
 
-  // Fallback: check for content field (older message format)
-  if ("content" in userMessage && typeof userMessage.content === "string") {
-    return userMessage.content;
+  // Legacy fallback: pre-v6 messages stored in DB with a content string
+  if ("content" in msg && typeof (msg as { content?: unknown }).content === "string") {
+    return (msg as { content: string }).content;
   }
 
-  return "Continue the conversation.";
+  return "(empty)";
 }

--- a/apps/chat/lib/arcan/execute.ts
+++ b/apps/chat/lib/arcan/execute.ts
@@ -20,6 +20,18 @@ import type { ChatMessage } from "@/lib/ai/types";
 
 const log = createModuleLogger("arcan:execute");
 
+/** Mirrors aios-protocol's PolicySet — capability strings must use the aios-protocol format */
+export interface ArcanPolicySet {
+  /** Capabilities allowed without approval. Use aios-protocol format: "fs:read:**", "net:egress:*", "*" */
+  allow_capabilities?: string[];
+  /** Capabilities requiring human approval before execution */
+  gate_capabilities?: string[];
+  /** Max wall-clock seconds for a single tool invocation (default: 30) */
+  max_tool_runtime_secs?: number;
+  /** Max agent events per turn before the run is interrupted (default: 256) */
+  max_events_per_turn?: number;
+}
+
 export interface ArcanExecuteOptions {
   chatId: string;
   userMessage: ChatMessage;
@@ -30,6 +42,8 @@ export interface ArcanExecuteOptions {
   /** Last known event sequence for cursor-based replay */
   lastSequence?: number;
   abortSignal?: AbortSignal;
+  /** Tier-based capability policy for the arcand session */
+  policy?: ArcanPolicySet;
 }
 
 /**
@@ -49,6 +63,7 @@ export async function executeViaArcan(
     userEmail,
     lastSequence,
     abortSignal,
+    policy,
   } = opts;
 
   let client: ArcanClient;
@@ -76,6 +91,7 @@ export async function executeViaArcan(
       await client.createSession({
         sessionId: chatId,
         owner: userId,
+        policy,
       });
       log.info({ chatId }, "Created new Arcan session");
     }

--- a/apps/chat/lib/arcan/index.ts
+++ b/apps/chat/lib/arcan/index.ts
@@ -8,7 +8,7 @@ export type {
   RunOptions,
   StreamOptions,
 } from "./client";
-export { resolveArcanUrl } from "./resolve";
+export { resolveArcanUrl, resolveArcanEndpoints, markInstanceDegraded } from "./resolve";
 export type { ArcanEndpoints } from "./resolve";
 export { executeViaArcan } from "./execute";
 export type { ArcanExecuteOptions } from "./execute";

--- a/apps/chat/lib/arcan/resolve.ts
+++ b/apps/chat/lib/arcan/resolve.ts
@@ -1,10 +1,14 @@
 /**
- * Resolve the Arcan URL for a given user.
+ * Resolve the Arcan URL for a given user (BRO-225).
  *
  * Priority:
  * 1. User's organization has a running Life instance on Railway → use its arcanUrl
  * 2. ARCAN_URL env var (local dev / shared instance)
  * 3. null (no Arcan available — fall back to direct streamText)
+ *
+ * Two-tier resolution is exposed via `resolveArcanEndpoints` so callers can
+ * attempt the dedicated instance first, then fall back to the shared instance
+ * if the dedicated one is unhealthy.
  */
 
 import "server-only";
@@ -12,7 +16,6 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import { db as tierDb } from "@/lib/db/client";
 import {
-  organization,
   organizationMember,
   organizationLifeInstance,
 } from "@/lib/db/schema";
@@ -20,19 +23,32 @@ import {
 export interface ArcanEndpoints {
   arcanUrl: string;
   lagoUrl: string | null;
+  /** True when this URL points to a dedicated Railway org instance. */
+  isDedicated: boolean;
+  /** Organization ID that owns the dedicated instance, or null for the shared instance. */
+  orgId: string | null;
 }
 
 /**
- * Look up the Arcan URL for an authenticated user.
- * Returns null if no Arcan instance is available.
+ * Resolve both the dedicated and shared Arcan endpoints for a user.
+ *
+ * - `dedicated` is the org's Railway Life instance URL (if running or degraded).
+ * - `shared` is the env-var fallback (ARCAN_URL), or null if not configured.
+ *
+ * Callers should try `dedicated` first. If unreachable, fall back to `shared`
+ * and call `markInstanceDegraded(orgId)` to record the health event.
  */
-export async function resolveArcanUrl(
-  userId: string
-): Promise<ArcanEndpoints | null> {
-  // 1. Check org Life instance (Railway deployment)
+export async function resolveArcanEndpoints(userId: string): Promise<{
+  dedicated: ArcanEndpoints | null;
+  shared: ArcanEndpoints | null;
+}> {
+  let dedicated: ArcanEndpoints | null = null;
+
   try {
     const rows = await tierDb
       .select({
+        id: organizationLifeInstance.id,
+        orgId: organizationLifeInstance.organizationId,
         arcanUrl: organizationLifeInstance.arcanUrl,
         lagoUrl: organizationLifeInstance.lagoUrl,
         status: organizationLifeInstance.status,
@@ -53,24 +69,58 @@ export async function resolveArcanUrl(
       instance?.arcanUrl &&
       (instance.status === "running" || instance.status === "degraded")
     ) {
-      return {
+      dedicated = {
         arcanUrl: instance.arcanUrl,
         lagoUrl: instance.lagoUrl ?? null,
+        isDedicated: true,
+        orgId: instance.orgId,
       };
     }
   } catch {
-    // DB query failed — fall through to env
+    // DB query failed — fall through to shared instance
   }
 
-  // 2. Env-based fallback (local dev or shared instance)
   const envUrl = process.env.ARCAN_URL;
-  if (envUrl) {
-    return {
-      arcanUrl: envUrl,
-      lagoUrl: process.env.LAGO_URL ?? null,
-    };
-  }
+  const shared: ArcanEndpoints | null = envUrl
+    ? {
+        arcanUrl: envUrl,
+        lagoUrl: process.env.LAGO_URL ?? null,
+        isDedicated: false,
+        orgId: null,
+      }
+    : null;
 
-  // 3. No Arcan available
-  return null;
+  return { dedicated, shared };
+}
+
+/**
+ * Mark a Life instance as degraded when its arcand fails a health check.
+ *
+ * The degraded state is visible in the admin dashboard and triggers a
+ * notification to the tenant admin (BRO-225 acceptance criterion).
+ */
+export async function markInstanceDegraded(orgId: string): Promise<void> {
+  try {
+    await tierDb
+      .update(organizationLifeInstance)
+      .set({ status: "degraded", lastHealthCheck: new Date() })
+      .where(eq(organizationLifeInstance.organizationId, orgId));
+  } catch {
+    // Non-fatal — degradation marking is best-effort
+  }
+}
+
+/**
+ * Look up the Arcan URL for an authenticated user.
+ *
+ * @deprecated Prefer `resolveArcanEndpoints` for two-tier fallback support.
+ * This wrapper exists for call sites that only need a single resolved URL.
+ */
+export async function resolveArcanUrl(
+  userId: string
+): Promise<{ arcanUrl: string; lagoUrl: string | null } | null> {
+  const { dedicated, shared } = await resolveArcanEndpoints(userId);
+  const endpoint = dedicated ?? shared;
+  if (!endpoint) return null;
+  return { arcanUrl: endpoint.arcanUrl, lagoUrl: endpoint.lagoUrl };
 }

--- a/apps/chat/lib/db/migrations/0053_add_tenant_arcan_admin_tables.sql
+++ b/apps/chat/lib/db/migrations/0053_add_tenant_arcan_admin_tables.sql
@@ -1,0 +1,46 @@
+-- BRO-228: Tenant admin portal tables
+-- OrganizationArcanRole: per-org Arcan capability overrides per role
+-- OrganizationCustomSkill: custom SKILL.md manifests uploaded by org admins
+-- OrganizationMcpServer: private MCP servers registered by enterprise org admins
+
+CREATE TABLE IF NOT EXISTS "OrganizationArcanRole" (
+  "id" uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "organizationId" uuid NOT NULL REFERENCES "Organization"("id") ON DELETE CASCADE,
+  "roleName" varchar(128) NOT NULL,
+  "allowCapabilities" json NOT NULL DEFAULT '[]'::json,
+  "maxEventsPerTurn" integer NOT NULL DEFAULT 20,
+  "createdAt" timestamp NOT NULL DEFAULT now(),
+  "updatedAt" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "OrgArcanRole_org_idx" ON "OrganizationArcanRole"("organizationId");
+CREATE UNIQUE INDEX IF NOT EXISTS "OrgArcanRole_org_role_unique" ON "OrganizationArcanRole"("organizationId", "roleName");
+
+CREATE TABLE IF NOT EXISTS "OrganizationCustomSkill" (
+  "id" uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "organizationId" uuid NOT NULL REFERENCES "Organization"("id") ON DELETE CASCADE,
+  "name" varchar(256) NOT NULL,
+  "manifestToml" text NOT NULL,
+  "assignedRoles" json NOT NULL DEFAULT '[]'::json,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "createdAt" timestamp NOT NULL DEFAULT now(),
+  "updatedAt" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "OrgCustomSkill_org_idx" ON "OrganizationCustomSkill"("organizationId");
+CREATE UNIQUE INDEX IF NOT EXISTS "OrgCustomSkill_org_name_unique" ON "OrganizationCustomSkill"("organizationId", "name");
+
+CREATE TABLE IF NOT EXISTS "OrganizationMcpServer" (
+  "id" uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "organizationId" uuid NOT NULL REFERENCES "Organization"("id") ON DELETE CASCADE,
+  "name" varchar(256) NOT NULL,
+  "url" text NOT NULL,
+  "bearerToken" text,
+  "assignedRoles" json NOT NULL DEFAULT '[]'::json,
+  "enabled" boolean NOT NULL DEFAULT true,
+  "createdAt" timestamp NOT NULL DEFAULT now(),
+  "updatedAt" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "OrgMcpServer_org_idx" ON "OrganizationMcpServer"("organizationId");
+CREATE UNIQUE INDEX IF NOT EXISTS "OrgMcpServer_org_name_unique" ON "OrganizationMcpServer"("organizationId", "name");

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -1120,4 +1120,135 @@ export type MarketplaceTransaction = InferSelectModel<
   typeof marketplaceTransaction
 >;
 
+// ─── BRO-228: Tenant Admin Portal tables ──────────────────────────────────────
+
+/**
+ * Per-org RBAC capability overrides for Arcan (BRO-228 — Capability Policy).
+ *
+ * Enterprise admins can configure which Arcan capability strings are
+ * allow-listed for each named role. When present, these override arcand's
+ * built-in tier defaults for sessions belonging to that org.
+ */
+export const organizationArcanRole = pgTable(
+  "OrganizationArcanRole",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    organizationId: uuid("organizationId")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** Role name matching the Better Auth / tenant role (e.g. "admin", "member"). */
+    roleName: varchar("roleName", { length: 128 }).notNull(),
+    /** JSON array of Arcan capability strings, e.g. ["*"] or ["exec:cmd:ls"]. */
+    allowCapabilities: json("allowCapabilities")
+      .notNull()
+      .$type<string[]>()
+      .default([]),
+    /** Max events allowed per agent turn for this role. */
+    maxEventsPerTurn: integer("maxEventsPerTurn").notNull().default(20),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    OrgArcanRole_org_idx: index("OrgArcanRole_org_idx").on(t.organizationId),
+    OrgArcanRole_org_role_unique: uniqueIndex("OrgArcanRole_org_role_unique").on(
+      t.organizationId,
+      t.roleName,
+    ),
+  }),
+);
+
+export type OrganizationArcanRole = InferSelectModel<
+  typeof organizationArcanRole
+>;
+
+/**
+ * Custom SKILL.md manifests uploaded by enterprise org admins (BRO-228).
+ *
+ * Manifests are stored as raw TOML text, validated server-side before saving.
+ * Skills are assigned to specific roles within the org.
+ */
+export const organizationCustomSkill = pgTable(
+  "OrganizationCustomSkill",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    organizationId: uuid("organizationId")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** Unique skill name within the org (from TOML `[skill] name`). */
+    name: varchar("name", { length: 256 }).notNull(),
+    /** Raw TOML content of the SKILL.md manifest. */
+    manifestToml: text("manifestToml").notNull(),
+    /** Role names allowed to use this skill. Empty = all roles. */
+    assignedRoles: json("assignedRoles")
+      .notNull()
+      .$type<string[]>()
+      .default([]),
+    /** Whether the skill is active (false = staged/draft). */
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    OrgCustomSkill_org_idx: index("OrgCustomSkill_org_idx").on(t.organizationId),
+    OrgCustomSkill_org_name_unique: uniqueIndex(
+      "OrgCustomSkill_org_name_unique",
+    ).on(t.organizationId, t.name),
+  }),
+);
+
+export type OrganizationCustomSkill = InferSelectModel<
+  typeof organizationCustomSkill
+>;
+
+/**
+ * Private MCP servers registered by enterprise org admins (BRO-226 / BRO-228).
+ *
+ * URL and bearer token are encrypted at rest. The server is injected into
+ * Arcan sessions for org members whose role is in `assignedRoles`.
+ */
+export const organizationMcpServer = pgTable(
+  "OrganizationMcpServer",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    organizationId: uuid("organizationId")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    /** Logical server name (matches SKILL.md `mcp_servers[].name`). */
+    name: varchar("name", { length: 256 }).notNull(),
+    /** MCP server URL — encrypted at rest. */
+    url: encryptedText("url").notNull(),
+    /** Auth bearer token or API key — encrypted at rest. Null for public servers. */
+    bearerToken: encryptedText("bearerToken"),
+    /** Role names allowed to use this server. Empty = all org roles. */
+    assignedRoles: json("assignedRoles")
+      .notNull()
+      .$type<string[]>()
+      .default([]),
+    /** Whether the server is active. */
+    enabled: boolean("enabled").notNull().default(true),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    OrgMcpServer_org_idx: index("OrgMcpServer_org_idx").on(t.organizationId),
+    OrgMcpServer_org_name_unique: uniqueIndex("OrgMcpServer_org_name_unique").on(
+      t.organizationId,
+      t.name,
+    ),
+  }),
+);
+
+export type OrganizationMcpServer = InferSelectModel<
+  typeof organizationMcpServer
+>;
+
 export const schema = { user, session, account, verification };


### PR DESCRIPTION
## Summary

Implements the full Arcan Runtime Capability & Permission System (18 tickets) on the broomva.tech web layer.

- **BRO-212** — Wire tier-aware `PolicySet` into `executeViaArcan()` — resolves user tier (anon/free/pro/enterprise) and passes it to arcand on every run
- **BRO-220** — Enterprise Railway provisioning — auto-provision/deprovision dedicated Life instances on Stripe plan transitions via `after()` background tasks
- **BRO-225** — Multi-tenant runtime routing — `resolveArcanUrl()` queries `organizationLifeInstance.arcanUrl` for enterprise sessions; falls back to shared instance
- **BRO-227** — Anonymous identity upgrade — `PATCH /api/auth/migrate-anonymous` saves chat history to DB and upgrades arcand session identity in-place
- **BRO-228** — Tenant admin portal — 4-tab `/console/arcan-admin` page (Capability Policy, Custom Skills, MCP Servers, Usage & Audit) + 3 API routes + DB schema/migration

## Arcan Rust changes (already merged to arcan/main)

- BRO-211–BRO-219, BRO-221–BRO-224, BRO-226–BRO-227 — all merged via PR #16 and direct commits to arcan submodule

## Test plan

- [ ] Anonymous user can chat without auth — session gets anon PolicySet
- [ ] Authenticated free/pro user — correct tier policy enforced
- [ ] Enterprise org with dedicated Life instance — routes to tenant `arcan_url`
- [ ] Stripe enterprise checkout → Railway Life stack auto-provisioned
- [ ] POST `/api/auth/migrate-anonymous` saves messages, clears anon cookie
- [ ] `/console/arcan-admin` accessible to org owner/admin only
- [ ] MCP server registration blocked for non-enterprise orgs
- [ ] DB migration 0053 applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Arcan Admin console for managing per-role capabilities, custom skills, MCP servers (enterprise-only), and organization usage metrics
  * Added session migration enabling anonymous users to upgrade to authenticated accounts with conversation history preserved
  * Enhanced endpoint routing with dedicated org-level instances, automatic fallback handling, and instance health monitoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->