### PR TITLE
feat(flags): PostHog runtime feature flags — BRO-207

### DIFF
--- a/apps/chat/hooks/use-feature-flag.ts
+++ b/apps/chat/hooks/use-feature-flag.ts
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * useFeatureFlag — BRO-207
+ *
+ * Client-side feature flag hook backed by PostHog with fallback to
+ * the static config values from chat.config.ts.
+ */
+
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import type { FeatureFlag } from "@/lib/feature-flags";
+import { getStaticFeatureFlag } from "@/lib/feature-flags";
+
+/**
+ * Returns true if the feature flag is enabled for the current user.
+ * Falls back to the static config value while PostHog is loading or
+ * when PostHog is not configured.
+ *
+ * @example
+ * const hasMarketplace = useFeatureFlag("marketplace_enabled");
+ */
+export function useFeatureFlag(flag: FeatureFlag): boolean {
+  // posthog-js returns undefined while bootstrapping, then true/false/null
+  const phValue = useFeatureFlagEnabled(flag);
+
+  if (phValue === undefined || phValue === null) {
+    return getStaticFeatureFlag(flag);
+  }
+
+  return phValue;
+}

--- a/apps/chat/lib/feature-flags.ts
+++ b/apps/chat/lib/feature-flags.ts
@@ -1,0 +1,106 @@
+/**
+ * Feature flags — BRO-207
+ *
+ * Runtime feature flags backed by PostHog with fallback to chat.config.ts.
+ * PostHog flag names map 1:1 to the keys below.
+ * Plan-tier targeting is configured in the PostHog dashboard using the
+ * 'organization' group property 'plan'.
+ */
+
+import { PostHog } from "posthog-node";
+import { config } from "@/lib/config";
+
+// ── Flag name union ───────────────────────────────────────────────────────────
+
+/** All feature flags. Names match PostHog flag keys. */
+export type FeatureFlag =
+  // Existing features (mirrors chat.config.ts features.*)
+  | "sandbox"
+  | "web_search"
+  | "url_retrieval"
+  | "deep_research"
+  | "mcp"
+  | "image_generation"
+  | "attachments"
+  | "followup_suggestions"
+  | "knowledge_graph"
+  | "memory_vault"
+  | "agent_auth"
+  // New plan-gated flags
+  | "marketplace_enabled"
+  | "trust_api_enabled"
+  | "managed_deployments";
+
+// ── Static fallback map ───────────────────────────────────────────────────────
+
+/**
+ * Fallback values from chat.config.ts for when PostHog is unavailable.
+ * New flags default to false until explicitly enabled in PostHog.
+ */
+const STATIC_FALLBACKS: Record<FeatureFlag, boolean> = {
+  sandbox: config.features.sandbox,
+  web_search: config.features.webSearch,
+  url_retrieval: config.features.urlRetrieval,
+  deep_research: config.features.deepResearch,
+  mcp: config.features.mcp,
+  image_generation: config.features.imageGeneration,
+  attachments: config.features.attachments,
+  followup_suggestions: config.features.followupSuggestions,
+  knowledge_graph: config.features.knowledgeGraph,
+  memory_vault: config.features.memoryVault,
+  agent_auth: config.features.agentAuth,
+  marketplace_enabled: false,
+  trust_api_enabled: false,
+  managed_deployments: false,
+};
+
+// ── Server-side client ────────────────────────────────────────────────────────
+
+let _ph: PostHog | null = null;
+
+function getServerPostHog(): PostHog | null {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) return null;
+  if (!_ph) {
+    _ph = new PostHog(key, {
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+  }
+  return _ph;
+}
+
+// ── Server helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate a feature flag server-side for a given user.
+ * Falls back to the static config value if PostHog is unavailable or errors.
+ *
+ * @param flag  - Feature flag key
+ * @param userId - PostHog distinct ID (user.id or anonymous ID)
+ * @param groups - Optional group memberships, e.g. { organization: orgId }
+ */
+export async function getServerFeatureFlag(
+  flag: FeatureFlag,
+  userId: string,
+  groups?: Record<string, string>,
+): Promise<boolean> {
+  const ph = getServerPostHog();
+  if (!ph) return STATIC_FALLBACKS[flag];
+
+  try {
+    const enabled = await ph.isFeatureEnabled(flag, userId, { groups });
+    return enabled ?? STATIC_FALLBACKS[flag];
+  } catch {
+    return STATIC_FALLBACKS[flag];
+  }
+}
+
+/**
+ * Get the static fallback for a flag without making a network request.
+ * Use this in non-async contexts or as a synchronous default.
+ */
+export function getStaticFeatureFlag(flag: FeatureFlag): boolean {
+  return STATIC_FALLBACKS[flag];
+}


### PR DESCRIPTION
## Summary
- `lib/feature-flags.ts` — typed `FeatureFlag` union, `getServerFeatureFlag(flag, userId, groups?)` (PostHog decide + static fallback), `getStaticFeatureFlag(flag)` for sync access
- `hooks/use-feature-flag.ts` — `useFeatureFlag(flag)` client hook wrapping `useFeatureFlagEnabled` with static fallback during bootstrap
- 3 new plan-gated flags: `marketplace_enabled`, `trust_api_enabled`, `managed_deployments` (default false)
- 11 existing flags mapped from `chat.config.ts` with static fallbacks

## How plan-tier targeting works
Configure in PostHog dashboard: create flags with rollout targeting `organization.plan = "pro"` (group property set during onboarding via BRO-204 `captureServerEvent`).

## Test plan
- [ ] `useFeatureFlag("sandbox")` returns `true` (matches static config) before PostHog loads
- [ ] `useFeatureFlag("marketplace_enabled")` returns `false` (new flag, default off)
- [ ] Enable `marketplace_enabled` for a user in PostHog → hook returns `true`
- [ ] `getServerFeatureFlag("deep_research", userId)` returns correct value server-side
- [ ] Works gracefully when `NEXT_PUBLIC_POSTHOG_KEY` is absent

## Closes
BRO-207

🤖 Generated with [Claude Code](https://claude.com/claude-code)