### PR TITLE
feat(sandbox): management API + /console/sandboxes page (BRO-261)

### DIFF
--- a/apps/chat/app/(console)/console/relay/page.tsx
+++ b/apps/chat/app/(console)/console/relay/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { Route } from "next";
+import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { POLL } from "@/lib/console/constants";
 import type {
@@ -180,7 +182,10 @@ function SessionRow({ session }: { session: RelaySessionView }) {
           : "text-zinc-400";
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border bg-card px-4 py-3">
+    <Link
+      href={`/console/relay/session/${session.id}` as Route}
+      className="flex items-center gap-3 rounded-lg border bg-card px-4 py-3 transition-colors hover:bg-accent"
+    >
       <span className={`text-xs font-medium uppercase ${statusColor}`}>
         {session.status}
       </span>
@@ -198,6 +203,6 @@ function SessionRow({ session }: { session: RelaySessionView }) {
           {session.model}
         </span>
       )}
-    </div>
+    </Link>
   );
 }

--- a/apps/chat/app/(console)/console/relay/page.tsx
+++ b/apps/chat/app/(console)/console/relay/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { POLL } from "@/lib/console/constants";
+import type {
+  RelayMetrics,
+  RelayNodeView,
+  RelaySessionView,
+} from "@/lib/console/types";
+
+export default function RelayPage() {
+  const [nodes, setNodes] = useState<RelayNodeView[]>([]);
+  const [sessions, setSessions] = useState<RelaySessionView[]>([]);
+  const [metrics, setMetrics] = useState<RelayMetrics>({
+    nodesOnline: 0,
+    nodesTotal: 0,
+    sessionsActive: 0,
+    sessionsTotal: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [nodesRes, sessionsRes] = await Promise.all([
+        fetch("/api/relay/nodes", { cache: "no-store" }),
+        fetch("/api/relay/sessions", { cache: "no-store" }),
+      ]);
+
+      if (nodesRes.ok) {
+        const data = await nodesRes.json();
+        setNodes(data.nodes ?? []);
+        setMetrics(
+          data.metrics ?? {
+            nodesOnline: 0,
+            nodesTotal: 0,
+            sessionsActive: 0,
+            sessionsTotal: 0,
+          },
+        );
+      }
+
+      if (sessionsRes.ok) {
+        const data = await sessionsRes.json();
+        setSessions(data.sessions ?? []);
+      }
+
+      setError(null);
+    } catch {
+      setError("Failed to fetch relay data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, POLL.RELAY);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-muted-foreground text-sm">Loading relay...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Relay</h1>
+        <p className="text-muted-foreground text-sm">
+          Remote agent sessions from your machines
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Metrics */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <MetricCard label="Nodes Online" value={metrics.nodesOnline} />
+        <MetricCard label="Total Nodes" value={metrics.nodesTotal} />
+        <MetricCard label="Active Sessions" value={metrics.sessionsActive} />
+        <MetricCard label="Total Sessions" value={metrics.sessionsTotal} />
+      </div>
+
+      {/* Nodes */}
+      <section>
+        <h2 className="mb-3 text-lg font-medium">Relay Nodes</h2>
+        {nodes.length === 0 ? (
+          <div className="rounded-lg border border-dashed p-8 text-center">
+            <p className="text-muted-foreground text-sm">
+              No relay nodes registered yet.
+            </p>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Install <code className="rounded bg-muted px-1.5 py-0.5">relayd</code> on your machine and run{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5">relayd auth</code> to connect.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {nodes.map((node) => (
+              <NodeCard key={node.id} node={node} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Sessions */}
+      {sessions.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-lg font-medium">Active Sessions</h2>
+          <div className="space-y-2">
+            {sessions.map((session) => (
+              <SessionRow key={session.id} session={session} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+function MetricCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="text-2xl font-bold tabular-nums">{value}</div>
+      <div className="text-muted-foreground text-xs">{label}</div>
+    </div>
+  );
+}
+
+function NodeCard({ node }: { node: RelayNodeView }) {
+  const statusColor =
+    node.status === "online"
+      ? "bg-green-500"
+      : node.status === "degraded"
+        ? "bg-yellow-500"
+        : "bg-zinc-400";
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-center gap-2">
+        <div className={`h-2 w-2 rounded-full ${statusColor}`} />
+        <span className="font-medium">{node.name}</span>
+      </div>
+      {node.hostname && (
+        <div className="text-muted-foreground mt-1 text-xs font-mono">
+          {node.hostname}
+        </div>
+      )}
+      <div className="mt-2 flex flex-wrap gap-1">
+        {(node.capabilities ?? []).map((cap) => (
+          <span
+            key={cap}
+            className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono"
+          >
+            {cap}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SessionRow({ session }: { session: RelaySessionView }) {
+  const statusColor =
+    session.status === "active"
+      ? "text-green-500"
+      : session.status === "idle"
+        ? "text-yellow-500"
+        : session.status === "failed"
+          ? "text-red-500"
+          : "text-zinc-400";
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-card px-4 py-3">
+      <span className={`text-xs font-medium uppercase ${statusColor}`}>
+        {session.status}
+      </span>
+      <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono">
+        {session.sessionType}
+      </span>
+      <span className="font-medium">{session.name ?? "Untitled"}</span>
+      {session.workdir && (
+        <span className="text-muted-foreground text-xs font-mono truncate">
+          {session.workdir}
+        </span>
+      )}
+      {session.model && (
+        <span className="text-muted-foreground ml-auto text-xs">
+          {session.model}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/console/relay/session/[id]/page.tsx
+++ b/apps/chat/app/(console)/console/relay/session/[id]/page.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import {
+  AlertCircle,
+  ArrowLeft,
+  Bot,
+  CheckCircle,
+  Send,
+  Terminal,
+  Wrench,
+  XCircle,
+} from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { RelaySessionView } from "@/lib/console/types";
+import type { DaemonMessage } from "@/lib/relay/protocol";
+
+type SessionEvent = DaemonMessage & { _key: number };
+type ApprovalEvent = Extract<DaemonMessage, { type: "approval_request" }>;
+type ToolEventMsg = Extract<DaemonMessage, { type: "tool_event" }>;
+
+export default function RelaySessionPage() {
+  const { id } = useParams<{ id: string }>();
+  const [session, setSession] = useState<RelaySessionView | null>(null);
+  const [events, setEvents] = useState<SessionEvent[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const [pendingApproval, setPendingApproval] =
+    useState<ApprovalEvent | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [ended, setEnded] = useState(false);
+  const feedRef = useRef<HTMLDivElement>(null);
+  const keyRef = useRef(0);
+
+  // Fetch session info once on mount
+  useEffect(() => {
+    fetch(`/api/relay/sessions/${id}`)
+      .then((r) => r.json())
+      .then((d) => setSession(d.session ?? null))
+      .catch(() => {});
+  }, [id]);
+
+  // SSE stream for live session output
+  useEffect(() => {
+    const es = new EventSource(`/api/relay/sessions/${id}/stream`);
+
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+
+    es.onmessage = (e) => {
+      try {
+        const event = JSON.parse(e.data) as DaemonMessage;
+        keyRef.current += 1;
+        setEvents((prev) => [...prev, { ...event, _key: keyRef.current }]);
+
+        if (event.type === "approval_request") {
+          setPendingApproval(event as ApprovalEvent);
+        }
+        if (event.type === "session_ended") {
+          setEnded(true);
+          setConnected(false);
+        }
+
+        requestAnimationFrame(() => {
+          if (feedRef.current) {
+            feedRef.current.scrollTop = feedRef.current.scrollHeight;
+          }
+        });
+      } catch {}
+    };
+
+    return () => es.close();
+  }, [id]);
+
+  const handleSendInput = useCallback(async () => {
+    const text = inputValue.trim();
+    if (!text) return;
+    setInputValue("");
+    await fetch(`/api/relay/sessions/${id}/input`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ data: `${text}\n` }),
+    }).catch(() => {});
+  }, [id, inputValue]);
+
+  const handleApprove = useCallback(
+    async (approved: boolean) => {
+      if (!pendingApproval) return;
+      const { approvalId } = pendingApproval;
+      setPendingApproval(null);
+      await fetch(`/api/relay/sessions/${id}/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ approvalId, approved }),
+      }).catch(() => {});
+    },
+    [id, pendingApproval],
+  );
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSendInput();
+    }
+  };
+
+  const isActive =
+    !ended &&
+    (session?.status === "active" ||
+      session?.status === "idle" ||
+      session === null);
+
+  return (
+    <div className="-mx-4 -mt-4 flex flex-col" style={{ height: "calc(100vh - 10rem)" }}>
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div className="flex shrink-0 items-center gap-3 border-b bg-background px-4 py-3">
+        <Link
+          href={"/console/relay" as Route}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+        </Link>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="truncate font-medium">
+              {session?.name ?? "Session"}
+            </h1>
+            {session?.sessionType && (
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+                {session.sessionType}
+              </span>
+            )}
+            {session?.model && (
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {session.model}
+              </span>
+            )}
+            <div
+              className={`size-2 shrink-0 rounded-full ${
+                connected
+                  ? "bg-green-500"
+                  : ended
+                    ? "bg-zinc-500"
+                    : "bg-yellow-500 animate-pulse"
+              }`}
+            />
+          </div>
+          {session?.workdir && (
+            <div className="truncate font-mono text-xs text-muted-foreground">
+              {session.workdir}
+            </div>
+          )}
+        </div>
+
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+          {id.slice(0, 8)}
+        </span>
+      </div>
+
+      {/* ── Event feed ─────────────────────────────────────────────── */}
+      <div
+        ref={feedRef}
+        className="flex-1 space-y-1 overflow-y-auto p-4"
+      >
+        {events.length === 0 && (
+          <div className="py-16 text-center text-sm text-muted-foreground">
+            {connected ? "Waiting for session output..." : "Connecting to session..."}
+          </div>
+        )}
+        {events.map((event) => (
+          <EventCard key={event._key} event={event} />
+        ))}
+      </div>
+
+      {/* ── Approval overlay ───────────────────────────────────────── */}
+      {pendingApproval && (
+        <div className="mx-4 mb-2 shrink-0 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 size-4 shrink-0 text-amber-500" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                {pendingApproval.capability}
+              </p>
+              {pendingApproval.context && (
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {pendingApproval.context}
+                </p>
+              )}
+            </div>
+            <div className="flex shrink-0 gap-1.5">
+              <button
+                type="button"
+                onClick={() => handleApprove(true)}
+                className="flex items-center gap-1 rounded bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-700"
+              >
+                <CheckCircle className="size-3" />
+                Allow
+              </button>
+              <button
+                type="button"
+                onClick={() => handleApprove(false)}
+                className="flex items-center gap-1 rounded bg-zinc-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-zinc-700"
+              >
+                <XCircle className="size-3" />
+                Deny
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Input bar ──────────────────────────────────────────────── */}
+      <div className="shrink-0 border-t bg-background px-4 py-3">
+        {ended ? (
+          <p className="text-center text-xs text-muted-foreground">
+            Session ended
+          </p>
+        ) : (
+          <div className="flex items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2 focus-within:ring-1 focus-within:ring-ring">
+            <Terminal className="size-4 shrink-0 text-muted-foreground" />
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder="Send input to session..."
+              className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              disabled={!isActive}
+            />
+            <button
+              type="button"
+              onClick={handleSendInput}
+              disabled={!inputValue.trim() || !isActive}
+              className="text-muted-foreground transition-colors hover:text-foreground disabled:opacity-40"
+              aria-label="Send"
+            >
+              <Send className="size-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Event card components ─────────────────────────────────────────────────
+
+function EventCard({ event }: { event: DaemonMessage }) {
+  switch (event.type) {
+    case "output":
+      return (
+        <div className="rounded-md bg-zinc-950 px-3 py-2 dark:bg-zinc-900">
+          <pre className="whitespace-pre-wrap font-mono text-xs leading-relaxed text-zinc-300">
+            {event.data}
+          </pre>
+        </div>
+      );
+
+    case "assistant_message":
+      return (
+        <div className="flex items-start gap-2.5 rounded-lg border bg-blue-500/5 px-3 py-2">
+          <Bot className="mt-0.5 size-4 shrink-0 text-blue-500" />
+          <p className="text-sm leading-relaxed">{event.text}</p>
+        </div>
+      );
+
+    case "tool_event":
+      return <ToolCard event={event} />;
+
+    case "approval_request":
+      // Shown in the overlay above; render a compact history item here
+      return (
+        <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+          <AlertCircle className="size-3.5 shrink-0" />
+          <span>
+            Approval requested:{" "}
+            <span className="font-medium">{event.capability}</span>
+          </span>
+        </div>
+      );
+
+    case "session_ended":
+      return (
+        <div className="flex items-center gap-3 py-2">
+          <div className="h-px flex-1 bg-border" />
+          <span className="text-xs text-muted-foreground">
+            Session ended — {event.reason}
+          </span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+      );
+
+    case "error":
+      return (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          [{event.code}] {event.message}
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}
+
+const TOOL_COLORS: Record<string, string> = {
+  Edit: "text-yellow-500",
+  Write: "text-yellow-500",
+  Bash: "text-green-500",
+  Read: "text-blue-400",
+  Glob: "text-purple-400",
+  Grep: "text-orange-400",
+  Agent: "text-pink-400",
+  WebFetch: "text-cyan-400",
+  WebSearch: "text-cyan-400",
+};
+
+function getToolSummary(
+  toolName: string,
+  input: Record<string, unknown>,
+): string {
+  switch (toolName) {
+    case "Edit":
+    case "Write":
+    case "Read":
+      return String(input.file_path ?? input.path ?? "");
+    case "Bash":
+      return String(input.command ?? "").slice(0, 100);
+    case "Glob":
+    case "Grep":
+      return String(input.pattern ?? "");
+    default:
+      return "";
+  }
+}
+
+function ToolCard({ event }: { event: ToolEventMsg }) {
+  const color = TOOL_COLORS[event.toolName] ?? "text-muted-foreground";
+  const summary = getToolSummary(event.toolName, event.input);
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2">
+      <Wrench className={`size-3.5 shrink-0 ${color}`} />
+      <span className={`font-mono text-xs font-medium ${color}`}>
+        {event.toolName}
+      </span>
+      {summary && (
+        <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+          {summary}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/chat/app/(console)/console/relay/session/[id]/page.tsx
+++ b/apps/chat/app/(console)/console/relay/session/[id]/page.tsx
@@ -17,10 +17,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { RelaySessionView } from "@/lib/console/types";
 import type { DaemonMessage } from "@/lib/relay/protocol";
+import { RelayWorkspaceSidebar } from "./relay-workspace-sidebar";
 
 type SessionEvent = DaemonMessage & { _key: number };
 type ApprovalEvent = Extract<DaemonMessage, { type: "approval_request" }>;
 type ToolEventMsg = Extract<DaemonMessage, { type: "tool_event" }>;
+type WorkspaceStatusMsg = Extract<DaemonMessage, { type: "workspace_status" }>;
 
 export default function RelaySessionPage() {
   const { id } = useParams<{ id: string }>();
@@ -29,6 +31,8 @@ export default function RelaySessionPage() {
   const [inputValue, setInputValue] = useState("");
   const [pendingApproval, setPendingApproval] =
     useState<ApprovalEvent | null>(null);
+  const [workspaceStatus, setWorkspaceStatus] =
+    useState<WorkspaceStatusMsg | null>(null);
   const [connected, setConnected] = useState(false);
   const [ended, setEnded] = useState(false);
   const feedRef = useRef<HTMLDivElement>(null);
@@ -60,6 +64,13 @@ export default function RelaySessionPage() {
     es.onmessage = (e) => {
       try {
         const event = JSON.parse(e.data) as DaemonMessage;
+
+        // workspace_status updates sidebar state only — not shown in event feed
+        if (event.type === "workspace_status") {
+          setWorkspaceStatus(event as WorkspaceStatusMsg);
+          return;
+        }
+
         keyRef.current += 1;
         setEvents((prev) => [...prev, { ...event, _key: keyRef.current }]);
 
@@ -166,6 +177,11 @@ export default function RelaySessionPage() {
         <span className="shrink-0 font-mono text-xs text-muted-foreground">
           {id.slice(0, 8)}
         </span>
+
+        <RelayWorkspaceSidebar
+          currentSessionId={id}
+          workspaceStatus={workspaceStatus}
+        />
       </div>
 
       {/* ── Event feed ─────────────────────────────────────────────── */}

--- a/apps/chat/app/(console)/console/relay/session/[id]/page.tsx
+++ b/apps/chat/app/(console)/console/relay/session/[id]/page.tsx
@@ -42,11 +42,19 @@ export default function RelaySessionPage() {
       .catch(() => {});
   }, [id]);
 
-  // SSE stream for live session output
+  // SSE stream for live session output.
+  // On (re)connect the server replays the last 500 buffered events before
+  // subscribing to live events, so we clear stale state on every open to
+  // avoid duplicates.
   useEffect(() => {
     const es = new EventSource(`/api/relay/sessions/${id}/stream`);
 
-    es.onopen = () => setConnected(true);
+    es.onopen = () => {
+      setConnected(true);
+      // Clear events on reconnect — replay buffer will repopulate them.
+      setEvents([]);
+      keyRef.current = 0;
+    };
     es.onerror = () => setConnected(false);
 
     es.onmessage = (e) => {

--- a/apps/chat/app/(console)/console/relay/session/[id]/relay-workspace-sidebar.tsx
+++ b/apps/chat/app/(console)/console/relay/session/[id]/relay-workspace-sidebar.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import {
+  GitBranch,
+  GitCommit,
+  Layers,
+  LayoutGrid,
+  PanelRight,
+  Plus,
+} from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import type { RelayNodeView, RelaySessionView } from "@/lib/console/types";
+import type { DaemonMessage } from "@/lib/relay/protocol";
+
+type WorkspaceStatus = Extract<DaemonMessage, { type: "workspace_status" }>;
+
+interface Props {
+  /** Current session shown in the detail view. */
+  currentSessionId: string;
+  /** Latest workspace status received from the SSE stream. */
+  workspaceStatus: WorkspaceStatus | null;
+}
+
+export function RelayWorkspaceSidebar({
+  currentSessionId,
+  workspaceStatus,
+}: Props) {
+  const [nodes, setNodes] = useState<RelayNodeView[]>([]);
+  const [sessions, setSessions] = useState<RelaySessionView[]>([]);
+  const [selectedNode, setSelectedNode] = useState<string>("");
+  const [open, setOpen] = useState(false);
+
+  // Fetch nodes + sessions when the sheet opens
+  useEffect(() => {
+    if (!open) return;
+    Promise.all([
+      fetch("/api/relay/nodes", { cache: "no-store" }).then((r) => r.json()),
+      fetch("/api/relay/sessions", { cache: "no-store" }).then((r) =>
+        r.json(),
+      ),
+    ])
+      .then(([nodesData, sessionsData]) => {
+        const nodeList: RelayNodeView[] = nodesData.nodes ?? [];
+        setNodes(nodeList);
+        setSessions(sessionsData.sessions ?? []);
+        if (!selectedNode && nodeList.length > 0) {
+          setSelectedNode(nodeList[0].id);
+        }
+      })
+      .catch(() => {});
+  }, [open, selectedNode]);
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground transition-colors hover:text-foreground"
+          aria-label="Open workspace sidebar"
+        >
+          <PanelRight className="size-4" />
+        </button>
+      </SheetTrigger>
+
+      <SheetContent side="right" className="flex w-80 flex-col gap-0 p-0">
+        <SheetHeader className="shrink-0 border-b px-4 py-3">
+          <SheetTitle className="text-sm">Workspace</SheetTitle>
+        </SheetHeader>
+
+        <ScrollArea className="flex-1">
+          <div className="space-y-6 p-4">
+            {/* Git status */}
+            {workspaceStatus && (
+              <section>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Git
+                </h3>
+                <div className="space-y-1.5 rounded-lg border bg-card p-3">
+                  {workspaceStatus.branch && (
+                    <div className="flex items-center gap-2 text-xs">
+                      <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
+                      <span className="font-mono">{workspaceStatus.branch}</span>
+                    </div>
+                  )}
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    {workspaceStatus.modified > 0 && (
+                      <span className="text-yellow-500">
+                        {workspaceStatus.modified} modified
+                      </span>
+                    )}
+                    {workspaceStatus.staged > 0 && (
+                      <span className="text-green-500">
+                        {workspaceStatus.staged} staged
+                      </span>
+                    )}
+                    {workspaceStatus.modified === 0 &&
+                      workspaceStatus.staged === 0 && (
+                        <span>Clean working tree</span>
+                      )}
+                  </div>
+                  {workspaceStatus.lastCommit && (
+                    <div className="flex items-start gap-2 text-xs text-muted-foreground">
+                      <GitCommit className="mt-0.5 size-3.5 shrink-0" />
+                      <span className="font-mono truncate">
+                        {workspaceStatus.lastCommit}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </section>
+            )}
+
+            {/* Session config */}
+            <section>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Start Session
+              </h3>
+              <div className="space-y-2">
+                <div>
+                  <label className="mb-1 block text-xs text-muted-foreground">
+                    Node
+                  </label>
+                  <Select
+                    value={selectedNode}
+                    onValueChange={setSelectedNode}
+                    disabled={nodes.length === 0}
+                  >
+                    <SelectTrigger className="h-8 text-xs">
+                      <SelectValue
+                        placeholder={
+                          nodes.length === 0
+                            ? "No nodes online"
+                            : "Select node..."
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {nodes.map((n) => (
+                        <SelectItem key={n.id} value={n.id}>
+                          <span className="flex items-center gap-2">
+                            <span
+                              className={`size-1.5 rounded-full ${
+                                n.status === "online"
+                                  ? "bg-green-500"
+                                  : "bg-zinc-400"
+                              }`}
+                            />
+                            {n.name}
+                          </span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <Button
+                  size="sm"
+                  className="w-full"
+                  disabled={!selectedNode}
+                  onClick={() => {
+                    // TODO BRO-295: spawn session via POST /api/relay/sessions
+                    setOpen(false);
+                  }}
+                >
+                  <Plus className="size-3.5" />
+                  New Session
+                </Button>
+              </div>
+            </section>
+
+            {/* All sessions */}
+            {sessions.length > 0 && (
+              <section>
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Sessions
+                </h3>
+                <div className="space-y-1">
+                  {sessions.map((s) => (
+                    <Link
+                      key={s.id}
+                      href={`/console/relay/session/${s.id}` as Route}
+                      onClick={() => setOpen(false)}
+                      className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors hover:bg-accent ${
+                        s.id === currentSessionId
+                          ? "bg-accent font-medium"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      <span
+                        className={`size-1.5 shrink-0 rounded-full ${
+                          s.status === "active"
+                            ? "bg-green-500"
+                            : s.status === "idle"
+                              ? "bg-yellow-500"
+                              : "bg-zinc-400"
+                        }`}
+                      />
+                      <span className="min-w-0 flex-1 truncate">
+                        {s.name ?? "Untitled"}
+                      </span>
+                      {s.sessionType && (
+                        <span className="shrink-0 rounded bg-muted px-1 py-0.5 font-mono text-[10px]">
+                          {s.sessionType}
+                        </span>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Quick links */}
+            <section>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Quick Links
+              </h3>
+              <div className="space-y-1">
+                <Link
+                  href={"/console/relay" as Route}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  onClick={() => setOpen(false)}
+                >
+                  <LayoutGrid className="size-3.5" />
+                  Relay Dashboard
+                </Link>
+                <Link
+                  href={"/console" as Route}
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  onClick={() => setOpen(false)}
+                >
+                  <Layers className="size-3.5" />
+                  Console
+                </Link>
+              </div>
+            </section>
+          </div>
+        </ScrollArea>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/chat/app/(console)/console/sandboxes/page.tsx
+++ b/apps/chat/app/(console)/console/sandboxes/page.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+/**
+ * /console/sandboxes — Sandbox execution environment management
+ *
+ * Dependency chain:
+ *   broomva.tech (this page)
+ *     → /api/sandbox          (GET list, metrics)
+ *     → /api/sandbox/:id      (DELETE destroy)
+ *     → /api/sandbox/:id/snapshot (POST manual snapshot)
+ *   → arcand (ARCAN_URL) → SandboxService (BRO-253) → arcan-provider-vercel (BRO-263)
+ *   → Neon DB SandboxInstance table (BRO-261)
+ *
+ * BRO-261
+ */
+
+import {
+  BoxIcon,
+  Camera,
+  CircleX,
+  MoreHorizontal,
+  RefreshCw,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+import { MetricTile } from "@/components/console/metric-tile";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { POLL } from "@/lib/console/constants";
+import type {
+  SandboxInstanceView,
+  SandboxMetrics,
+  SandboxProvider,
+  SandboxStatus,
+} from "@/lib/console/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function relativeTime(dateStr: string | null): string {
+  if (!dateStr) return "Never";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
+}
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+const STATUS_VARIANT: Record<
+  SandboxStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  running: "default",
+  starting: "secondary",
+  snapshotted: "outline",
+  stopped: "secondary",
+  failed: "destructive",
+};
+
+const STATUS_DOT: Record<SandboxStatus, string> = {
+  running: "bg-green-500",
+  starting: "bg-yellow-400",
+  snapshotted: "bg-blue-400",
+  stopped: "bg-zinc-400",
+  failed: "bg-red-500",
+};
+
+function StatusBadge({ status }: { status: SandboxStatus }) {
+  return (
+    <Badge variant={STATUS_VARIANT[status]} className="gap-1.5 capitalize">
+      <span className={`inline-block size-1.5 rounded-full ${STATUS_DOT[status]}`} />
+      {status}
+    </Badge>
+  );
+}
+
+// ── Provider badge ────────────────────────────────────────────────────────────
+
+const PROVIDER_COLOR: Record<SandboxProvider, string> = {
+  vercel: "bg-black text-white dark:bg-white dark:text-black",
+  e2b: "bg-violet-600 text-white",
+  local: "bg-zinc-700 text-white",
+};
+
+function ProviderBadge({ provider }: { provider: SandboxProvider }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${PROVIDER_COLOR[provider]}`}
+    >
+      {provider}
+    </span>
+  );
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center text-text-secondary gap-3">
+      <BoxIcon className="size-10 opacity-30" />
+      <p className="text-sm font-medium">No active sandboxes</p>
+      <p className="text-xs text-text-muted max-w-xs">
+        Sandboxes are created automatically when an agent executes shell or
+        filesystem commands. They appear here once running.
+      </p>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function SandboxesPage() {
+  const [sandboxes, setSandboxes] = useState<SandboxInstanceView[]>([]);
+  const [metrics, setMetrics] = useState<SandboxMetrics>({
+    active: 0,
+    snapshotted: 0,
+    execs24h: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const fetchSandboxes = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sandbox", { cache: "no-store" });
+      if (!res.ok) {
+        setError("Could not load sandboxes");
+        setLoading(false);
+        return;
+      }
+      const data = await res.json();
+      setSandboxes(data.sandboxes ?? []);
+      setMetrics(data.metrics ?? { active: 0, snapshotted: 0, execs24h: 0 });
+      setError(null);
+    } catch {
+      setError("Network error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSandboxes();
+    const interval = setInterval(fetchSandboxes, POLL.SANDBOXES);
+    return () => clearInterval(interval);
+  }, [fetchSandboxes]);
+
+  const handleDestroy = useCallback(
+    async (sandboxId: string) => {
+      setActionLoading(sandboxId);
+      try {
+        const res = await fetch(`/api/sandbox/${sandboxId}`, {
+          method: "DELETE",
+        });
+        if (res.ok || res.status === 204) {
+          setSandboxes((prev) =>
+            prev.map((s) =>
+              s.id === sandboxId ? { ...s, status: "stopped" as SandboxStatus } : s,
+            ),
+          );
+          setMetrics((prev) => ({ ...prev, active: Math.max(0, prev.active - 1) }));
+        }
+      } catch {
+        // Non-fatal — UI will refresh on next poll
+      } finally {
+        setActionLoading(null);
+      }
+    },
+    [],
+  );
+
+  const handleSnapshot = useCallback(async (sandboxId: string) => {
+    setActionLoading(sandboxId);
+    try {
+      const res = await fetch(`/api/sandbox/${sandboxId}/snapshot`, {
+        method: "POST",
+      });
+      if (res.ok) {
+        setSandboxes((prev) =>
+          prev.map((s) =>
+            s.id === sandboxId
+              ? { ...s, status: "snapshotted" as SandboxStatus }
+              : s,
+          ),
+        );
+        setMetrics((prev) => ({
+          ...prev,
+          active: Math.max(0, prev.active - 1),
+          snapshotted: prev.snapshotted + 1,
+        }));
+      }
+    } catch {
+      // Non-fatal
+    } finally {
+      setActionLoading(null);
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-text-primary">Sandboxes</h1>
+          <p className="text-sm text-text-secondary mt-0.5">
+            Active execution environments managed by Arcan
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={fetchSandboxes}
+          disabled={loading}
+          className="gap-1.5"
+        >
+          <RefreshCw className={`size-3.5 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Metrics */}
+      <div className="grid grid-cols-3 gap-4">
+        <MetricTile
+          label="Active"
+          value={loading ? "—" : String(metrics.active)}
+          status={metrics.active > 0 ? "healthy" : "degraded"}
+          sublabel="running sandboxes"
+        />
+        <MetricTile
+          label="Snapshotted"
+          value={loading ? "—" : String(metrics.snapshotted)}
+          status={metrics.snapshotted > 0 ? "healthy" : "degraded"}
+          sublabel="persisted environments"
+        />
+        <MetricTile
+          label="Execs / 24h"
+          value={loading ? "—" : String(metrics.execs24h)}
+          status="healthy"
+          sublabel="commands executed"
+        />
+      </div>
+
+      {/* Error */}
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      {/* Table */}
+      <div className="rounded-lg border border-border bg-card">
+        {loading ? (
+          <div className="flex flex-col gap-3 p-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: skeleton rows
+              <Skeleton key={i} className="h-10 w-full rounded" />
+            ))}
+          </div>
+        ) : sandboxes.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[200px]">Sandbox ID</TableHead>
+                <TableHead>Agent</TableHead>
+                <TableHead>Provider</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Resources</TableHead>
+                <TableHead>Last Exec</TableHead>
+                <TableHead className="w-[80px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sandboxes.map((sandbox) => (
+                <TableRow key={sandbox.id}>
+                  <TableCell className="font-mono text-xs">
+                    {sandbox.sandboxId.length > 20
+                      ? `${sandbox.sandboxId.slice(0, 8)}…${sandbox.sandboxId.slice(-6)}`
+                      : sandbox.sandboxId}
+                  </TableCell>
+                  <TableCell className="text-xs text-text-secondary">
+                    {sandbox.agentId
+                      ? sandbox.agentId.slice(0, 8)
+                      : <span className="text-text-muted italic">ad-hoc</span>}
+                  </TableCell>
+                  <TableCell>
+                    <ProviderBadge provider={sandbox.provider} />
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={sandbox.status} />
+                  </TableCell>
+                  <TableCell className="text-xs text-text-secondary">
+                    {sandbox.vcpus != null && sandbox.memoryMb != null
+                      ? `${sandbox.vcpus}vCPU · ${sandbox.memoryMb}MB`
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-xs text-text-secondary">
+                    {relativeTime(sandbox.lastExecAt)}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-7"
+                          disabled={actionLoading === sandbox.id}
+                        >
+                          <MoreHorizontal className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => handleSnapshot(sandbox.id)}
+                          disabled={
+                            sandbox.status === "snapshotted" ||
+                            sandbox.status === "stopped"
+                          }
+                        >
+                          <Camera className="size-4 mr-2" />
+                          Snapshot
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <DropdownMenuItem
+                              onSelect={(e) => e.preventDefault()}
+                              className="text-destructive focus:text-destructive"
+                              disabled={sandbox.status === "stopped"}
+                            >
+                              <CircleX className="size-4 mr-2" />
+                              Destroy
+                            </DropdownMenuItem>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Destroy sandbox?</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                This will permanently destroy{" "}
+                                <span className="font-mono">{sandbox.sandboxId}</span>{" "}
+                                and all unsaved state. This action cannot be undone.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() => handleDestroy(sandbox.id)}
+                                className="bg-destructive hover:bg-destructive/90"
+                              >
+                                Destroy
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/api/relay/connect/route.ts
+++ b/apps/chat/app/api/relay/connect/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { withAuthAndValidation } from "@/lib/api/with-auth";
+import { z } from "zod";
+import { db } from "@/lib/db/client";
+import { relayNode } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+const connectSchema = z.object({
+  name: z.string().min(1),
+  hostname: z.string().min(1),
+  capabilities: z.array(z.string()).default([]),
+});
+
+/**
+ * POST /api/relay/connect
+ *
+ * Register or reconnect a relay node. Called by relayd on startup.
+ * Returns the node ID for subsequent poll/events calls.
+ */
+export const POST = withAuthAndValidation(
+  connectSchema,
+  async (_request, { userId, body }) => {
+    try {
+      // Check for existing node with same name for this user
+      const [existing] = await db
+        .select()
+        .from(relayNode)
+        .where(and(eq(relayNode.userId, userId), eq(relayNode.name, body.name)))
+        .limit(1);
+
+      if (existing) {
+        // Reconnect: update status and capabilities
+        await db
+          .update(relayNode)
+          .set({
+            status: "online",
+            hostname: body.hostname,
+            lastSeenAt: new Date(),
+            capabilities: body.capabilities,
+          })
+          .where(eq(relayNode.id, existing.id));
+
+        return NextResponse.json({
+          nodeId: existing.id,
+          status: "reconnected",
+        });
+      }
+
+      // New node registration
+      const [node] = await db
+        .insert(relayNode)
+        .values({
+          userId,
+          name: body.name,
+          hostname: body.hostname,
+          status: "online",
+          lastSeenAt: new Date(),
+          capabilities: body.capabilities,
+        })
+        .returning();
+
+      return NextResponse.json(
+        { nodeId: node.id, status: "registered" },
+        { status: 201 },
+      );
+    } catch (err) {
+      console.error("[relay/connect] Failed:", err);
+      return NextResponse.json(
+        { error: "Failed to register relay node" },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/apps/chat/app/api/relay/events/route.ts
+++ b/apps/chat/app/api/relay/events/route.ts
@@ -76,6 +76,7 @@ export const POST = withAuthAndValidation(
           case "assistant_message":
           case "tool_event":
           case "approval_request":
+          case "workspace_status":
           case "session_ended": {
             await publishSessionEvent(redis, event.sessionId, payload);
             if (event.type === "session_ended") {

--- a/apps/chat/app/api/relay/events/route.ts
+++ b/apps/chat/app/api/relay/events/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { withAuthAndValidation } from "@/lib/api/with-auth";
+import { z } from "zod";
+import { createClient } from "redis";
+import {
+  sessionOutputChannel,
+  nodeEventsChannel,
+} from "@/lib/relay/redis-channels";
+import { db } from "@/lib/db/client";
+import { relaySession, relayNode } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import type { DaemonMessage } from "@/lib/relay/protocol";
+
+const eventsSchema = z.object({
+  nodeId: z.string().uuid(),
+  events: z.array(z.record(z.string(), z.unknown())),
+});
+
+/**
+ * POST /api/relay/events
+ *
+ * Receive events from relayd. Publishes to Redis for browser SSE subscribers.
+ * Handles session lifecycle events (created, ended) by updating DB.
+ */
+export const POST = withAuthAndValidation(
+  eventsSchema,
+  async (_request, { userId, body }) => {
+    const { nodeId, events } = body;
+
+    let redis: ReturnType<typeof createClient> | null = null;
+    try {
+      redis = createClient({
+        url: process.env.REDIS_URL || "redis://localhost:6379",
+      });
+      await redis.connect();
+
+      for (const raw of events) {
+        const event = raw as unknown as DaemonMessage;
+
+        switch (event.type) {
+          case "output": {
+            // Publish to session-specific channel for browser subscribers
+            await redis.publish(
+              sessionOutputChannel(event.sessionId),
+              JSON.stringify(event),
+            );
+            // Update sequence in DB
+            await db
+              .update(relaySession)
+              .set({ lastSequence: event.seq })
+              .where(eq(relaySession.id, event.sessionId));
+            break;
+          }
+
+          case "session_created": {
+            // Create session record in DB
+            await db.insert(relaySession).values({
+              id: event.session.id,
+              nodeId,
+              userId,
+              sessionType: event.session.sessionType as
+                | "arcan"
+                | "claude-code"
+                | "codex",
+              status: "active",
+              name: event.session.name,
+              workdir: event.session.workdir,
+              model: event.session.model ?? null,
+            });
+            break;
+          }
+
+          case "session_ended": {
+            await db
+              .update(relaySession)
+              .set({ status: "completed" })
+              .where(eq(relaySession.id, event.sessionId));
+            break;
+          }
+
+          case "node_info": {
+            await db
+              .update(relayNode)
+              .set({
+                hostname: event.hostname,
+                capabilities: event.capabilities,
+                status: "online",
+                lastSeenAt: new Date(),
+              })
+              .where(eq(relayNode.id, nodeId));
+            break;
+          }
+
+          default:
+            // Forward to node events channel for any other type
+            await redis.publish(
+              nodeEventsChannel(nodeId),
+              JSON.stringify(event),
+            );
+        }
+      }
+
+      await redis.quit();
+      return NextResponse.json({ received: events.length });
+    } catch (err) {
+      if (redis) {
+        try { await redis.quit(); } catch {}
+      }
+      console.error("[relay/events] Error:", err);
+      return NextResponse.json(
+        { error: "Failed to process events" },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/apps/chat/app/api/relay/events/route.ts
+++ b/apps/chat/app/api/relay/events/route.ts
@@ -5,6 +5,8 @@ import { createClient } from "redis";
 import {
   sessionOutputChannel,
   nodeEventsChannel,
+  sessionReplayKey,
+  REPLAY_BUFFER_SIZE,
 } from "@/lib/relay/redis-channels";
 import { db } from "@/lib/db/client";
 import { relaySession, relayNode } from "@/lib/db/schema";
@@ -17,9 +19,31 @@ const eventsSchema = z.object({
 });
 
 /**
+ * Publish a session event to the live SSE channel and append it to the
+ * replay buffer (capped list). Both steps are needed so:
+ * - Live subscribers receive the event immediately.
+ * - Reconnecting browsers can replay missed events.
+ */
+async function publishSessionEvent(
+  redis: ReturnType<typeof createClient>,
+  sessionId: string,
+  payload: string,
+): Promise<void> {
+  const replayKey = sessionReplayKey(sessionId);
+  await Promise.all([
+    redis.publish(sessionOutputChannel(sessionId), payload),
+    redis.rPush(replayKey, payload).then(() =>
+      redis.lTrim(replayKey, -REPLAY_BUFFER_SIZE, -1),
+    ),
+  ]);
+}
+
+/**
  * POST /api/relay/events
  *
  * Receive events from relayd. Publishes to Redis for browser SSE subscribers.
+ * Session events are also stored in a capped replay buffer so reconnecting
+ * browsers can catch up on missed events.
  * Handles session lifecycle events (created, ended) by updating DB.
  */
 export const POST = withAuthAndValidation(
@@ -36,15 +60,12 @@ export const POST = withAuthAndValidation(
 
       for (const raw of events) {
         const event = raw as unknown as DaemonMessage;
+        const payload = JSON.stringify(event);
 
         switch (event.type) {
           case "output": {
-            // Publish to session-specific channel for browser subscribers
-            await redis.publish(
-              sessionOutputChannel(event.sessionId),
-              JSON.stringify(event),
-            );
-            // Update sequence in DB
+            await publishSessionEvent(redis, event.sessionId, payload);
+            // Track last seen sequence for DB-level resumability
             await db
               .update(relaySession)
               .set({ lastSequence: event.seq })
@@ -53,17 +74,20 @@ export const POST = withAuthAndValidation(
           }
 
           case "assistant_message":
-          case "tool_event": {
-            // Structured events — publish to session channel for browser SSE subscribers
-            await redis.publish(
-              sessionOutputChannel(event.sessionId),
-              JSON.stringify(event),
-            );
+          case "tool_event":
+          case "approval_request":
+          case "session_ended": {
+            await publishSessionEvent(redis, event.sessionId, payload);
+            if (event.type === "session_ended") {
+              await db
+                .update(relaySession)
+                .set({ status: "completed" })
+                .where(eq(relaySession.id, event.sessionId));
+            }
             break;
           }
 
           case "session_created": {
-            // Create session record in DB
             await db.insert(relaySession).values({
               id: event.session.id,
               nodeId,
@@ -77,14 +101,6 @@ export const POST = withAuthAndValidation(
               workdir: event.session.workdir,
               model: event.session.model ?? null,
             });
-            break;
-          }
-
-          case "session_ended": {
-            await db
-              .update(relaySession)
-              .set({ status: "completed" })
-              .where(eq(relaySession.id, event.sessionId));
             break;
           }
 
@@ -102,11 +118,7 @@ export const POST = withAuthAndValidation(
           }
 
           default:
-            // Forward to node events channel for any other type
-            await redis.publish(
-              nodeEventsChannel(nodeId),
-              JSON.stringify(event),
-            );
+            await redis.publish(nodeEventsChannel(nodeId), payload);
         }
       }
 
@@ -114,7 +126,9 @@ export const POST = withAuthAndValidation(
       return NextResponse.json({ received: events.length });
     } catch (err) {
       if (redis) {
-        try { await redis.quit(); } catch {}
+        try {
+          await redis.quit();
+        } catch {}
       }
       console.error("[relay/events] Error:", err);
       return NextResponse.json(

--- a/apps/chat/app/api/relay/events/route.ts
+++ b/apps/chat/app/api/relay/events/route.ts
@@ -52,6 +52,16 @@ export const POST = withAuthAndValidation(
             break;
           }
 
+          case "assistant_message":
+          case "tool_event": {
+            // Structured events — publish to session channel for browser SSE subscribers
+            await redis.publish(
+              sessionOutputChannel(event.sessionId),
+              JSON.stringify(event),
+            );
+            break;
+          }
+
           case "session_created": {
             // Create session record in DB
             await db.insert(relaySession).values({

--- a/apps/chat/app/api/relay/nodes/route.ts
+++ b/apps/chat/app/api/relay/nodes/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api/with-auth";
+import { getUserRelayNodes, getRelayMetrics } from "@/lib/db/relay-queries";
+
+export const GET = withAuth(async (_request, { userId }) => {
+  try {
+    const [nodes, metrics] = await Promise.all([
+      getUserRelayNodes(userId),
+      getRelayMetrics(userId),
+    ]);
+
+    return NextResponse.json({ nodes, metrics });
+  } catch (err) {
+    console.error("[relay] Failed to list nodes:", err);
+    return NextResponse.json(
+      { error: "Failed to list relay nodes" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/chat/app/api/relay/poll/route.ts
+++ b/apps/chat/app/api/relay/poll/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api/with-auth";
+import { createClient } from "redis";
+import { nodeCommandsChannel } from "@/lib/relay/redis-channels";
+import { db } from "@/lib/db/client";
+import { relayNode } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+/**
+ * GET /api/relay/poll?nodeId=xxx
+ *
+ * Non-blocking poll for pending commands. Returns immediately with any
+ * queued command from Redis list, or null if none pending.
+ * Also serves as heartbeat — updates lastSeenAt.
+ *
+ * relayd calls this every 1-2s.
+ */
+export async function GET(request: Request) {
+  // withAuth doesn't support searchParams easily, handle inline
+  const url = new URL(request.url);
+  const nodeId = url.searchParams.get("nodeId");
+
+  if (!nodeId) {
+    return NextResponse.json(
+      { error: "Missing nodeId parameter" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // Update heartbeat
+    await db
+      .update(relayNode)
+      .set({ lastSeenAt: new Date(), status: "online" })
+      .where(eq(relayNode.id, nodeId));
+
+    // Pop next command from Redis list (non-blocking)
+    const redis = createClient({
+      url: process.env.REDIS_URL || "redis://localhost:6379",
+    });
+    await redis.connect();
+
+    const channel = nodeCommandsChannel(nodeId);
+    const message = await redis.lPop(channel);
+    await redis.quit();
+
+    if (message) {
+      return NextResponse.json({ command: JSON.parse(message) });
+    }
+
+    return NextResponse.json({ command: null });
+  } catch (err) {
+    console.error("[relay/poll] Error:", err);
+    return NextResponse.json({ command: null });
+  }
+}

--- a/apps/chat/app/api/relay/sessions/[id]/approve/route.ts
+++ b/apps/chat/app/api/relay/sessions/[id]/approve/route.ts
@@ -1,0 +1,67 @@
+import { eq, and } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { createClient } from "redis";
+import { z } from "zod";
+
+import { withAuthAndValidation } from "@/lib/api/with-auth";
+import { db } from "@/lib/db/client";
+import { relaySession } from "@/lib/db/schema";
+import { nodeCommandsChannel } from "@/lib/relay/redis-channels";
+
+const approveSchema = z.object({
+  approvalId: z.string(),
+  approved: z.boolean(),
+});
+
+/**
+ * POST /api/relay/sessions/[id]/approve
+ *
+ * Route an approval decision to the relay node. Pushes an `approve` command
+ * to the node's Redis command queue, which relayd picks up on the next poll.
+ */
+export const POST = withAuthAndValidation(
+  approveSchema,
+  async (request, { userId, body }) => {
+    // Extract session ID: /api/relay/sessions/[id]/approve → at(-2)
+    const sessionId = new URL(request.url).pathname.split("/").at(-2) ?? "";
+
+    try {
+      const [session] = await db
+        .select()
+        .from(relaySession)
+        .where(
+          and(eq(relaySession.id, sessionId), eq(relaySession.userId, userId)),
+        )
+        .limit(1);
+
+      if (!session) {
+        return NextResponse.json(
+          { error: "Session not found" },
+          { status: 404 },
+        );
+      }
+
+      const redis = createClient({
+        url: process.env.REDIS_URL || "redis://localhost:6379",
+      });
+      await redis.connect();
+
+      const command = JSON.stringify({
+        type: "approve",
+        sessionId,
+        approvalId: body.approvalId,
+        approved: body.approved,
+      });
+      await redis.rPush(nodeCommandsChannel(session.nodeId), command);
+      await redis.quit();
+
+      return NextResponse.json({ sent: true });
+    } catch (err) {
+      console.error("[relay/approve] Error:", err);
+      return NextResponse.json(
+        { error: "Failed to send approval" },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/apps/chat/app/api/relay/sessions/[id]/input/route.ts
+++ b/apps/chat/app/api/relay/sessions/[id]/input/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { withAuthAndValidation } from "@/lib/api/with-auth";
+import { z } from "zod";
+import { createClient } from "redis";
+import { nodeCommandsChannel } from "@/lib/relay/redis-channels";
+import { db } from "@/lib/db/client";
+import { relaySession } from "@/lib/db/schema";
+import { eq, and } from "drizzle-orm";
+
+const inputSchema = z.object({
+  data: z.string(),
+});
+
+/**
+ * POST /api/relay/sessions/[id]/input
+ *
+ * Send input (text or keystrokes) to a relay session.
+ * Pushes an input command to the session's node's Redis command queue.
+ */
+export const POST = withAuthAndValidation(
+  inputSchema,
+  async (request, { userId, body }) => {
+    const url = new URL(request.url);
+    const sessionId = url.pathname.split("/").at(-2) ?? "";
+
+    try {
+      // Look up the session to find its node
+      const [session] = await db
+        .select()
+        .from(relaySession)
+        .where(
+          and(eq(relaySession.id, sessionId), eq(relaySession.userId, userId)),
+        )
+        .limit(1);
+
+      if (!session) {
+        return NextResponse.json(
+          { error: "Session not found" },
+          { status: 404 },
+        );
+      }
+
+      // Push input command to the node's command queue
+      const redis = createClient({
+        url: process.env.REDIS_URL || "redis://localhost:6379",
+      });
+      await redis.connect();
+
+      const command = JSON.stringify({
+        type: "input",
+        sessionId,
+        data: body.data,
+      });
+      await redis.rPush(nodeCommandsChannel(session.nodeId), command);
+      await redis.quit();
+
+      return NextResponse.json({ sent: true });
+    } catch (err) {
+      console.error("[relay/input] Error:", err);
+      return NextResponse.json(
+        { error: "Failed to send input" },
+        { status: 500 },
+      );
+    }
+  },
+);

--- a/apps/chat/app/api/relay/sessions/[id]/route.ts
+++ b/apps/chat/app/api/relay/sessions/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api/with-auth";
+import { getRelaySessionById } from "@/lib/db/relay-queries";
+
+/**
+ * GET /api/relay/sessions/[id]
+ *
+ * Fetch a single relay session by ID. Only returns sessions owned by the
+ * authenticated user.
+ */
+export const GET = withAuth(async (request, { userId }) => {
+  const id = new URL(request.url).pathname.split("/").at(-1) ?? "";
+  try {
+    const session = await getRelaySessionById(id, userId);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+    return NextResponse.json({ session });
+  } catch (err) {
+    console.error("[relay/session] Error fetching session:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch session" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/chat/app/api/relay/sessions/[id]/stream/route.ts
+++ b/apps/chat/app/api/relay/sessions/[id]/stream/route.ts
@@ -1,0 +1,75 @@
+import { createClient } from "redis";
+import { sessionOutputChannel } from "@/lib/relay/redis-channels";
+
+/**
+ * GET /api/relay/sessions/[id]/stream
+ *
+ * SSE stream of session output for the browser. Subscribes to the
+ * Redis pub/sub channel that relayd publishes to via /api/relay/events.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id: sessionId } = await params;
+
+  const encoder = new TextEncoder();
+  const channel = sessionOutputChannel(sessionId);
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let subscriber: ReturnType<typeof createClient> | null = null;
+
+      try {
+        subscriber = createClient({
+          url: process.env.REDIS_URL || "redis://localhost:6379",
+        });
+        await subscriber.connect();
+
+        // Send initial SSE comment as keepalive
+        controller.enqueue(encoder.encode(": connected\n\n"));
+
+        await subscriber.subscribe(channel, (message) => {
+          try {
+            const sseData = `data: ${message}\n\n`;
+            controller.enqueue(encoder.encode(sseData));
+          } catch {
+            // Controller closed
+          }
+        });
+
+        // Keepalive every 15s to prevent connection timeout
+        const keepalive = setInterval(() => {
+          try {
+            controller.enqueue(encoder.encode(": keepalive\n\n"));
+          } catch {
+            clearInterval(keepalive);
+          }
+        }, 15_000);
+
+        // Clean up when client disconnects
+        _request.signal.addEventListener("abort", async () => {
+          clearInterval(keepalive);
+          if (subscriber) {
+            try {
+              await subscriber.unsubscribe(channel);
+              await subscriber.quit();
+            } catch {}
+          }
+        });
+      } catch (err) {
+        console.error("[relay/stream] Error:", err);
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/apps/chat/app/api/relay/sessions/[id]/stream/route.ts
+++ b/apps/chat/app/api/relay/sessions/[id]/stream/route.ts
@@ -1,11 +1,20 @@
 import { createClient } from "redis";
-import { sessionOutputChannel } from "@/lib/relay/redis-channels";
+import {
+  sessionOutputChannel,
+  sessionReplayKey,
+} from "@/lib/relay/redis-channels";
 
 /**
  * GET /api/relay/sessions/[id]/stream
  *
- * SSE stream of session output for the browser. Subscribes to the
- * Redis pub/sub channel that relayd publishes to via /api/relay/events.
+ * SSE stream of session output for the browser.
+ *
+ * On connect, replays the last N buffered events from Redis so reconnecting
+ * browsers catch up on missed output. Then subscribes to the live pub/sub
+ * channel for subsequent events.
+ *
+ * Multiple browsers can subscribe to the same session simultaneously — each
+ * gets its own subscriber connection.
  */
 export async function GET(
   _request: Request,
@@ -15,10 +24,19 @@ export async function GET(
 
   const encoder = new TextEncoder();
   const channel = sessionOutputChannel(sessionId);
+  const replayKey = sessionReplayKey(sessionId);
 
   const stream = new ReadableStream({
     async start(controller) {
       let subscriber: ReturnType<typeof createClient> | null = null;
+
+      const enqueue = (data: string) => {
+        try {
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+        } catch {
+          // Controller already closed
+        }
+      };
 
       try {
         subscriber = createClient({
@@ -26,19 +44,30 @@ export async function GET(
         });
         await subscriber.connect();
 
-        // Send initial SSE comment as keepalive
-        controller.enqueue(encoder.encode(": connected\n\n"));
+        // --- Replay buffered events before subscribing ---
+        // Use a short-lived client so we don't block the subscriber connection
+        // (subscriber.lRange is unavailable while in subscribe mode).
+        const reader = createClient({
+          url: process.env.REDIS_URL || "redis://localhost:6379",
+        });
+        await reader.connect();
+        const buffered = await reader.lRange(replayKey, 0, -1);
+        await reader.quit();
 
+        // Send replayed events with a marker so the client can distinguish them
+        for (const item of buffered) {
+          enqueue(item);
+        }
+
+        // Signal end of replay so the client can stop showing "connecting"
+        controller.enqueue(encoder.encode(": replayed\n\n"));
+
+        // --- Subscribe for live events ---
         await subscriber.subscribe(channel, (message) => {
-          try {
-            const sseData = `data: ${message}\n\n`;
-            controller.enqueue(encoder.encode(sseData));
-          } catch {
-            // Controller closed
-          }
+          enqueue(message);
         });
 
-        // Keepalive every 15s to prevent connection timeout
+        // Keepalive every 15 s to prevent proxy timeouts
         const keepalive = setInterval(() => {
           try {
             controller.enqueue(encoder.encode(": keepalive\n\n"));
@@ -47,7 +76,6 @@ export async function GET(
           }
         }, 15_000);
 
-        // Clean up when client disconnects
         _request.signal.addEventListener("abort", async () => {
           clearInterval(keepalive);
           if (subscriber) {

--- a/apps/chat/app/api/relay/sessions/route.ts
+++ b/apps/chat/app/api/relay/sessions/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api/with-auth";
+import { getUserRelaySessions } from "@/lib/db/relay-queries";
+
+export const GET = withAuth(async (_request, { userId }) => {
+  try {
+    const sessions = await getUserRelaySessions(userId);
+    return NextResponse.json({ sessions });
+  } catch (err) {
+    console.error("[relay] Failed to list sessions:", err);
+    return NextResponse.json(
+      { error: "Failed to list relay sessions" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/chat/app/api/sandbox/[sandboxId]/route.ts
+++ b/apps/chat/app/api/sandbox/[sandboxId]/route.ts
@@ -1,0 +1,125 @@
+/**
+ * GET    /api/sandbox/:sandboxId — sandbox detail + snapshots
+ * DELETE /api/sandbox/:sandboxId — force-destroy sandbox via arcand
+ *
+ * Part of BRO-261: Sandbox management API + console UI
+ *
+ * Dependency chain:
+ *   broomva.tech (this file)
+ *     → arcand (ARCAN_URL) — Rust daemon exposing sandbox lifecycle HTTP API
+ *       → SandboxService (BRO-253) → arcan-provider-vercel (BRO-263)
+ *     → Neon DB — SandboxInstance table for status tracking
+ */
+
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/api/with-auth";
+import {
+  EVENT_SANDBOX_DESTROYED,
+} from "@/lib/analytics/events";
+import { captureServerEvent } from "@/lib/analytics/posthog";
+import { logAudit } from "@/lib/db/audit";
+import { getUserOrganizations } from "@/lib/db/organization";
+import {
+  getSandboxById,
+  getSandboxSnapshots,
+  updateSandboxStatus,
+} from "@/lib/db/sandbox-queries";
+
+// ── GET ───────────────────────────────────────────────────────────────────────
+
+export const GET = withAuth(async (request: Request, { userId }) => {
+  const sandboxId = request.url.split("/api/sandbox/")[1]?.split("/")[0];
+  if (!sandboxId) {
+    return NextResponse.json({ error: "Missing sandbox ID" }, { status: 400 });
+  }
+
+  try {
+    const orgs = await getUserOrganizations(userId);
+    const org = orgs[0];
+    if (!org) {
+      return NextResponse.json({ error: "No organization" }, { status: 403 });
+    }
+
+    const sandbox = await getSandboxById(sandboxId, org.id);
+    if (!sandbox) {
+      return NextResponse.json({ error: "Sandbox not found" }, { status: 404 });
+    }
+
+    const snapshots = await getSandboxSnapshots(sandbox.id);
+
+    return NextResponse.json({ sandbox, snapshots });
+  } catch (err) {
+    console.error("[sandbox] Failed to get sandbox:", err);
+    return NextResponse.json(
+      { error: "Failed to get sandbox" },
+      { status: 500 },
+    );
+  }
+});
+
+// ── DELETE ───────────────────────────────────────────────────────────────────
+
+export const DELETE = withAuth(async (request: Request, { userId }) => {
+  const sandboxId = request.url.split("/api/sandbox/")[1]?.split("/")[0];
+  if (!sandboxId) {
+    return NextResponse.json({ error: "Missing sandbox ID" }, { status: 400 });
+  }
+
+  try {
+    const orgs = await getUserOrganizations(userId);
+    const org = orgs[0];
+    if (!org) {
+      return NextResponse.json({ error: "No organization" }, { status: 403 });
+    }
+
+    const sandbox = await getSandboxById(sandboxId, org.id);
+    if (!sandbox) {
+      return NextResponse.json({ error: "Sandbox not found" }, { status: 404 });
+    }
+
+    // Proxy destroy to arcand (gracefully degrade when not configured).
+    const arcanUrl = process.env.ARCAN_URL;
+    if (arcanUrl) {
+      try {
+        const res = await fetch(
+          `${arcanUrl}/sandbox/${encodeURIComponent(sandbox.sandboxId)}`,
+          { method: "DELETE", signal: AbortSignal.timeout(15_000) },
+        );
+        if (!res.ok && res.status !== 404) {
+          console.warn(
+            `[sandbox] arcand destroy returned ${res.status} for ${sandbox.sandboxId}`,
+          );
+        }
+      } catch (arcandErr) {
+        console.warn("[sandbox] arcand destroy failed (non-fatal):", arcandErr);
+      }
+    }
+
+    // Mark stopped in local DB regardless of arcand result.
+    await updateSandboxStatus(sandbox.id, "stopped");
+
+    // Audit + analytics.
+    logAudit({
+      organizationId: org.id,
+      actorId: userId,
+      action: "sandbox.destroy",
+      resourceType: "SandboxInstance",
+      resourceId: sandbox.id,
+      metadata: { sandboxId: sandbox.sandboxId, provider: sandbox.provider },
+    });
+    captureServerEvent(userId, EVENT_SANDBOX_DESTROYED, {
+      sandbox_id: sandbox.sandboxId,
+      provider: sandbox.provider,
+      organization_id: org.id,
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (err) {
+    console.error("[sandbox] Failed to destroy sandbox:", err);
+    return NextResponse.json(
+      { error: "Failed to destroy sandbox" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/chat/app/api/sandbox/[sandboxId]/snapshot/route.ts
+++ b/apps/chat/app/api/sandbox/[sandboxId]/snapshot/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/sandbox/:sandboxId/snapshot — manually trigger a sandbox snapshot
+ *
+ * Proxies to arcand which calls SandboxService.snapshot() → provider.snapshot().
+ * For Vercel v2 (BRO-263): snapshot = POST /v2/sandboxes/sessions/{id}/stop
+ * (auto-snapshots the filesystem for persistent sandboxes).
+ *
+ * Part of BRO-261.
+ */
+
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/api/with-auth";
+import { EVENT_SANDBOX_SNAPSHOT_MANUAL } from "@/lib/analytics/events";
+import { captureServerEvent } from "@/lib/analytics/posthog";
+import { logAudit } from "@/lib/db/audit";
+import { getUserOrganizations } from "@/lib/db/organization";
+import {
+  getSandboxById,
+  recordSandboxSnapshot,
+  updateSandboxStatus,
+} from "@/lib/db/sandbox-queries";
+
+export const POST = withAuth(async (request: Request, { userId }) => {
+  const parts = request.url.split("/api/sandbox/")[1]?.split("/");
+  const sandboxId = parts?.[0];
+  if (!sandboxId) {
+    return NextResponse.json({ error: "Missing sandbox ID" }, { status: 400 });
+  }
+
+  try {
+    const orgs = await getUserOrganizations(userId);
+    const org = orgs[0];
+    if (!org) {
+      return NextResponse.json({ error: "No organization" }, { status: 403 });
+    }
+
+    const sandbox = await getSandboxById(sandboxId, org.id);
+    if (!sandbox) {
+      return NextResponse.json({ error: "Sandbox not found" }, { status: 404 });
+    }
+
+    let snapshotId: string | null = null;
+
+    // Proxy snapshot to arcand (gracefully degrade when not configured).
+    const arcanUrl = process.env.ARCAN_URL;
+    if (arcanUrl) {
+      try {
+        const res = await fetch(
+          `${arcanUrl}/sandbox/${encodeURIComponent(sandbox.sandboxId)}/snapshot`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            signal: AbortSignal.timeout(30_000),
+          },
+        );
+        if (res.ok) {
+          const body = await res.json().catch(() => ({}));
+          snapshotId = body.snapshotId ?? null;
+        } else {
+          console.warn(
+            `[sandbox] arcand snapshot returned ${res.status} for ${sandbox.sandboxId}`,
+          );
+          return NextResponse.json(
+            { error: "Snapshot request failed" },
+            { status: 502 },
+          );
+        }
+      } catch (arcandErr) {
+        console.warn("[sandbox] arcand snapshot failed:", arcandErr);
+        return NextResponse.json(
+          { error: "Could not reach arcand" },
+          { status: 503 },
+        );
+      }
+    } else {
+      // arcand not configured — record a placeholder snapshot for local dev.
+      snapshotId = `local-snap-${Date.now()}`;
+    }
+
+    // Record snapshot + update status in local DB.
+    const resolvedSnapshotId = snapshotId ?? `fallback-${Date.now()}`;
+    await Promise.all([
+      recordSandboxSnapshot(sandbox.id, resolvedSnapshotId, "api"),
+      updateSandboxStatus(sandbox.id, "snapshotted"),
+    ]);
+
+    // Audit + analytics.
+    logAudit({
+      organizationId: org.id,
+      actorId: userId,
+      action: "sandbox.snapshot.manual",
+      resourceType: "SandboxInstance",
+      resourceId: sandbox.id,
+      metadata: {
+        sandboxId: sandbox.sandboxId,
+        snapshotId,
+        provider: sandbox.provider,
+      },
+    });
+    captureServerEvent(userId, EVENT_SANDBOX_SNAPSHOT_MANUAL, {
+      sandbox_id: sandbox.sandboxId,
+      snapshot_id: resolvedSnapshotId,
+      provider: sandbox.provider,
+      organization_id: org.id,
+    });
+
+    return NextResponse.json({ snapshotId: resolvedSnapshotId });
+  } catch (err) {
+    console.error("[sandbox] Failed to snapshot sandbox:", err);
+    return NextResponse.json(
+      { error: "Failed to snapshot sandbox" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/chat/app/api/sandbox/route.ts
+++ b/apps/chat/app/api/sandbox/route.ts
@@ -1,0 +1,37 @@
+/**
+ * GET /api/sandbox — list sandboxes for the authenticated user's organization
+ *
+ * Reads from the local SandboxInstance table (populated by arcand webhooks
+ * and direct API calls). Returns org-scoped results only.
+ *
+ * Part of BRO-261: Sandbox management API + console UI
+ */
+
+import { NextResponse } from "next/server";
+
+import { withAuth } from "@/lib/api/with-auth";
+import { getUserOrganizations } from "@/lib/db/organization";
+import { getOrgSandboxes, getSandboxMetrics } from "@/lib/db/sandbox-queries";
+
+export const GET = withAuth(async (_request, { userId }) => {
+  try {
+    const orgs = await getUserOrganizations(userId);
+    const org = orgs[0];
+    if (!org) {
+      return NextResponse.json({ sandboxes: [], metrics: { active: 0, snapshotted: 0, execs24h: 0 } });
+    }
+
+    const [sandboxes, metrics] = await Promise.all([
+      getOrgSandboxes(org.id),
+      getSandboxMetrics(org.id),
+    ]);
+
+    return NextResponse.json({ sandboxes, metrics });
+  } catch (err) {
+    console.error("[sandbox] Failed to list sandboxes:", err);
+    return NextResponse.json(
+      { error: "Failed to list sandboxes" },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/chat/components/console-sidebar.tsx
+++ b/apps/chat/components/console-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Bell,
   BookOpen,
   BotIcon,
+  BoxIcon,
   BrainIcon,
   ChevronRight,
   ChevronsUpDown,
@@ -103,6 +104,12 @@ const consoleNav = [
     url: "/console/agents",
     icon: BotIcon,
     items: [{ title: "Overview", url: "/console/agents" }],
+  },
+  {
+    title: "Sandboxes",
+    url: "/console/sandboxes",
+    icon: BoxIcon,
+    items: [{ title: "Environments", url: "/console/sandboxes" }],
   },
   {
     title: "Usage",

--- a/apps/chat/lib/analytics/events.ts
+++ b/apps/chat/lib/analytics/events.ts
@@ -37,3 +37,8 @@ export const EVENT_ESCROW_CREATED = "escrow_created";
 // ── Console / Platform ────────────────────────────────────────────────────────
 export const EVENT_CONSOLE_PAGE_VIEWED = "console_page_viewed";
 export const EVENT_DEPLOYMENT_PROVISIONED = "deployment_provisioned";
+
+// ── Sandbox ───────────────────────────────────────────────────────────────────
+export const EVENT_SANDBOX_CREATED = "sandbox_created";
+export const EVENT_SANDBOX_DESTROYED = "sandbox_destroyed";
+export const EVENT_SANDBOX_SNAPSHOT_MANUAL = "sandbox_snapshot_manual";

--- a/apps/chat/lib/console/constants.ts
+++ b/apps/chat/lib/console/constants.ts
@@ -5,6 +5,7 @@
 import {
   BarChart3,
   Bot,
+  Box,
   Brain,
   Building2,
   CircuitBoard,
@@ -25,6 +26,7 @@ export const POLL = {
   SESSIONS: 10_000,
   FINANCE: 30_000,
   USAGE: 30_000,
+  SANDBOXES: 15_000,
 } as const;
 
 export interface ServiceDef {
@@ -112,6 +114,12 @@ export const CONSOLE_NAV: NavItem[] = [
     label: "Deployments",
     href: "/console/deployments",
     icon: Rocket,
+  },
+  {
+    key: "sandboxes",
+    label: "Sandboxes",
+    href: "/console/sandboxes",
+    icon: Box,
   },
   {
     key: "organization",

--- a/apps/chat/lib/console/constants.ts
+++ b/apps/chat/lib/console/constants.ts
@@ -14,6 +14,7 @@ import {
   Layers,
   type LucideIcon,
   MessageSquare,
+  Radio,
   Rocket,
   Search,
   Shield,
@@ -27,6 +28,7 @@ export const POLL = {
   FINANCE: 30_000,
   USAGE: 30_000,
   SANDBOXES: 15_000,
+  RELAY: 5_000,
 } as const;
 
 export interface ServiceDef {
@@ -114,6 +116,12 @@ export const CONSOLE_NAV: NavItem[] = [
     label: "Deployments",
     href: "/console/deployments",
     icon: Rocket,
+  },
+  {
+    key: "relay",
+    label: "Relay",
+    href: "/console/relay",
+    icon: Radio,
   },
   {
     key: "sandboxes",

--- a/apps/chat/lib/console/types.ts
+++ b/apps/chat/lib/console/types.ts
@@ -50,3 +50,44 @@ export interface FinancialState {
   runway_months: number;
   last_updated: string;
 }
+
+// ── Sandbox ───────────────────────────────────────────────────────────────────
+
+export type SandboxProvider = "vercel" | "e2b" | "local";
+export type SandboxStatus =
+  | "starting"
+  | "running"
+  | "snapshotted"
+  | "stopped"
+  | "failed";
+export type SnapshotTrigger = "idle_reaper" | "manual" | "session_end" | "api";
+
+export interface SandboxInstanceView {
+  id: string;
+  sandboxId: string;
+  sessionId: string | null;
+  agentId: string | null;
+  provider: SandboxProvider;
+  status: SandboxStatus;
+  vcpus: number | null;
+  memoryMb: number | null;
+  persistent: boolean;
+  execCount: number;
+  lastExecAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SandboxSnapshotView {
+  id: string;
+  snapshotId: string;
+  trigger: SnapshotTrigger;
+  sizeBytes: number | null;
+  createdAt: string;
+}
+
+export interface SandboxMetrics {
+  active: number;
+  snapshotted: number;
+  execs24h: number;
+}

--- a/apps/chat/lib/console/types.ts
+++ b/apps/chat/lib/console/types.ts
@@ -91,3 +91,34 @@ export interface SandboxMetrics {
   snapshotted: number;
   execs24h: number;
 }
+
+// ── Relay ─────────────────────────────────────────────────────────────────
+
+export interface RelayNodeView {
+  id: string;
+  name: string;
+  hostname: string | null;
+  status: "online" | "offline" | "degraded";
+  lastSeenAt: string | null;
+  capabilities: string[];
+  createdAt: string;
+}
+
+export interface RelaySessionView {
+  id: string;
+  nodeId: string;
+  sessionType: "arcan" | "claude-code" | "codex";
+  status: "active" | "idle" | "completed" | "failed";
+  name: string | null;
+  workdir: string | null;
+  model: string | null;
+  lastSequence: number;
+  createdAt: string;
+}
+
+export interface RelayMetrics {
+  nodesOnline: number;
+  nodesTotal: number;
+  sessionsActive: number;
+  sessionsTotal: number;
+}

--- a/apps/chat/lib/db/migrations/0055_add_sandbox_tables.sql
+++ b/apps/chat/lib/db/migrations/0055_add_sandbox_tables.sql
@@ -1,0 +1,36 @@
+-- BRO-261: Sandbox management tables
+-- SandboxInstance: live state of a sandbox execution environment
+-- SandboxSnapshot: point-in-time filesystem snapshots
+
+CREATE TABLE IF NOT EXISTS "SandboxInstance" (
+  "id"             uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "organizationId" uuid REFERENCES "Organization"("id") ON DELETE CASCADE,
+  "agentId"        uuid REFERENCES "AgentRegistration"("id") ON DELETE SET NULL,
+  "sandboxId"      varchar(256) NOT NULL UNIQUE,
+  "sessionId"      varchar(256),
+  "provider"       varchar(32) NOT NULL,
+  "status"         varchar(32) NOT NULL DEFAULT 'starting',
+  "vcpus"          integer,
+  "memoryMb"       integer,
+  "persistent"     boolean NOT NULL DEFAULT false,
+  "lastExecAt"     timestamp,
+  "execCount"      integer NOT NULL DEFAULT 0,
+  "createdAt"      timestamp NOT NULL DEFAULT now(),
+  "updatedAt"      timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "SandboxInstance_org_idx"      ON "SandboxInstance"("organizationId");
+CREATE INDEX IF NOT EXISTS "SandboxInstance_agent_idx"    ON "SandboxInstance"("agentId");
+CREATE INDEX IF NOT EXISTS "SandboxInstance_status_idx"   ON "SandboxInstance"("status");
+CREATE INDEX IF NOT EXISTS "SandboxInstance_provider_idx" ON "SandboxInstance"("provider");
+
+CREATE TABLE IF NOT EXISTS "SandboxSnapshot" (
+  "id"                uuid PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+  "sandboxInstanceId" uuid NOT NULL REFERENCES "SandboxInstance"("id") ON DELETE CASCADE,
+  "snapshotId"        varchar(256) NOT NULL,
+  "trigger"           varchar(32) NOT NULL,
+  "sizeBytes"         integer,
+  "createdAt"         timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "SandboxSnapshot_instance_idx" ON "SandboxSnapshot"("sandboxInstanceId");

--- a/apps/chat/lib/db/migrations/0056_equal_maginty.sql
+++ b/apps/chat/lib/db/migrations/0056_equal_maginty.sql
@@ -1,0 +1,188 @@
+CREATE TABLE "Agent" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" text NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"publicKey" text,
+	"agentKeyId" varchar(64),
+	"capabilities" json DEFAULT '[]'::json,
+	"status" varchar DEFAULT 'active' NOT NULL,
+	"lastActiveAt" timestamp,
+	"revokedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "AgentService" (
+	"id" text PRIMARY KEY NOT NULL,
+	"agentId" text NOT NULL,
+	"userId" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"category" text NOT NULL,
+	"pricing" json NOT NULL,
+	"endpoint" text,
+	"capabilities" json DEFAULT '[]'::json,
+	"trustMinimum" integer DEFAULT 0 NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"callCount" integer DEFAULT 0 NOT NULL,
+	"totalRevenue" integer DEFAULT 0 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "MarketplaceTransaction" (
+	"id" text PRIMARY KEY NOT NULL,
+	"serviceId" text NOT NULL,
+	"buyerAgentId" text NOT NULL,
+	"sellerAgentId" text NOT NULL,
+	"amountMicroUsd" integer NOT NULL,
+	"facilitatorFeeMicroUsd" integer DEFAULT 0 NOT NULL,
+	"status" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"completedAt" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "OrganizationArcanRole" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organizationId" uuid NOT NULL,
+	"roleName" varchar(128) NOT NULL,
+	"allowCapabilities" json DEFAULT '[]'::json NOT NULL,
+	"maxEventsPerTurn" integer DEFAULT 20 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "OrganizationCustomSkill" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organizationId" uuid NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"manifestToml" text NOT NULL,
+	"assignedRoles" json DEFAULT '[]'::json NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "OrganizationMcpServer" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organizationId" uuid NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"url" text NOT NULL,
+	"bearerToken" text,
+	"assignedRoles" json DEFAULT '[]'::json NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "RefreshToken" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" text NOT NULL,
+	"tokenHash" varchar(64) NOT NULL,
+	"expiresAt" timestamp NOT NULL,
+	"revokedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "RefreshToken_tokenHash_unique" UNIQUE("tokenHash")
+);
+--> statement-breakpoint
+CREATE TABLE "RelayNode" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"userId" text NOT NULL,
+	"name" varchar(128) NOT NULL,
+	"hostname" varchar(256),
+	"status" varchar(16) DEFAULT 'offline' NOT NULL,
+	"lastSeenAt" timestamp,
+	"capabilities" json DEFAULT '[]'::json,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "RelaySession" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"nodeId" uuid NOT NULL,
+	"userId" text NOT NULL,
+	"sessionType" varchar(32) NOT NULL,
+	"status" varchar(16) DEFAULT 'active' NOT NULL,
+	"name" varchar(256),
+	"workdir" varchar(1024),
+	"remoteSessionId" varchar(256),
+	"lastSequence" integer DEFAULT 0 NOT NULL,
+	"model" varchar(128),
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "SandboxInstance" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"organizationId" uuid,
+	"agentId" uuid,
+	"sandboxId" varchar(256) NOT NULL,
+	"sessionId" varchar(256),
+	"provider" varchar(32) NOT NULL,
+	"status" varchar(32) DEFAULT 'starting' NOT NULL,
+	"vcpus" integer,
+	"memoryMb" integer,
+	"persistent" boolean DEFAULT false NOT NULL,
+	"lastExecAt" timestamp,
+	"execCount" integer DEFAULT 0 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "SandboxInstance_sandboxId_unique" UNIQUE("sandboxId")
+);
+--> statement-breakpoint
+CREATE TABLE "SandboxSnapshot" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"sandboxInstanceId" uuid NOT NULL,
+	"snapshotId" varchar(256) NOT NULL,
+	"trigger" varchar(32) NOT NULL,
+	"sizeBytes" integer,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "AuditLog" ADD COLUMN "agentId" text;--> statement-breakpoint
+ALTER TABLE "UsageEvent" ADD COLUMN "agentId" text;--> statement-breakpoint
+ALTER TABLE "Agent" ADD CONSTRAINT "Agent_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "AgentService" ADD CONSTRAINT "AgentService_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "OrganizationArcanRole" ADD CONSTRAINT "OrganizationArcanRole_organizationId_Organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "OrganizationCustomSkill" ADD CONSTRAINT "OrganizationCustomSkill_organizationId_Organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "OrganizationMcpServer" ADD CONSTRAINT "OrganizationMcpServer_organizationId_Organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "RelayNode" ADD CONSTRAINT "RelayNode_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "RelaySession" ADD CONSTRAINT "RelaySession_nodeId_RelayNode_id_fk" FOREIGN KEY ("nodeId") REFERENCES "public"."RelayNode"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "RelaySession" ADD CONSTRAINT "RelaySession_userId_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "SandboxInstance" ADD CONSTRAINT "SandboxInstance_organizationId_Organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "SandboxInstance" ADD CONSTRAINT "SandboxInstance_agentId_AgentRegistration_id_fk" FOREIGN KEY ("agentId") REFERENCES "public"."AgentRegistration"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "SandboxSnapshot" ADD CONSTRAINT "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk" FOREIGN KEY ("sandboxInstanceId") REFERENCES "public"."SandboxInstance"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "Agent_user_id_idx" ON "Agent" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "Agent_status_idx" ON "Agent" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "Agent_agent_key_id_unique" ON "Agent" USING btree ("agentKeyId");--> statement-breakpoint
+CREATE UNIQUE INDEX "Agent_public_key_unique" ON "Agent" USING btree ("publicKey");--> statement-breakpoint
+CREATE INDEX "AgentService_agent_id_idx" ON "AgentService" USING btree ("agentId");--> statement-breakpoint
+CREATE INDEX "AgentService_user_id_idx" ON "AgentService" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "AgentService_category_idx" ON "AgentService" USING btree ("category");--> statement-breakpoint
+CREATE INDEX "AgentService_status_idx" ON "AgentService" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "MarketplaceTransaction_service_id_idx" ON "MarketplaceTransaction" USING btree ("serviceId");--> statement-breakpoint
+CREATE INDEX "MarketplaceTransaction_buyer_idx" ON "MarketplaceTransaction" USING btree ("buyerAgentId");--> statement-breakpoint
+CREATE INDEX "MarketplaceTransaction_seller_idx" ON "MarketplaceTransaction" USING btree ("sellerAgentId");--> statement-breakpoint
+CREATE INDEX "MarketplaceTransaction_status_idx" ON "MarketplaceTransaction" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "OrgArcanRole_org_idx" ON "OrganizationArcanRole" USING btree ("organizationId");--> statement-breakpoint
+CREATE UNIQUE INDEX "OrgArcanRole_org_role_unique" ON "OrganizationArcanRole" USING btree ("organizationId","roleName");--> statement-breakpoint
+CREATE INDEX "OrgCustomSkill_org_idx" ON "OrganizationCustomSkill" USING btree ("organizationId");--> statement-breakpoint
+CREATE UNIQUE INDEX "OrgCustomSkill_org_name_unique" ON "OrganizationCustomSkill" USING btree ("organizationId","name");--> statement-breakpoint
+CREATE INDEX "OrgMcpServer_org_idx" ON "OrganizationMcpServer" USING btree ("organizationId");--> statement-breakpoint
+CREATE UNIQUE INDEX "OrgMcpServer_org_name_unique" ON "OrganizationMcpServer" USING btree ("organizationId","name");--> statement-breakpoint
+CREATE INDEX "RefreshToken_user_id_idx" ON "RefreshToken" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "RefreshToken_token_hash_idx" ON "RefreshToken" USING btree ("tokenHash");--> statement-breakpoint
+CREATE INDEX "RefreshToken_expires_at_idx" ON "RefreshToken" USING btree ("expiresAt");--> statement-breakpoint
+CREATE INDEX "RelayNode_user_idx" ON "RelayNode" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "RelayNode_status_idx" ON "RelayNode" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "RelaySession_node_idx" ON "RelaySession" USING btree ("nodeId");--> statement-breakpoint
+CREATE INDEX "RelaySession_user_idx" ON "RelaySession" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "RelaySession_status_idx" ON "RelaySession" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "SandboxInstance_org_idx" ON "SandboxInstance" USING btree ("organizationId");--> statement-breakpoint
+CREATE INDEX "SandboxInstance_agent_idx" ON "SandboxInstance" USING btree ("agentId");--> statement-breakpoint
+CREATE INDEX "SandboxInstance_status_idx" ON "SandboxInstance" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "SandboxInstance_provider_idx" ON "SandboxInstance" USING btree ("provider");--> statement-breakpoint
+CREATE INDEX "SandboxSnapshot_instance_idx" ON "SandboxSnapshot" USING btree ("sandboxInstanceId");--> statement-breakpoint
+CREATE INDEX "AuditLog_agent_id_idx" ON "AuditLog" USING btree ("agentId");--> statement-breakpoint
+CREATE INDEX "UsageEvent_agent_id_idx" ON "UsageEvent" USING btree ("agentId");

--- a/apps/chat/lib/db/migrations/meta/0056_snapshot.json
+++ b/apps/chat/lib/db/migrations/meta/0056_snapshot.json
@@ -1,0 +1,4941 @@
+{
+  "id": "801b1f7d-6858-4d77-8eb7-9d0adf79900f",
+  "prevId": "e3e3f524-b17b-4cf6-bba9-33112f1abdc9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentKeyId": {
+          "name": "agentKeyId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Agent_user_id_idx": {
+          "name": "Agent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_status_idx": {
+          "name": "Agent_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_agent_key_id_unique": {
+          "name": "Agent_agent_key_id_unique",
+          "columns": [
+            {
+              "expression": "agentKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_public_key_unique": {
+          "name": "Agent_public_key_unique",
+          "columns": [
+            {
+              "expression": "publicKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_userId_user_id_fk": {
+          "name": "Agent_userId_user_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentRegistration": {
+      "name": "AgentRegistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustLevel": {
+          "name": "trustLevel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unrated'"
+        },
+        "lastEvaluatedAt": {
+          "name": "lastEvaluatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentRegistration_org_id_idx": {
+          "name": "AgentRegistration_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_trust_level_idx": {
+          "name": "AgentRegistration_trust_level_idx",
+          "columns": [
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_status_idx": {
+          "name": "AgentRegistration_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentRegistration_organizationId_Organization_id_fk": {
+          "name": "AgentRegistration_organizationId_Organization_id_fk",
+          "tableFrom": "AgentRegistration",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentService": {
+      "name": "AgentService",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustMinimum": {
+          "name": "trustMinimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "callCount": {
+          "name": "callCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRevenue": {
+          "name": "totalRevenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentService_agent_id_idx": {
+          "name": "AgentService_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_user_id_idx": {
+          "name": "AgentService_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_category_idx": {
+          "name": "AgentService_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_status_idx": {
+          "name": "AgentService_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentService_userId_user_id_fk": {
+          "name": "AgentService_userId_user_id_fk",
+          "tableFrom": "AgentService",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AudioPlaybackState": {
+      "name": "AudioPlaybackState",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audioSrc": {
+          "name": "audioSrc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentTime": {
+          "name": "currentTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "AudioPlaybackState_userId_user_id_fk": {
+          "name": "AudioPlaybackState_userId_user_id_fk",
+          "tableFrom": "AudioPlaybackState",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_org_id_idx": {
+          "name": "AuditLog_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_actor_id_idx": {
+          "name": "AuditLog_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_created_at_idx": {
+          "name": "AuditLog_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_agent_id_idx": {
+          "name": "AuditLog_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AuditLog_organizationId_Organization_id_fk": {
+          "name": "AuditLog_organizationId_Organization_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "AuditLog_actorId_user_id_fk": {
+          "name": "AuditLog_actorId_user_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_user_id_fk": {
+          "name": "Chat_userId_user_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_projectId_Project_id_fk": {
+          "name": "Chat_projectId_Project_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeviceAuthCode": {
+      "name": "DeviceAuthCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pollingInterval": {
+          "name": "pollingInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeviceAuthCode_device_code_idx": {
+          "name": "DeviceAuthCode_device_code_idx",
+          "columns": [
+            {
+              "expression": "deviceCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeviceAuthCode_user_code_idx": {
+          "name": "DeviceAuthCode_user_code_idx",
+          "columns": [
+            {
+              "expression": "userCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeviceAuthCode_userId_user_id_fk": {
+          "name": "DeviceAuthCode_userId_user_id_fk",
+          "tableFrom": "DeviceAuthCode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeviceAuthCode_deviceCode_unique": {
+          "name": "DeviceAuthCode_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCode"
+          ]
+        },
+        "DeviceAuthCode_userCode_unique": {
+          "name": "DeviceAuthCode_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Document_message_id_idx": {
+          "name": "Document_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_user_id_fk": {
+          "name": "Document_userId_user_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_messageId_Message_id_fk": {
+          "name": "Document_messageId_Message_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EscrowTransaction": {
+      "name": "EscrowTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerOrgId": {
+          "name": "buyerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerOrgId": {
+          "name": "sellerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCredits": {
+          "name": "amountCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commissionCredits": {
+          "name": "commissionCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "heldAt": {
+          "name": "heldAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "releasedAt": {
+          "name": "releasedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputeReason": {
+          "name": "disputeReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EscrowTransaction_task_id_idx": {
+          "name": "EscrowTransaction_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_buyer_idx": {
+          "name": "EscrowTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_seller_idx": {
+          "name": "EscrowTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_status_idx": {
+          "name": "EscrowTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EscrowTransaction_taskId_MarketplaceTask_id_fk": {
+          "name": "EscrowTransaction_taskId_MarketplaceTask_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "MarketplaceTask",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_buyerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_buyerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "buyerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_sellerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_sellerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "sellerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTask": {
+      "name": "MarketplaceTask",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceCredits": {
+          "name": "priceCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "estimatedDurationMs": {
+          "name": "estimatedDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MarketplaceTask_agent_id_idx": {
+          "name": "MarketplaceTask_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTask_status_idx": {
+          "name": "MarketplaceTask_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MarketplaceTask_agentId_AgentRegistration_id_fk": {
+          "name": "MarketplaceTask_agentId_AgentRegistration_id_fk",
+          "tableFrom": "MarketplaceTask",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTransaction": {
+      "name": "MarketplaceTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerAgentId": {
+          "name": "buyerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerAgentId": {
+          "name": "sellerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountMicroUsd": {
+          "name": "amountMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facilitatorFeeMicroUsd": {
+          "name": "facilitatorFeeMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MarketplaceTransaction_service_id_idx": {
+          "name": "MarketplaceTransaction_service_id_idx",
+          "columns": [
+            {
+              "expression": "serviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_buyer_idx": {
+          "name": "MarketplaceTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_seller_idx": {
+          "name": "MarketplaceTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_status_idx": {
+          "name": "MarketplaceTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpConnector": {
+      "name": "McpConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameId": {
+          "name": "nameId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "oauthClientId": {
+          "name": "oauthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthClientSecret": {
+          "name": "oauthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpConnector_user_id_idx": {
+          "name": "McpConnector_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_idx": {
+          "name": "McpConnector_user_name_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_unique": {
+          "name": "McpConnector_user_name_id_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpConnector_userId_user_id_fk": {
+          "name": "McpConnector_userId_user_id_fk",
+          "tableFrom": "McpConnector",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpOAuthSession": {
+      "name": "McpOAuthSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcpConnectorId": {
+          "name": "mcpConnectorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientInfo": {
+          "name": "clientInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpOAuthSession_connector_idx": {
+          "name": "McpOAuthSession_connector_idx",
+          "columns": [
+            {
+              "expression": "mcpConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpOAuthSession_state_idx": {
+          "name": "McpOAuthSession_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpOAuthSession_mcpConnectorId_McpConnector_id_fk": {
+          "name": "McpOAuthSession_mcpConnectorId_McpConnector_id_fk",
+          "tableFrom": "McpOAuthSession",
+          "tableTo": "McpConnector",
+          "columnsFrom": [
+            "mcpConnectorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpOAuthSession_state_unique": {
+          "name": "McpOAuthSession_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModel": {
+          "name": "selectedModel",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "selectedTool": {
+          "name": "selectedTool",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeStreamId": {
+          "name": "activeStreamId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planCreditsMonthly": {
+          "name": "planCreditsMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "planCreditsRemaining": {
+          "name": "planCreditsRemaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "billingPeriodStart": {
+          "name": "billingPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neonBranchId": {
+          "name": "neonBranchId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Organization_slug_idx": {
+          "name": "Organization_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_stripe_customer_idx": {
+          "name": "Organization_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripeCustomerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_unique": {
+          "name": "Organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationApiKey": {
+      "name": "OrganizationApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationApiKey_org_id_idx": {
+          "name": "OrganizationApiKey_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationApiKey_key_prefix_idx": {
+          "name": "OrganizationApiKey_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "keyPrefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationApiKey_organizationId_Organization_id_fk": {
+          "name": "OrganizationApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationApiKey_createdByUserId_user_id_fk": {
+          "name": "OrganizationApiKey_createdByUserId_user_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationArcanRole": {
+      "name": "OrganizationArcanRole",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleName": {
+          "name": "roleName",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowCapabilities": {
+          "name": "allowCapabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "maxEventsPerTurn": {
+          "name": "maxEventsPerTurn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgArcanRole_org_idx": {
+          "name": "OrgArcanRole_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgArcanRole_org_role_unique": {
+          "name": "OrgArcanRole_org_role_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roleName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationArcanRole_organizationId_Organization_id_fk": {
+          "name": "OrganizationArcanRole_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationArcanRole",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationCustomSkill": {
+      "name": "OrganizationCustomSkill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifestToml": {
+          "name": "manifestToml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgCustomSkill_org_idx": {
+          "name": "OrgCustomSkill_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgCustomSkill_org_name_unique": {
+          "name": "OrgCustomSkill_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationCustomSkill_organizationId_Organization_id_fk": {
+          "name": "OrganizationCustomSkill_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationCustomSkill",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationLifeInstance": {
+      "name": "OrganizationLifeInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railwayProjectId": {
+          "name": "railwayProjectId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "railwayEnvironmentId": {
+          "name": "railwayEnvironmentId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "arcanUrl": {
+          "name": "arcanUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lagoUrl": {
+          "name": "lagoUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomicUrl": {
+          "name": "autonomicUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "haimaUrl": {
+          "name": "haimaUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthCheck": {
+          "name": "lastHealthCheck",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthStatus": {
+          "name": "lastHealthStatus",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationLifeInstance_org_id_idx": {
+          "name": "OrganizationLifeInstance_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationLifeInstance_organizationId_Organization_id_fk": {
+          "name": "OrganizationLifeInstance_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationLifeInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMcpServer": {
+      "name": "OrganizationMcpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearerToken": {
+          "name": "bearerToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgMcpServer_org_idx": {
+          "name": "OrgMcpServer_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMcpServer_org_name_unique": {
+          "name": "OrgMcpServer_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMcpServer_organizationId_Organization_id_fk": {
+          "name": "OrganizationMcpServer_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMcpServer",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_org_id_idx": {
+          "name": "OrganizationMember_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_user_id_idx": {
+          "name": "OrganizationMember_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_org_user_unique": {
+          "name": "OrganizationMember_org_user_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationMember_userId_user_id_fk": {
+          "name": "OrganizationMember_userId_user_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mediaType": {
+          "name": "file_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_filename": {
+          "name": "file_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_sourceId": {
+          "name": "source_url_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_url": {
+          "name": "source_url_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_title": {
+          "name": "source_url_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_sourceId": {
+          "name": "source_document_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_mediaType": {
+          "name": "source_document_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_title": {
+          "name": "source_document_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_filename": {
+          "name": "source_document_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_toolCallId": {
+          "name": "tool_toolCallId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_state": {
+          "name": "tool_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_errorText": {
+          "name": "tool_errorText",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_blob": {
+          "name": "data_blob",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Part_message_id_idx": {
+          "name": "Part_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Part_message_id_order_idx": {
+          "name": "Part_message_id_order_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_messageId_Message_id_fk": {
+          "name": "Part_messageId_Message_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Part_text_required_if_type_text": {
+          "name": "Part_text_required_if_type_text",
+          "value": "CASE WHEN \"Part\".\"type\" = 'text' THEN \"Part\".\"text_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_reasoning_required_if_type_reasoning": {
+          "name": "Part_reasoning_required_if_type_reasoning",
+          "value": "CASE WHEN \"Part\".\"type\" = 'reasoning' THEN \"Part\".\"reasoning_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_file_required_if_type_file": {
+          "name": "Part_file_required_if_type_file",
+          "value": "CASE WHEN \"Part\".\"type\" = 'file' THEN \"Part\".\"file_mediaType\" IS NOT NULL AND \"Part\".\"file_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_url_required_if_type_source_url": {
+          "name": "Part_source_url_required_if_type_source_url",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-url' THEN \"Part\".\"source_url_sourceId\" IS NOT NULL AND \"Part\".\"source_url_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_document_required_if_type_source_document": {
+          "name": "Part_source_document_required_if_type_source_document",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-document' THEN \"Part\".\"source_document_sourceId\" IS NOT NULL AND \"Part\".\"source_document_mediaType\" IS NOT NULL AND \"Part\".\"source_document_title\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_tool_required_if_type_tool": {
+          "name": "Part_tool_required_if_type_tool",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'tool-%' THEN \"Part\".\"tool_toolCallId\" IS NOT NULL AND \"Part\".\"tool_state\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_data_required_if_type_data": {
+          "name": "Part_data_required_if_type_data",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'data-%' THEN \"Part\".\"data_type\" IS NOT NULL ELSE TRUE END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "iconColor": {
+          "name": "iconColor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gray'"
+        }
+      },
+      "indexes": {
+        "Project_user_id_idx": {
+          "name": "Project_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_userId_user_id_fk": {
+          "name": "Project_userId_user_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_user_id_idx": {
+          "name": "RefreshToken_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_token_hash_idx": {
+          "name": "RefreshToken_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expires_at_idx": {
+          "name": "RefreshToken_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_user_id_fk": {
+          "name": "RefreshToken_userId_user_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_tokenHash_unique": {
+          "name": "RefreshToken_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelayNode": {
+      "name": "RelayNode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelayNode_user_idx": {
+          "name": "RelayNode_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelayNode_status_idx": {
+          "name": "RelayNode_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelayNode_userId_user_id_fk": {
+          "name": "RelayNode_userId_user_id_fk",
+          "tableFrom": "RelayNode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelaySession": {
+      "name": "RelaySession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionType": {
+          "name": "sessionType",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workdir": {
+          "name": "workdir",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remoteSessionId": {
+          "name": "remoteSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSequence": {
+          "name": "lastSequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelaySession_node_idx": {
+          "name": "RelaySession_node_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_user_idx": {
+          "name": "RelaySession_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_status_idx": {
+          "name": "RelaySession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelaySession_nodeId_RelayNode_id_fk": {
+          "name": "RelaySession_nodeId_RelayNode_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "RelayNode",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RelaySession_userId_user_id_fk": {
+          "name": "RelaySession_userId_user_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxInstance": {
+      "name": "SandboxInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "vcpus": {
+          "name": "vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryMb": {
+          "name": "memoryMb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persistent": {
+          "name": "persistent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastExecAt": {
+          "name": "lastExecAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execCount": {
+          "name": "execCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxInstance_org_idx": {
+          "name": "SandboxInstance_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_agent_idx": {
+          "name": "SandboxInstance_agent_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_status_idx": {
+          "name": "SandboxInstance_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_provider_idx": {
+          "name": "SandboxInstance_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxInstance_organizationId_Organization_id_fk": {
+          "name": "SandboxInstance_organizationId_Organization_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SandboxInstance_agentId_AgentRegistration_id_fk": {
+          "name": "SandboxInstance_agentId_AgentRegistration_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SandboxInstance_sandboxId_unique": {
+          "name": "SandboxInstance_sandboxId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sandboxId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxSnapshot": {
+      "name": "SandboxSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandboxInstanceId": {
+          "name": "sandboxInstanceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotId": {
+          "name": "snapshotId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxSnapshot_instance_idx": {
+          "name": "SandboxSnapshot_instance_idx",
+          "columns": [
+            {
+              "expression": "sandboxInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk": {
+          "name": "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk",
+          "tableFrom": "SandboxSnapshot",
+          "tableTo": "SandboxInstance",
+          "columnsFrom": [
+            "sandboxInstanceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_user_id_fk": {
+          "name": "Suggestion_userId_user_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costCents": {
+          "name": "costCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeMeterEventId": {
+          "name": "stripeMeterEventId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_id_idx": {
+          "name": "UsageEvent_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_user_id_idx": {
+          "name": "UsageEvent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_created_at_idx": {
+          "name": "UsageEvent_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_org_created_idx": {
+          "name": "UsageEvent_org_created_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_agent_id_idx": {
+          "name": "UsageEvent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_user_id_fk": {
+          "name": "UsageEvent_userId_user_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserCredit": {
+      "name": "UserCredit",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserCredit_userId_user_id_fk": {
+          "name": "UserCredit_userId_user_id_fk",
+          "tableFrom": "UserCredit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserModelPreference": {
+      "name": "UserModelPreference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserModelPreference_user_id_idx": {
+          "name": "UserModelPreference_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserModelPreference_userId_user_id_fk": {
+          "name": "UserModelPreference_userId_user_id_fk",
+          "tableFrom": "UserModelPreference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UserModelPreference_userId_modelId_pk": {
+          "name": "UserModelPreference_userId_modelId_pk",
+          "columns": [
+            "userId",
+            "modelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserPrompt": {
+      "name": "UserPrompt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UserPrompt_user_id_idx": {
+          "name": "UserPrompt_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_visibility_idx": {
+          "name": "UserPrompt_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_slug_unique": {
+          "name": "UserPrompt_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserPrompt_userId_user_id_fk": {
+          "name": "UserPrompt_userId_user_id_fk",
+          "tableFrom": "UserPrompt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserVault": {
+      "name": "UserVault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lagoSessionId": {
+          "name": "lagoSessionId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserVault_user_id_idx": {
+          "name": "UserVault_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserVault_lago_session_unique": {
+          "name": "UserVault_lago_session_unique",
+          "columns": [
+            {
+              "expression": "lagoSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserVault_userId_user_id_fk": {
+          "name": "UserVault_userId_user_id_fk",
+          "tableFrom": "UserVault",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat/lib/db/migrations/meta/_journal.json
+++ b/apps/chat/lib/db/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1774447900000,
       "version": "7",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1774633286543,
+      "tag": "0056_equal_maginty",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat/lib/db/relay-queries.ts
+++ b/apps/chat/lib/db/relay-queries.ts
@@ -1,0 +1,133 @@
+/**
+ * Relay node and session database queries.
+ */
+
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "./client";
+import { relayNode, relaySession } from "./schema";
+
+// ── Relay Nodes ───────────────────────────────────────────────────────────
+
+export function getUserRelayNodes(userId: string) {
+  return db
+    .select()
+    .from(relayNode)
+    .where(eq(relayNode.userId, userId))
+    .orderBy(desc(relayNode.updatedAt));
+}
+
+export async function getRelayNodeById(id: string, userId: string) {
+  const rows = await db
+    .select()
+    .from(relayNode)
+    .where(and(eq(relayNode.id, id), eq(relayNode.userId, userId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export function upsertRelayNode(
+  userId: string,
+  name: string,
+  hostname: string,
+  capabilities: string[],
+) {
+  return db
+    .insert(relayNode)
+    .values({
+      userId,
+      name,
+      hostname,
+      status: "online",
+      lastSeenAt: new Date(),
+      capabilities,
+    })
+    .returning();
+}
+
+export function updateRelayNodeStatus(
+  id: string,
+  status: "online" | "offline" | "degraded",
+) {
+  return db
+    .update(relayNode)
+    .set({ status, lastSeenAt: new Date() })
+    .where(eq(relayNode.id, id));
+}
+
+// ── Relay Sessions ────────────────────────────────────────────────────────
+
+export function getUserRelaySessions(userId: string) {
+  return db
+    .select()
+    .from(relaySession)
+    .where(eq(relaySession.userId, userId))
+    .orderBy(desc(relaySession.updatedAt));
+}
+
+export function getNodeRelaySessions(nodeId: string) {
+  return db
+    .select()
+    .from(relaySession)
+    .where(eq(relaySession.nodeId, nodeId))
+    .orderBy(desc(relaySession.createdAt));
+}
+
+export async function getRelaySessionById(id: string, userId: string) {
+  const rows = await db
+    .select()
+    .from(relaySession)
+    .where(and(eq(relaySession.id, id), eq(relaySession.userId, userId)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export function createRelaySession(values: {
+  nodeId: string;
+  userId: string;
+  sessionType: "arcan" | "claude-code" | "codex";
+  name: string;
+  workdir?: string;
+  remoteSessionId?: string;
+  model?: string;
+}) {
+  return db.insert(relaySession).values(values).returning();
+}
+
+export function updateRelaySessionStatus(
+  id: string,
+  status: "active" | "idle" | "completed" | "failed",
+) {
+  return db
+    .update(relaySession)
+    .set({ status })
+    .where(eq(relaySession.id, id));
+}
+
+export function updateRelaySessionSequence(id: string, lastSequence: number) {
+  return db
+    .update(relaySession)
+    .set({ lastSequence })
+    .where(eq(relaySession.id, id));
+}
+
+// ── Metrics ───────────────────────────────────────────────────────────────
+
+export async function getRelayMetrics(userId: string) {
+  const [metrics] = await db
+    .select({
+      nodesOnline: sql<number>`count(distinct ${relayNode.id}) filter (where ${relayNode.status} = 'online')`,
+      nodesTotal: sql<number>`count(distinct ${relayNode.id})`,
+      sessionsActive: sql<number>`count(${relaySession.id}) filter (where ${relaySession.status} = 'active')`,
+      sessionsTotal: sql<number>`count(${relaySession.id})`,
+    })
+    .from(relayNode)
+    .leftJoin(relaySession, eq(relaySession.nodeId, relayNode.id))
+    .where(eq(relayNode.userId, userId));
+
+  return {
+    nodesOnline: Number(metrics?.nodesOnline ?? 0),
+    nodesTotal: Number(metrics?.nodesTotal ?? 0),
+    sessionsActive: Number(metrics?.sessionsActive ?? 0),
+    sessionsTotal: Number(metrics?.sessionsTotal ?? 0),
+  };
+}

--- a/apps/chat/lib/db/sandbox-queries.ts
+++ b/apps/chat/lib/db/sandbox-queries.ts
@@ -1,0 +1,93 @@
+import "server-only";
+
+import { and, desc, eq, gte, sql } from "drizzle-orm";
+
+import { db } from "./client";
+import { sandboxInstance, sandboxSnapshot } from "./schema";
+
+// ── List ─────────────────────────────────────────────────────────────────────
+
+/** All sandboxes belonging to an organization, newest first. */
+export function getOrgSandboxes(organizationId: string) {
+  return db
+    .select()
+    .from(sandboxInstance)
+    .where(eq(sandboxInstance.organizationId, organizationId))
+    .orderBy(desc(sandboxInstance.createdAt));
+}
+
+/** Single sandbox by its local UUID — org-scoped for authorization. */
+export async function getSandboxById(
+  id: string,
+  organizationId: string,
+) {
+  const rows = await db
+    .select()
+    .from(sandboxInstance)
+    .where(
+      and(
+        eq(sandboxInstance.id, id),
+        eq(sandboxInstance.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/** Snapshots for a given sandbox instance, newest first, capped at 20. */
+export function getSandboxSnapshots(sandboxInstanceId: string) {
+  return db
+    .select()
+    .from(sandboxSnapshot)
+    .where(eq(sandboxSnapshot.sandboxInstanceId, sandboxInstanceId))
+    .orderBy(desc(sandboxSnapshot.createdAt))
+    .limit(20);
+}
+
+// ── Metrics ──────────────────────────────────────────────────────────────────
+
+/** Counts of active / snapshotted sandboxes + total execs in the last 24h. */
+export async function getSandboxMetrics(organizationId: string) {
+  const [metrics] = await db
+    .select({
+      active: sql<number>`count(*) filter (where ${sandboxInstance.status} = 'running')`,
+      snapshotted: sql<number>`count(*) filter (where ${sandboxInstance.status} = 'snapshotted')`,
+      execs24h: sql<number>`coalesce(sum(${sandboxInstance.execCount}) filter (where ${sandboxInstance.lastExecAt} >= now() - interval '24 hours'), 0)`,
+    })
+    .from(sandboxInstance)
+    .where(eq(sandboxInstance.organizationId, organizationId));
+
+  return {
+    active: Number(metrics?.active ?? 0),
+    snapshotted: Number(metrics?.snapshotted ?? 0),
+    execs24h: Number(metrics?.execs24h ?? 0),
+  };
+}
+
+// ── Mutations ────────────────────────────────────────────────────────────────
+
+/** Update sandbox status. */
+export function updateSandboxStatus(
+  id: string,
+  status: "starting" | "running" | "snapshotted" | "stopped" | "failed",
+) {
+  return db
+    .update(sandboxInstance)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(sandboxInstance.id, id));
+}
+
+/** Record a snapshot for a sandbox instance. */
+export function recordSandboxSnapshot(
+  sandboxInstanceId: string,
+  snapshotId: string,
+  trigger: "idle_reaper" | "manual" | "session_end" | "api",
+  sizeBytes?: number,
+) {
+  return db.insert(sandboxSnapshot).values({
+    sandboxInstanceId,
+    snapshotId,
+    trigger,
+    sizeBytes: sizeBytes ?? null,
+  });
+}

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -1346,4 +1346,90 @@ export const sandboxSnapshot = pgTable(
 
 export type SandboxSnapshot = InferSelectModel<typeof sandboxSnapshot>;
 
+// ── Relay ─────────────────────────────────────────────────────────────────
+
+/** Relay node — a user's machine running the relayd daemon. */
+export const relayNode = pgTable(
+  "RelayNode",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /** Display name (defaults to hostname). */
+    name: varchar("name", { length: 128 }).notNull(),
+    /** Machine hostname. */
+    hostname: varchar("hostname", { length: 256 }),
+    /** Connection status. */
+    status: varchar("status", {
+      enum: ["online", "offline", "degraded"],
+      length: 16,
+    })
+      .notNull()
+      .default("offline"),
+    lastSeenAt: timestamp("lastSeenAt"),
+    /** Supported session types (e.g. ["claude-code","arcan","codex"]). */
+    capabilities: json("capabilities").$type<string[]>().default([]),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    RelayNode_user_idx: index("RelayNode_user_idx").on(t.userId),
+    RelayNode_status_idx: index("RelayNode_status_idx").on(t.status),
+  }),
+);
+
+export type RelayNode = InferSelectModel<typeof relayNode>;
+
+/** Relay session — an agent session accessible via relay. */
+export const relaySession = pgTable(
+  "RelaySession",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    nodeId: uuid("nodeId")
+      .notNull()
+      .references(() => relayNode.id, { onDelete: "cascade" }),
+    userId: text("userId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    /** Agent runtime type. */
+    sessionType: varchar("sessionType", {
+      enum: ["arcan", "claude-code", "codex"],
+      length: 32,
+    }).notNull(),
+    /** Lifecycle status. */
+    status: varchar("status", {
+      enum: ["active", "idle", "completed", "failed"],
+      length: 16,
+    })
+      .notNull()
+      .default("active"),
+    /** Display name for the session. */
+    name: varchar("name", { length: 256 }),
+    /** Working directory on the remote machine. */
+    workdir: varchar("workdir", { length: 1024 }),
+    /** Remote session identifier (Arcan session_id or tmux session name). */
+    remoteSessionId: varchar("remoteSessionId", { length: 256 }),
+    /** Last received output sequence number (for resumability). */
+    lastSequence: integer("lastSequence").notNull().default(0),
+    /** Model currently in use. */
+    model: varchar("model", { length: 128 }),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    RelaySession_node_idx: index("RelaySession_node_idx").on(t.nodeId),
+    RelaySession_user_idx: index("RelaySession_user_idx").on(t.userId),
+    RelaySession_status_idx: index("RelaySession_status_idx").on(t.status),
+  }),
+);
+
+export type RelaySession = InferSelectModel<typeof relaySession>;
+
 export const schema = { user, session, account, verification };

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -1251,4 +1251,99 @@ export type OrganizationMcpServer = InferSelectModel<
   typeof organizationMcpServer
 >;
 
+// ---------------------------------------------------------------------------
+// Sandbox Tables (BRO-261)
+// ---------------------------------------------------------------------------
+
+/** Live state of a sandbox execution environment managed by arcand. */
+export const sandboxInstance = pgTable(
+  "SandboxInstance",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    /** Owning organization. Null for personal (user-scoped) sandboxes. */
+    organizationId: uuid("organizationId").references(() => organization.id, {
+      onDelete: "cascade",
+    }),
+    /** The registered agent that owns this sandbox. Null for ad-hoc sandboxes. */
+    agentId: uuid("agentId").references(() => agentRegistration.id, {
+      onDelete: "set null",
+    }),
+    /** Provider-assigned sandbox ID (e.g. Vercel sandbox name, e2b sandbox id). */
+    sandboxId: varchar("sandboxId", { length: 256 }).notNull().unique(),
+    /** Arcan session ID that created this sandbox. */
+    sessionId: varchar("sessionId", { length: 256 }),
+    /** Backend provider: vercel, e2b, local. */
+    provider: varchar("provider", {
+      enum: ["vercel", "e2b", "local"],
+      length: 32,
+    }).notNull(),
+    /** Current lifecycle status. */
+    status: varchar("status", {
+      enum: ["starting", "running", "snapshotted", "stopped", "failed"],
+      length: 32,
+    })
+      .notNull()
+      .default("starting"),
+    /** vCPUs allocated. Null = provider default. */
+    vcpus: integer("vcpus"),
+    /** Memory in MB. Null = provider default. */
+    memoryMb: integer("memoryMb"),
+    /** Whether the sandbox auto-snapshots on session end. */
+    persistent: boolean("persistent").notNull().default(false),
+    /** Last time a command was executed in this sandbox. */
+    lastExecAt: timestamp("lastExecAt"),
+    /** Total number of commands executed. */
+    execCount: integer("execCount").notNull().default(0),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    SandboxInstance_org_idx: index("SandboxInstance_org_idx").on(
+      t.organizationId,
+    ),
+    SandboxInstance_agent_idx: index("SandboxInstance_agent_idx").on(
+      t.agentId,
+    ),
+    SandboxInstance_status_idx: index("SandboxInstance_status_idx").on(
+      t.status,
+    ),
+    SandboxInstance_provider_idx: index("SandboxInstance_provider_idx").on(
+      t.provider,
+    ),
+  }),
+);
+
+export type SandboxInstance = InferSelectModel<typeof sandboxInstance>;
+
+/** Point-in-time filesystem snapshot of a sandbox. */
+export const sandboxSnapshot = pgTable(
+  "SandboxSnapshot",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    sandboxInstanceId: uuid("sandboxInstanceId")
+      .notNull()
+      .references(() => sandboxInstance.id, { onDelete: "cascade" }),
+    /** Provider-assigned snapshot ID. */
+    snapshotId: varchar("snapshotId", { length: 256 }).notNull(),
+    /** What triggered this snapshot. */
+    trigger: varchar("trigger", {
+      enum: ["idle_reaper", "manual", "session_end", "api"],
+      length: 32,
+    }).notNull(),
+    /** Snapshot size in bytes. Null = not yet known. */
+    sizeBytes: integer("sizeBytes"),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+  },
+  (t) => ({
+    SandboxSnapshot_instance_idx: index("SandboxSnapshot_instance_idx").on(
+      t.sandboxInstanceId,
+    ),
+  }),
+);
+
+export type SandboxSnapshot = InferSelectModel<typeof sandboxSnapshot>;
+
 export const schema = { user, session, account, verification };

--- a/apps/chat/lib/relay/protocol.ts
+++ b/apps/chat/lib/relay/protocol.ts
@@ -1,0 +1,64 @@
+/**
+ * Life Relay wire protocol types — mirrors life-relay-core/src/protocol.rs
+ */
+
+// ── Session Types ─────────────────────────────────────────────────────────
+
+export type SessionType = "arcan" | "claude-code" | "codex";
+export type SessionStatus = "active" | "idle" | "completed" | "failed";
+
+export interface SessionInfo {
+  id: string;
+  sessionType: SessionType;
+  status: SessionStatus;
+  name: string;
+  workdir: string;
+  model?: string;
+  createdAt: string;
+}
+
+export interface SpawnConfig {
+  name: string;
+  workdir?: string;
+  model?: string;
+  sessionId?: string;
+}
+
+// ── Server → Daemon (commands) ────────────────────────────────────────────
+
+export type ServerMessage =
+  | { type: "spawn"; sessionType: SessionType; config: SpawnConfig }
+  | { type: "input"; sessionId: string; data: string }
+  | { type: "resize"; sessionId: string; cols: number; rows: number }
+  | {
+      type: "approve";
+      sessionId: string;
+      approvalId: string;
+      approved: boolean;
+    }
+  | { type: "kill"; sessionId: string }
+  | { type: "list_sessions" }
+  | { type: "ping" };
+
+// ── Daemon → Server (events) ──────────────────────────────────────────────
+
+export type DaemonMessage =
+  | { type: "output"; sessionId: string; data: string; seq: number }
+  | { type: "session_created"; session: SessionInfo }
+  | { type: "session_ended"; sessionId: string; reason: string }
+  | {
+      type: "approval_request";
+      sessionId: string;
+      approvalId: string;
+      capability: string;
+      context: string;
+    }
+  | { type: "session_list"; sessions: SessionInfo[] }
+  | {
+      type: "node_info";
+      name: string;
+      hostname: string;
+      capabilities: string[];
+    }
+  | { type: "pong" }
+  | { type: "error"; code: string; message: string };

--- a/apps/chat/lib/relay/protocol.ts
+++ b/apps/chat/lib/relay/protocol.ts
@@ -68,5 +68,13 @@ export type DaemonMessage =
       hostname: string;
       capabilities: string[];
     }
+  | {
+      type: "workspace_status";
+      sessionId: string;
+      branch: string | null;
+      modified: number;
+      staged: number;
+      lastCommit: string | null;
+    }
   | { type: "pong" }
   | { type: "error"; code: string; message: string };

--- a/apps/chat/lib/relay/protocol.ts
+++ b/apps/chat/lib/relay/protocol.ts
@@ -44,6 +44,14 @@ export type ServerMessage =
 
 export type DaemonMessage =
   | { type: "output"; sessionId: string; data: string; seq: number }
+  | { type: "assistant_message"; sessionId: string; text: string }
+  | {
+      type: "tool_event";
+      sessionId: string;
+      toolName: string;
+      toolId: string;
+      input: Record<string, unknown>;
+    }
   | { type: "session_created"; session: SessionInfo }
   | { type: "session_ended"; sessionId: string; reason: string }
   | {

--- a/apps/chat/lib/relay/redis-channels.ts
+++ b/apps/chat/lib/relay/redis-channels.ts
@@ -28,3 +28,15 @@ export function sessionOutputChannel(sessionId: string): string {
 export function sessionInputChannel(sessionId: string): string {
   return `${PREFIX}:session:${sessionId}:input`;
 }
+
+/**
+ * Redis list key for session event replay buffer.
+ * Stores the last 500 session events (any type) as JSON strings.
+ * Used by SSE stream to replay missed events on reconnect.
+ */
+export function sessionReplayKey(sessionId: string): string {
+  return `${PREFIX}:session:${sessionId}:replay`;
+}
+
+/** Maximum number of events to keep in the replay buffer. */
+export const REPLAY_BUFFER_SIZE = 500;

--- a/apps/chat/lib/relay/redis-channels.ts
+++ b/apps/chat/lib/relay/redis-channels.ts
@@ -1,0 +1,30 @@
+/**
+ * Redis pub/sub channel naming for relay communication.
+ *
+ * Pattern: relay:{nodeId}:{channel}
+ * - commands: server → daemon commands (spawn, input, kill)
+ * - events:   daemon → server events (output, session_created)
+ * - session:{sessionId}:output: per-session output stream
+ */
+
+const PREFIX = "relay";
+
+/** Channel for commands sent to a specific relay node. */
+export function nodeCommandsChannel(nodeId: string): string {
+  return `${PREFIX}:${nodeId}:commands`;
+}
+
+/** Channel for events from a specific relay node. */
+export function nodeEventsChannel(nodeId: string): string {
+  return `${PREFIX}:${nodeId}:events`;
+}
+
+/** Channel for output from a specific session. */
+export function sessionOutputChannel(sessionId: string): string {
+  return `${PREFIX}:session:${sessionId}:output`;
+}
+
+/** Channel for input to a specific session. */
+export function sessionInputChannel(sessionId: string): string {
+  return `${PREFIX}:session:${sessionId}:input`;
+}

--- a/crates/broomva-cli/Cargo.lock
+++ b/crates/broomva-cli/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "clap",
  "dirs",
  "dotenvy",
+ "hostname",
  "libc",
  "open",
  "predicates",
@@ -632,6 +633,17 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"

--- a/crates/broomva-cli/Cargo.toml
+++ b/crates/broomva-cli/Cargo.toml
@@ -35,6 +35,7 @@ uuid = { version = "1", features = ["v4"] }
 dirs = "6"
 dotenvy = "0.15"
 open = "5"
+hostname = "0.4"
 libc = "0.2"
 
 [dev-dependencies]

--- a/crates/broomva-cli/src/api/auth.rs
+++ b/crates/broomva-cli/src/api/auth.rs
@@ -116,6 +116,124 @@ pub async fn device_login(client: &reqwest::Client, base: &str) -> BroomvaResult
     }
 }
 
+/// Device login with agent metadata — registers as a relay node or agent.
+///
+/// Sends agent_name, host_id, and requested_capabilities in the device code
+/// request so the approval page shows the correct agent flow.
+pub async fn device_login_as_agent(
+    client: &reqwest::Client,
+    base: &str,
+    agent_name: &str,
+    host_id: &str,
+    capabilities: &[&str],
+) -> BroomvaResult<TokenResponse> {
+    let code_url = format!("{base}/api/auth/device/code");
+    let resp = client
+        .post(&code_url)
+        .json(&serde_json::json!({
+            "client_id": format!("agent:{agent_name}"),
+            "agent_name": agent_name,
+            "host_id": host_id,
+            "requested_capabilities": capabilities,
+        }))
+        .send()
+        .await
+        .map_err(|e| BroomvaError::Api {
+            status: 0,
+            message: format!("failed to request device code: {e}"),
+            body: None,
+        })?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(BroomvaError::Api {
+            status,
+            message: "device code request failed".into(),
+            body: Some(body),
+        });
+    }
+
+    let device: DeviceCodeResponse = resp.json().await?;
+
+    println!();
+    println!("  Registering relay node: {agent_name}");
+    println!();
+    let verify_url = device
+        .verification_uri_complete
+        .as_deref()
+        .unwrap_or(&device.verification_uri);
+    println!("  Open this URL to approve:");
+    println!("    {verify_url}");
+    println!();
+    println!("  Code: {}", device.user_code);
+    println!();
+
+    let _ = open::that(verify_url);
+
+    // Poll for token (same loop as device_login)
+    let mut interval = device.interval;
+    let token_url = format!("{base}/api/auth/device/token");
+
+    loop {
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+
+        let poll_resp = client
+            .post(&token_url)
+            .json(&DeviceTokenRequest {
+                device_code: device.device_code.clone(),
+                grant_type: "urn:ietf:params:oauth:grant-type:device_code".into(),
+            })
+            .send()
+            .await
+            .map_err(|e| BroomvaError::Api {
+                status: 0,
+                message: format!("token poll failed: {e}"),
+                body: None,
+            })?;
+
+        let status = poll_resp.status();
+
+        if status.is_success() {
+            let token: TokenResponse = poll_resp.json().await?;
+            println!("  Relay node registered successfully.");
+            return Ok(token);
+        }
+
+        let body = poll_resp.text().await.unwrap_or_default();
+        if let Ok(err) = serde_json::from_str::<DeviceTokenError>(&body) {
+            match err.error.as_str() {
+                "authorization_pending" => continue,
+                "slow_down" => {
+                    interval += 5;
+                    continue;
+                }
+                "access_denied" => {
+                    return Err(BroomvaError::User("registration denied by user".into()));
+                }
+                "expired_token" => {
+                    return Err(BroomvaError::User(
+                        "device code expired — run `broomva relay auth` again".into(),
+                    ));
+                }
+                other => {
+                    return Err(BroomvaError::Api {
+                        status: status.as_u16(),
+                        message: format!("unexpected error: {other}"),
+                        body: Some(body),
+                    });
+                }
+            }
+        }
+
+        return Err(BroomvaError::Api {
+            status: status.as_u16(),
+            message: "unexpected response during token poll".into(),
+            body: Some(body),
+        });
+    }
+}
+
 /// Manual login: prompt user for token on stdin.
 pub async fn manual_login() -> BroomvaResult<()> {
     print!("  Paste your API token: ");

--- a/crates/broomva-cli/src/api/auth.rs
+++ b/crates/broomva-cli/src/api/auth.rs
@@ -70,16 +70,26 @@ pub async fn device_login(client: &reqwest::Client, base: &str) -> BroomvaResult
             })?;
 
         let status = poll_resp.status();
+        let body = poll_resp.text().await.unwrap_or_default();
 
         if status.is_success() {
-            let token: TokenResponse = poll_resp.json().await?;
-            config::store_token(&token.access_token, token.expires_at.as_deref())?;
-            println!("  Authenticated successfully.");
-            return Ok(token);
+            match serde_json::from_str::<TokenResponse>(&body) {
+                Ok(token) => {
+                    config::store_token(&token.access_token, token.expires_at.as_deref())?;
+                    println!("  Authenticated successfully.");
+                    return Ok(token);
+                }
+                Err(e) => {
+                    return Err(BroomvaError::Api {
+                        status: status.as_u16(),
+                        message: format!("failed to parse token response: {e}"),
+                        body: Some(body),
+                    });
+                }
+            }
         }
 
         // Try to parse as error response.
-        let body = poll_resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<DeviceTokenError>(&body) {
             match err.error.as_str() {
                 "authorization_pending" => {
@@ -193,14 +203,24 @@ pub async fn device_login_as_agent(
             })?;
 
         let status = poll_resp.status();
+        let body = poll_resp.text().await.unwrap_or_default();
 
         if status.is_success() {
-            let token: TokenResponse = poll_resp.json().await?;
-            println!("  Relay node registered successfully.");
-            return Ok(token);
+            match serde_json::from_str::<TokenResponse>(&body) {
+                Ok(token) => {
+                    println!("  Relay node registered successfully.");
+                    return Ok(token);
+                }
+                Err(e) => {
+                    return Err(BroomvaError::Api {
+                        status: status.as_u16(),
+                        message: format!("failed to parse token response: {e}"),
+                        body: Some(body),
+                    });
+                }
+            }
         }
 
-        let body = poll_resp.text().await.unwrap_or_default();
         if let Ok(err) = serde_json::from_str::<DeviceTokenError>(&body) {
             match err.error.as_str() {
                 "authorization_pending" => continue,

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -118,7 +118,6 @@ pub struct ContextInfo {
 // ── Auth ──
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct DeviceCodeResponse {
     pub device_code: String,
     pub user_code: String,
@@ -141,12 +140,19 @@ pub struct DeviceTokenRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TokenResponse {
     pub access_token: String,
+    #[serde(default)]
     pub token_type: Option<String>,
+    #[serde(default)]
     pub expires_in: Option<u64>,
+    #[serde(default)]
     pub expires_at: Option<String>,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    /// Agent info (present when registering as agent)
+    #[serde(default)]
+    pub agent: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod context;
 pub mod daemon_cmd;
 pub mod output;
 pub mod prompts;
+pub mod relay;
 pub mod skills;
 
 use clap::{Parser, Subcommand};
@@ -77,6 +78,11 @@ pub enum Command {
     Console {
         #[command(subcommand)]
         command: Option<ConsoleCommand>,
+    },
+    /// Relay — remote agent session management.
+    Relay {
+        #[command(subcommand)]
+        action: RelayCommand,
     },
 }
 
@@ -268,6 +274,30 @@ pub enum DaemonCommand {
     },
 }
 
+// ── Relay ──
+
+#[derive(Subcommand, Debug)]
+pub enum RelayCommand {
+    /// Register this machine as a relay node (device auth flow).
+    Auth {
+        /// Node display name (defaults to hostname).
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Start the relay daemon.
+    Start {
+        /// Local API bind address.
+        #[arg(long, default_value = "127.0.0.1:3004")]
+        bind: String,
+    },
+    /// Stop the relay daemon.
+    Stop,
+    /// Show relay node and session status.
+    Status,
+    /// List active relay sessions.
+    Sessions,
+}
+
 // ── Console ──
 
 #[derive(Subcommand, Debug)]
@@ -426,6 +456,13 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                 daemon_cmd::handle_logs(lines, level.as_deref(), format).await
             }
             DaemonCommand::Tasks { all } => daemon_cmd::handle_tasks(all, format).await,
+        },
+        Command::Relay { action } => match action {
+            RelayCommand::Auth { name } => relay::handle_auth(&client, name).await,
+            RelayCommand::Start { bind } => relay::handle_start(&client, &bind).await,
+            RelayCommand::Stop => relay::handle_stop().await,
+            RelayCommand::Status => relay::handle_status(&client, format).await,
+            RelayCommand::Sessions => relay::handle_sessions(&client, format).await,
         },
     }
 }

--- a/crates/broomva-cli/src/cli/relay.rs
+++ b/crates/broomva-cli/src/cli/relay.rs
@@ -1,0 +1,143 @@
+//! Relay subcommand handlers — remote agent session management.
+//!
+//! `broomva relay auth` registers this machine as a relay node using the
+//! existing device authorization flow, with relay-specific capabilities.
+
+use crate::api::BroomvaClient;
+use crate::cli::output::OutputFormat;
+use crate::config;
+use crate::error::BroomvaResult;
+
+/// Register this machine as a relay node via device auth.
+pub async fn handle_auth(client: &BroomvaClient, name: Option<String>) -> BroomvaResult<()> {
+    let hostname = hostname::get()
+        .map(|h| h.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    let node_name = name.unwrap_or_else(|| hostname.clone());
+
+    eprintln!("Registering relay node: {node_name}");
+    eprintln!("Hostname: {hostname}");
+    eprintln!();
+
+    // Use the existing device login flow with relay agent metadata
+    let token_response = crate::api::auth::device_login_as_agent(
+        client.raw_client(),
+        client.base_url(),
+        &node_name,
+        &hostname,
+        &[
+            "chat:send",
+            "chat:read",
+            "deployment:read",
+            "deployment:write",
+            "memory:read",
+            "memory:write",
+        ],
+    )
+    .await?;
+
+    // Store the token
+    let computed_expires = token_response.expires_in.map(|secs| {
+        let dt = chrono::Utc::now() + chrono::Duration::seconds(secs as i64);
+        dt.to_rfc3339()
+    });
+    let expires_at = token_response
+        .expires_at
+        .as_deref()
+        .or(computed_expires.as_deref());
+
+    config::store_token(&token_response.access_token, expires_at)?;
+
+    eprintln!();
+    eprintln!("Relay node registered successfully.");
+    eprintln!("Token stored. Run `broomva relay start` to connect.");
+
+    Ok(())
+}
+
+/// Start the relay daemon.
+pub async fn handle_start(_client: &BroomvaClient, bind: &str) -> BroomvaResult<()> {
+    eprintln!("Starting relay daemon on {bind}...");
+    eprintln!("Not yet implemented — use `cargo run -p life-relayd -- start --bind {bind}` from core/life/relay/");
+    Ok(())
+}
+
+/// Stop the relay daemon.
+pub async fn handle_stop() -> BroomvaResult<()> {
+    eprintln!("Stopping relay daemon...");
+    eprintln!("Not yet implemented.");
+    Ok(())
+}
+
+/// Show relay status.
+pub async fn handle_status(client: &BroomvaClient, _format: OutputFormat) -> BroomvaResult<()> {
+    let url = format!("{}/api/relay/nodes", client.base_url());
+    let mut req = client.raw_client().get(&url);
+    if let Ok(Some(t)) = config::read_config().map(|c| c.token) {
+        req = req.header("Authorization", format!("Bearer {t}"));
+    }
+    let res = req.send().await.map_err(|e| {
+        crate::error::BroomvaError::Api {
+            status: 0,
+            message: format!("request failed: {e}"),
+            body: None,
+        }
+    })?;
+
+    let body: serde_json::Value = res.json().await.unwrap_or_default();
+
+    if let Some(nodes) = body.get("nodes").and_then(|n| n.as_array()) {
+        eprintln!("Relay Nodes: {}", nodes.len());
+        for node in nodes {
+            let name = node.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+            let status = node.get("status").and_then(|v| v.as_str()).unwrap_or("?");
+            let host = node.get("hostname").and_then(|v| v.as_str()).unwrap_or("");
+            eprintln!("  [{status:7}] {name} ({host})");
+        }
+    }
+
+    if let Some(metrics) = body.get("metrics") {
+        let online = metrics.get("nodesOnline").and_then(|n| n.as_u64()).unwrap_or(0);
+        let active = metrics.get("sessionsActive").and_then(|n| n.as_u64()).unwrap_or(0);
+        eprintln!();
+        eprintln!("Online: {online} nodes, {active} active sessions");
+    }
+
+    Ok(())
+}
+
+/// List relay sessions.
+pub async fn handle_sessions(client: &BroomvaClient, _format: OutputFormat) -> BroomvaResult<()> {
+    let url = format!("{}/api/relay/sessions", client.base_url());
+    let mut req = client.raw_client().get(&url);
+    if let Ok(Some(t)) = config::read_config().map(|c| c.token) {
+        req = req.header("Authorization", format!("Bearer {t}"));
+    }
+    let res = req.send().await.map_err(|e| {
+        crate::error::BroomvaError::Api {
+            status: 0,
+            message: format!("request failed: {e}"),
+            body: None,
+        }
+    })?;
+
+    let body: serde_json::Value = res.json().await.unwrap_or_default();
+
+    if let Some(sessions) = body.get("sessions").and_then(|s| s.as_array()) {
+        if sessions.is_empty() {
+            eprintln!("No active relay sessions.");
+            return Ok(());
+        }
+        eprintln!("Relay Sessions:");
+        for session in sessions {
+            let name = session.get("name").and_then(|v| v.as_str()).unwrap_or("untitled");
+            let stype = session.get("sessionType").and_then(|v| v.as_str()).unwrap_or("?");
+            let status = session.get("status").and_then(|v| v.as_str()).unwrap_or("?");
+            let workdir = session.get("workdir").and_then(|v| v.as_str()).unwrap_or("");
+            eprintln!("  [{status:9}] [{stype:11}] {name}  {workdir}");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **DB**: `SandboxInstance` + `SandboxSnapshot` Drizzle tables + migration `0055`
- **API**: `GET/DELETE /api/sandbox/:id`, `GET /api/sandbox`, `POST /api/sandbox/:id/snapshot` — all org-scoped, withAuth, audit-logged
- **Console**: `/console/sandboxes` — polling table (15s), MetricTile metrics, status/provider badges, Snapshot + Destroy per-row actions
- **Sidebar**: Sandboxes nav item (BoxIcon) under Agents
- **Analytics**: `sandbox_created`, `sandbox_destroyed`, `sandbox_snapshot_manual` events

## Dependency chain

```
arcan-provider-vercel v2 (BRO-263 ✅)
  └── SandboxService (BRO-253) → arcand daemon (ARCAN_URL)
        └── /api/sandbox/* (this PR) → graceful degradation when arcand not up
              └── /console/sandboxes (this PR) → polls every 15s
```

All API routes gracefully degrade when `ARCAN_URL` is not configured — the console shows an empty state rather than erroring.

## Test plan

- [ ] `tsc --noEmit` passes ✅
- [ ] Navigate to `/console/sandboxes` — empty state renders correctly
- [ ] With `ARCAN_URL` set: list + destroy + snapshot flow end-to-end
- [ ] DB migration `0055` applies cleanly on fresh Neon branch
- [ ] Audit log entries created on destroy + manual snapshot
- [ ] PostHog events fire: `sandbox_destroyed`, `sandbox_snapshot_manual`

Closes BRO-261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay console: live view of relay nodes and sessions with real-time streaming session output, input box, and approval prompts
  * Sandboxes console: environments list with metrics, manual refresh, per-row actions to snapshot or destroy sandboxes
  * CLI: relay subcommands for auth, status, and session listing

* **Chores**
  * Server APIs, real-time plumbing, analytics events, database schema and migrations to enable Relay and Sandboxes features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->