### PR TITLE
fix(analytics): PostHog managed proxy via t.broomva.tech

### DIFF
--- a/apps/chat/content/writing/bitnet-1bit-llms-agentic-edge.mdx
+++ b/apps/chat/content/writing/bitnet-1bit-llms-agentic-edge.mdx
@@ -3,6 +3,7 @@ title: "BitNet: 1-Bit LLMs for Agentic Edge Inference"
 summary: "Microsoft's BitNet proves that ternary-weight models can match full-precision performance while running on any CPU. A hands-on tutorial with benchmarks, scaling projections, and implications for building agents that run anywhere."
 date: 2026-03-26
 published: true
+audio: /audio/writing/bitnet-1bit-llms-agentic-edge.mp3
 tags:
   - AI
   - LLMs

--- a/apps/chat/lib/analytics/posthog.ts
+++ b/apps/chat/lib/analytics/posthog.ts
@@ -15,7 +15,7 @@ export function getPostHogClient(): PostHog | null {
 
   if (!_client) {
     _client = new PostHog(key, {
-      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
       flushAt: 20,
       flushInterval: 5000,
     });

--- a/apps/chat/lib/feature-flags.ts
+++ b/apps/chat/lib/feature-flags.ts
@@ -63,7 +63,7 @@ function getServerPostHog(): PostHog | null {
   if (!key) return null;
   if (!_ph) {
     _ph = new PostHog(key, {
-      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com",
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
       flushAt: 1,
       flushInterval: 0,
     });

--- a/apps/chat/next.config.ts
+++ b/apps/chat/next.config.ts
@@ -17,15 +17,6 @@ const nextConfig: NextConfig = {
     return [
       { source: "/llms.txt", destination: "/api/llms" },
       { source: "/llms-full.txt", destination: "/api/llms-full" },
-      // Reverse-proxy PostHog to bypass ad blockers
-      {
-        source: "/ingest/static/:path*",
-        destination: "https://us-assets.i.posthog.com/static/:path*",
-      },
-      {
-        source: "/ingest/:path*",
-        destination: "https://us.i.posthog.com/:path*",
-      },
     ];
   },
 

--- a/apps/chat/providers/posthog-provider.tsx
+++ b/apps/chat/providers/posthog-provider.tsx
@@ -7,7 +7,7 @@ import { Suspense, useEffect, useRef } from "react";
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST =
-  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "/ingest";
+  process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://t.broomva.tech";
 
 if (typeof window !== "undefined" && POSTHOG_KEY) {
   posthog.init(POSTHOG_KEY, {
@@ -27,7 +27,9 @@ function PostHogPageView() {
   useEffect(() => {
     if (!pathname || pathname === lastPathname.current) return;
     lastPathname.current = pathname;
-    posthog.capture("$pageview", { $current_url: pathname });
+    posthog.capture("$pageview", {
+      $current_url: typeof window !== "undefined" ? window.location.href : pathname,
+    });
   }, [pathname]);
 
   return null;
@@ -69,9 +71,7 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <PHProvider client={posthog}>
-      <Suspense fallback={null}>
-        <PostHogPageView />
-      </Suspense>
+      <PostHogPageView />
       <Suspense fallback={null}>
         <UTMTracker />
       </Suspense>

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,11 +18,12 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/mdx": "^2.0.13",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.9.3",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "typescript": "^5.9.3"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -188,6 +188,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.0.0",
+        "@types/mdx": "^2.0.13",
         "@types/node": "^22.0.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary

- **Switch to managed proxy**: Replace Next.js `/ingest` rewrites with PostHog's managed reverse proxy at `t.broomva.tech` (first-party domain, stronger ad-blocker bypass)
- **Fix EU/US region mismatch**: Server-side clients (`lib/analytics/posthog.ts`, `lib/feature-flags.ts`) were falling back to `eu.i.posthog.com` but the project is on US Cloud — server events and flag evaluations were hitting the wrong region
- **Harden fallback**: Code fallback now points to `https://t.broomva.tech` directly (not `/ingest` which no longer exists as a rewrite)
- **Fix `$current_url`**: Pageview events now send `window.location.href` (full URL) instead of pathname-only — required for proper funnels and session replay
- **Cleanup**: Remove unnecessary `<Suspense>` around `PostHogPageView` (`usePathname` doesn't need it)

## Env vars updated

`NEXT_PUBLIC_POSTHOG_HOST=https://t.broomva.tech` added to Production, Preview, and Development via Vercel CLI + REST API.

## Test plan

- [ ] Verify PostHog events appear in US cloud dashboard after deploy
- [ ] Verify feature flags evaluate correctly server-side
- [ ] Verify pageview `$current_url` includes full URL in PostHog event stream
- [ ] Confirm `t.broomva.tech` proxy is routing correctly (PostHog settings page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics infrastructure configuration and endpoints
  * Improved URL tracking accuracy for analytics data collection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->