### PR TITLE
fix: platform validation gaps — feature flags, billing, error boundaries, domain refs

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -38,7 +38,7 @@ import { createAnonymousSession } from "@/lib/create-anonymous-session";
 import { CostAccumulator } from "@/lib/credits/cost-accumulator";
 import { canSpend, deductCredits } from "@/lib/db/credits";
 import { getMcpConnectorsByUserId } from "@/lib/db/mcp-queries";
-import { recordUsageEvent } from "@/lib/db/usage";
+import { deductOrgCredits, recordUsageEvent } from "@/lib/db/usage";
 import {
   getChatById,
   getMessageById,
@@ -84,6 +84,8 @@ import {
   EVENT_MESSAGE_SENT,
   EVENT_TOOL_USED,
 } from "@/lib/analytics/events";
+import { getServerFeatureFlag } from "@/lib/feature-flags";
+import type { FeatureFlag } from "@/lib/feature-flags";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 
@@ -119,7 +121,10 @@ async function ensureRedisClients() {
     redisPublisher = null;
     redisSubscriber = null;
     redisConnectPromise = null;
-    console.warn("Redis unavailable, continuing without resumable streams.", error);
+    console.warn(
+      "Redis unavailable, continuing without resumable streams.",
+      error,
+    );
     return null;
   }
 }
@@ -170,7 +175,7 @@ async function handleAnonymousSession({
       success: false,
       error: Response.json(
         { error: rateLimitResult.error, type: "RATE_LIMIT_EXCEEDED" },
-        { status: 429, headers: rateLimitResult.headers || {} }
+        { status: 429, headers: rateLimitResult.headers || {} },
       ),
     };
   }
@@ -189,14 +194,14 @@ async function handleAnonymousSession({
           suggestion:
             "Create an account to get more credits and access to more AI models",
         },
-        { status: 402, headers: rateLimitResult.headers || {} }
+        { status: 402, headers: rateLimitResult.headers || {} },
       ),
     };
   }
 
   if (
     !(ANONYMOUS_LIMITS.AVAILABLE_MODELS as readonly AppModelId[]).includes(
-      selectedModelId
+      selectedModelId,
     )
   ) {
     log.warn("Model not available for anonymous users");
@@ -207,7 +212,7 @@ async function handleAnonymousSession({
           error: "Model not available for anonymous users",
           availableModels: ANONYMOUS_LIMITS.AVAILABLE_MODELS,
         },
-        { status: 403, headers: rateLimitResult.headers || {} }
+        { status: 403, headers: rateLimitResult.headers || {} },
       ),
     };
   }
@@ -304,21 +309,98 @@ async function handleUserValidationAndCredits({
   return { isNewChat: validationResult.isNewChat };
 }
 
+// ── Feature-flag tool gating (BRO-393) ───────────────────────────────────────
+
 /**
- * Determines which built-in tools are allowed based on model capabilities.
+ * Mapping from feature flag to the tool names it gates.
+ * When a flag is disabled, all listed tools are excluded.
+ */
+const FLAG_GATED_TOOLS: Partial<Record<FeatureFlag, ToolName[]>> = {
+  deep_research: ["deepResearch"],
+  sandbox: ["codeExecution"],
+  image_generation: ["generateImage"],
+  web_search: ["webSearch"],
+  url_retrieval: ["retrieveUrl"],
+  knowledge_graph: ["searchKnowledge", "readKnowledgeNote"],
+};
+
+/** The feature flags that gate premium chat tools. */
+const TOOL_GATING_FLAGS = Object.keys(FLAG_GATED_TOOLS) as FeatureFlag[];
+
+/**
+ * Evaluate feature flags and return the set of tool names that should be
+ * excluded because their flag is disabled for this user/org.
+ */
+async function getGatedToolNames(
+  userId: string,
+  orgId?: string | null,
+): Promise<Set<ToolName>> {
+  const groups = orgId ? { organization: orgId } : undefined;
+  const disabled = new Set<ToolName>();
+
+  const results = await Promise.all(
+    TOOL_GATING_FLAGS.map(async (flag) => ({
+      flag,
+      enabled: await getServerFeatureFlag(flag, userId, groups),
+    })),
+  );
+
+  for (const { flag, enabled } of results) {
+    if (!enabled) {
+      for (const tool of FLAG_GATED_TOOLS[flag] ?? []) {
+        disabled.add(tool);
+      }
+    }
+  }
+
+  return disabled;
+}
+
+/**
+ * Returns a user-facing upgrade message when a gated tool is explicitly
+ * requested but the feature flag is disabled.
+ */
+function getToolGateUpgradeMessage(toolName: ToolName): string {
+  const messages: Partial<Record<ToolName, string>> = {
+    deepResearch:
+      "Deep research requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    codeExecution:
+      "Code execution (sandbox) requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    generateImage:
+      "Image generation requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    webSearch:
+      "Web search requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    retrieveUrl:
+      "URL retrieval requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    searchKnowledge:
+      "Knowledge graph search requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    readKnowledgeNote:
+      "Knowledge graph access requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+  };
+  return (
+    messages[toolName] ??
+    "This feature requires a plan upgrade. Visit /pricing for details."
+  );
+}
+
+/**
+ * Determines which built-in tools are allowed based on model capabilities
+ * and feature flags.
  * MCP tools are handled separately in core-chat-agent.
  */
 function determineAllowedTools({
   isAnonymous,
   modelDefinition,
   explicitlyRequestedTools,
+  gatedTools,
 }: {
   isAnonymous: boolean;
   modelDefinition: AppModelDefinition;
   explicitlyRequestedTools: ToolName[] | null;
+  gatedTools?: Set<ToolName>;
 }): ToolName[] {
   // Start with all tools or anonymous-limited tools
-  const allowedTools: ToolName[] = isAnonymous
+  let allowedTools: ToolName[] = isAnonymous
     ? [...ANONYMOUS_LIMITS.AVAILABLE_TOOLS]
     : [...allTools];
 
@@ -327,10 +409,15 @@ function determineAllowedTools({
     return [];
   }
 
+  // Remove tools disabled by feature flags (BRO-393)
+  if (gatedTools && gatedTools.size > 0) {
+    allowedTools = allowedTools.filter((tool) => !gatedTools.has(tool));
+  }
+
   // If specific tools were requested, filter them against allowed tools
   if (explicitlyRequestedTools && explicitlyRequestedTools.length > 0) {
     return explicitlyRequestedTools.filter((tool) =>
-      allowedTools.includes(tool)
+      allowedTools.includes(tool),
     );
   }
 
@@ -365,6 +452,7 @@ async function createChatStream({
   selectedModelId,
   explicitlyRequestedTools,
   userId,
+  organizationId,
   allowedTools,
   abortController,
   isAnonymous,
@@ -381,6 +469,7 @@ async function createChatStream({
   selectedModelId: AppModelId;
   explicitlyRequestedTools: ToolName[] | null;
   userId: string | null;
+  organizationId: string | null;
   allowedTools: ToolName[];
   abortController: AbortController;
   isAnonymous: boolean;
@@ -452,7 +541,7 @@ async function createChatStream({
                 costAccumulator.addLLMCost(
                   selectedModelId,
                   part.totalUsage,
-                  "main-chat"
+                  "main-chat",
                 );
               }
               return {
@@ -462,7 +551,7 @@ async function createChatStream({
               };
             }
           },
-        })
+        }),
       );
       await result.consumeStream();
 
@@ -487,6 +576,7 @@ async function createChatStream({
       await finalizeMessageAndCredits({
         messages,
         userId,
+        organizationId,
         isAnonymous,
         chatId,
         costAccumulator,
@@ -500,13 +590,16 @@ async function createChatStream({
       if (!isAnonymous) {
         after(() =>
           Promise.resolve(
-            updateMessageActiveStreamId({ id: messageId, activeStreamId: null })
+            updateMessageActiveStreamId({
+              id: messageId,
+              activeStreamId: null,
+            }),
           ).catch((dbError) => {
             log.error(
               { error: dbError },
-              "Failed to clear activeStreamId on stream error"
+              "Failed to clear activeStreamId on stream error",
             );
-          })
+          }),
         );
       }
 
@@ -525,6 +618,7 @@ async function executeChatRequest({
   selectedModelId,
   explicitlyRequestedTools,
   userId,
+  organizationId,
   isAnonymous,
   isNewChat,
   allowedTools,
@@ -538,6 +632,7 @@ async function executeChatRequest({
   selectedModelId: AppModelId;
   explicitlyRequestedTools: ToolName[] | null;
   userId: string | null;
+  organizationId: string | null;
   isAnonymous: boolean;
   isNewChat: boolean;
   allowedTools: ToolName[];
@@ -589,6 +684,7 @@ async function executeChatRequest({
     selectedModelId,
     explicitlyRequestedTools,
     userId,
+    organizationId,
     allowedTools,
     abortController,
     isAnonymous,
@@ -608,7 +704,7 @@ async function executeChatRequest({
         const keys = await publisher.keys(keyPattern);
         if (keys.length > 0) {
           await Promise.all(
-            keys.map((key: string) => publisher.expire(key, 300))
+            keys.map((key: string) => publisher.expire(key, 300)),
           );
         }
       } catch (error) {
@@ -630,7 +726,7 @@ async function executeChatRequest({
     log.debug("Returning resumable stream");
     return new Response(
       await streamContext.resumableStream(streamId, sseStream),
-      { headers: sseHeaders }
+      { headers: sseHeaders },
     );
   }
 
@@ -714,6 +810,7 @@ async function prepareRequestContext({
   anonymousPreviousMessages,
   modelDefinition,
   explicitlyRequestedTools,
+  gatedTools,
 }: {
   userMessage: ChatMessage;
   chatId: string;
@@ -721,6 +818,7 @@ async function prepareRequestContext({
   anonymousPreviousMessages: ChatMessage[];
   modelDefinition: AppModelDefinition;
   explicitlyRequestedTools: ToolName[] | null;
+  gatedTools?: Set<ToolName>;
 }): Promise<{
   previousMessages: ChatMessage[];
   allowedTools: ToolName[];
@@ -732,18 +830,19 @@ async function prepareRequestContext({
     isAnonymous,
     modelDefinition,
     explicitlyRequestedTools,
+    gatedTools,
   });
 
   // Validate input token limit (50k tokens for user message)
   const totalTokens = calculateMessagesTokens(
-    await convertToModelMessages([userMessage])
+    await convertToModelMessages([userMessage]),
   );
 
   if (totalTokens > MAX_INPUT_TOKENS) {
     log.warn({ totalTokens, MAX_INPUT_TOKENS }, "Token limit exceeded");
     const error = new ChatSDKError(
       "input_too_long:chat",
-      `Message too long: ${totalTokens} tokens (max: ${MAX_INPUT_TOKENS})`
+      `Message too long: ${totalTokens} tokens (max: ${MAX_INPUT_TOKENS})`,
     );
     return {
       previousMessages: [],
@@ -756,7 +855,7 @@ async function prepareRequestContext({
     ? anonymousPreviousMessages
     : await getThreadUpToMessageId(
         chatId,
-        userMessage.metadata.parentMessageId
+        userMessage.metadata.parentMessageId,
       );
 
   const previousMessages = messageThreadToParent.slice(-5);
@@ -768,12 +867,14 @@ async function prepareRequestContext({
 async function finalizeMessageAndCredits({
   messages,
   userId,
+  organizationId,
   isAnonymous,
   chatId,
   costAccumulator,
 }: {
   messages: ChatMessage[];
   userId: string | null;
+  organizationId: string | null;
   isAnonymous: boolean;
   chatId: string;
   costAccumulator: CostAccumulator;
@@ -826,9 +927,17 @@ async function finalizeMessageAndCredits({
     if (userId && !isAnonymous) {
       await deductCredits(userId, totalCost);
 
+      // Deduct org-level credits (atomic — skips if org has insufficient balance)
+      if (organizationId) {
+        deductOrgCredits(organizationId, totalCost).catch((err) => {
+          log.error({ error: err }, "Failed to deduct org credits");
+        });
+      }
+
       // Record usage event (fire-and-forget, non-blocking)
       const tokenBreakdown = costAccumulator.getTokenBreakdown();
       recordUsageEvent({
+        organizationId: organizationId ?? undefined,
         userId,
         type: "ai_tokens",
         resource: tokenBreakdown.modelId ?? undefined,
@@ -857,7 +966,12 @@ function buildArcanPolicy(plan: string): ArcanPolicySet {
   if (plan === "anonymous") {
     return {
       allow_capabilities: ["fs:read:/session/**"],
-      gate_capabilities: ["fs:write:**", "exec:cmd:*", "net:egress:*", "secrets:read:*"],
+      gate_capabilities: [
+        "fs:write:**",
+        "exec:cmd:*",
+        "net:egress:*",
+        "secrets:read:*",
+      ],
       max_events_per_turn: 5,
       max_tool_runtime_secs: 30,
     };
@@ -922,10 +1036,12 @@ export async function POST(request: NextRequest) {
     // ---- Tier-based model & credit gate (authenticated users only) ----
     // userPlan is hoisted so the arcan block can build a tier-appropriate policy
     let userPlan = "anonymous";
+    let orgId: string | null = null;
     if (userId && !isAnonymous) {
       // Lightweight single-row lookup for org plan + credits
       const [orgRow] = await tierDb
         .select({
+          orgId: organization.id,
           plan: organization.plan,
           planCreditsRemaining: organization.planCreditsRemaining,
         })
@@ -937,6 +1053,7 @@ export async function POST(request: NextRequest) {
         .where(eq(organizationMember.userId, userId))
         .limit(1);
 
+      orgId = orgRow?.orgId ?? null;
       userPlan = orgRow?.plan ?? "free";
 
       if (!isModelAllowed(userPlan, selectedModelId)) {
@@ -1019,6 +1136,40 @@ export async function POST(request: NextRequest) {
     const explicitlyRequestedTools =
       determineExplicitlyRequestedTools(selectedTool);
 
+    // ── Feature-flag tool gating (BRO-393) ──────────────────────────
+    // Evaluate PostHog feature flags to determine which premium tools
+    // should be excluded for this user/org. Anonymous users skip this
+    // (they already have a restricted tool set from ANONYMOUS_LIMITS).
+    let gatedTools: Set<ToolName> | undefined;
+
+    if (userId && !isAnonymous) {
+      gatedTools = await getGatedToolNames(userId, orgId);
+
+      // If the user explicitly requested a gated tool (e.g. clicked the
+      // deep-research button), return an upgrade message immediately
+      // instead of silently stripping the tool.
+      if (
+        gatedTools.size > 0 &&
+        explicitlyRequestedTools &&
+        explicitlyRequestedTools.length > 0
+      ) {
+        const blockedTool = explicitlyRequestedTools.find((t) =>
+          gatedTools!.has(t),
+        );
+        if (blockedTool) {
+          return Response.json(
+            {
+              error: "feature_gated",
+              message: getToolGateUpgradeMessage(blockedTool),
+              upgradeUrl: "/pricing",
+            },
+            { status: 403 },
+          );
+        }
+      }
+
+    }
+
     const contextResult = await prepareRequestContext({
       userMessage,
       chatId,
@@ -1026,6 +1177,7 @@ export async function POST(request: NextRequest) {
       anonymousPreviousMessages,
       modelDefinition,
       explicitlyRequestedTools,
+      gatedTools,
     });
 
     if (contextResult.error) {
@@ -1038,14 +1190,16 @@ export async function POST(request: NextRequest) {
     // Two-tier routing:
     //   1. Dedicated Railway org instance (enterprise only)
     //   2. Shared ARCAN_URL env instance (all tiers, fallback)
-    // If the dedicated instance fails health check → mark degraded, try shared.
+    // If the dedicated instance fails health check -> mark degraded, try shared.
     // Anonymous users skip the org lookup and go straight to the shared instance.
     {
       const arcanOwnerId = userId ?? anonymousSession?.id ?? null;
       const arcanEmail = userId
-        ? ((await getSafeSession({
-            fetchOptions: { headers: await headers() },
-          })).data?.user?.email ?? "")
+        ? ((
+            await getSafeSession({
+              fetchOptions: { headers: await headers() },
+            })
+          ).data?.user?.email ?? "")
         : `anon-${anonymousSession?.id?.slice(0, 8)}@guest.broomva.tech`;
 
       if (arcanOwnerId) {
@@ -1054,7 +1208,12 @@ export async function POST(request: NextRequest) {
           : {
               dedicated: null,
               shared: process.env.ARCAN_URL
-                ? { arcanUrl: process.env.ARCAN_URL, lagoUrl: process.env.LAGO_URL ?? null, isDedicated: false, orgId: null }
+                ? {
+                    arcanUrl: process.env.ARCAN_URL,
+                    lagoUrl: process.env.LAGO_URL ?? null,
+                    isDedicated: false,
+                    orgId: null,
+                  }
                 : null,
             };
 
@@ -1066,7 +1225,10 @@ export async function POST(request: NextRequest) {
           if (!endpoint) continue;
 
           const abortController = new AbortController();
-          const timeoutId = setTimeout(() => abortController.abort(), 290_000);
+          const timeoutId = setTimeout(
+            () => abortController.abort(),
+            290_000,
+          );
 
           // Degraded policy applied when falling back from a failed dedicated instance
           const isDegradedFallback = endpoint === shared && dedicated !== null;
@@ -1089,8 +1251,13 @@ export async function POST(request: NextRequest) {
 
           if (arcanResponse) {
             log.info(
-              { chatId, anonymous: isAnonymous, dedicated: endpoint.isDedicated, degraded: isDegradedFallback },
-              "Routed to Arcan"
+              {
+                chatId,
+                anonymous: isAnonymous,
+                dedicated: endpoint.isDedicated,
+                degraded: isDegradedFallback,
+              },
+              "Routed to Arcan",
             );
             return arcanResponse;
           }
@@ -1098,8 +1265,12 @@ export async function POST(request: NextRequest) {
           // Dedicated instance unreachable — mark degraded and try shared next
           if (endpoint.isDedicated && endpoint.orgId) {
             log.warn(
-              { chatId, orgId: endpoint.orgId, arcanUrl: endpoint.arcanUrl },
-              "Dedicated arcand unreachable — marking degraded, falling back to shared instance (BRO-225)"
+              {
+                chatId,
+                orgId: endpoint.orgId,
+                arcanUrl: endpoint.arcanUrl,
+              },
+              "Dedicated arcand unreachable — marking degraded, falling back to shared instance (BRO-225)",
             );
             await markInstanceDegraded(endpoint.orgId);
           }
@@ -1111,8 +1282,17 @@ export async function POST(request: NextRequest) {
 
     // ── Fallback: Direct streamText (template path) ─────────────────
     // Used for anonymous users, or when no Arcan instance is available.
+    // Gate MCP connectors behind the mcp feature flag (BRO-393)
+    const mcpFlagEnabled =
+      userId && !isAnonymous
+        ? await getServerFeatureFlag(
+            "mcp",
+            userId,
+            orgId ? { organization: orgId } : undefined,
+          )
+        : false;
     const mcpConnectors: McpConnector[] =
-      config.features.mcp && userId && !isAnonymous
+      config.features.mcp && mcpFlagEnabled && userId && !isAnonymous
         ? await getMcpConnectorsByUserId({ userId })
         : [];
 
@@ -1129,6 +1309,7 @@ export async function POST(request: NextRequest) {
       selectedModelId,
       explicitlyRequestedTools,
       userId,
+      organizationId: orgId,
       isAnonymous,
       isNewChat,
       allowedTools,
@@ -1144,7 +1325,7 @@ export async function POST(request: NextRequest) {
             ? { message: error.message, stack: error.stack }
             : error,
       },
-      "RESPONSE > POST /api/chat error"
+      "RESPONSE > POST /api/chat error",
     );
     return new Response("Internal Server Error", {
       status: 500,

--- a/apps/chat/app/(console)/console/deployments/page.tsx
+++ b/apps/chat/app/(console)/console/deployments/page.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { SERVICES } from "@/lib/console/constants";
 import { MetricTile } from "@/components/console/metric-tile";
 import type { ServiceStatus as MetricStatus } from "@/lib/console/types";
+import { useFeatureFlag } from "@/hooks/use-feature-flag";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -151,6 +152,7 @@ function railwayStatusToMetric(status: string): MetricStatus {
 // ---------------------------------------------------------------------------
 
 export default function DeploymentsPage() {
+  const deploymentsEnabled = useFeatureFlag("managed_deployments");
   const [org, setOrg] = useState<OrgSummary | null>(null);
   const [instance, setInstance] = useState<LifeInstance | null>(null);
   const [railwayServices, setRailwayServices] = useState<
@@ -367,6 +369,44 @@ export default function DeploymentsPage() {
     if (!org) return;
     await fetchInstance(org.id);
   };
+
+  // ── Render: Feature flag gate (BRO-393) ─────────────────────────────
+
+  if (!deploymentsEnabled) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-6">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold">Deployments</h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            Managed Life Agent OS instance provisioning and health monitoring.
+          </p>
+        </div>
+        <div className="glass-card">
+          <div className="flex flex-col items-center gap-4 py-8 text-center">
+            <div className="rounded-full bg-[var(--ag-accent)]/10 p-4">
+              <Rocket className="size-8 text-[var(--ag-accent)]" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-text-primary">
+                Managed Deployments
+              </h2>
+              <p className="mx-auto mt-2 max-w-md text-sm text-text-secondary">
+                Managed Life Agent OS deployments require a paid plan. Upgrade to
+                provision and manage dedicated instances.
+              </p>
+            </div>
+            <a
+              href="/pricing"
+              className="glass-button inline-flex items-center gap-2"
+            >
+              <Zap className="size-4" />
+              View Pricing
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // ── Render: Loading ─────────────────────────────────────────────────
 

--- a/apps/chat/app/(console)/console/lago/metrics/page.tsx
+++ b/apps/chat/app/(console)/console/lago/metrics/page.tsx
@@ -7,7 +7,7 @@ import type { ParsedMetric } from "@/lib/lago/types";
 import { parsePrometheusText } from "@/lib/lago/types";
 
 const LAGO_BASE =
-  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://lago.broomva.tech";
+  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://api.lago.arcan.la";
 
 export default function LagoMetricsPage() {
   const [metrics, setMetrics] = useState<ParsedMetric[]>([]);

--- a/apps/chat/app/(console)/console/lago/policy/page.tsx
+++ b/apps/chat/app/(console)/console/lago/policy/page.tsx
@@ -7,7 +7,7 @@ import type { LagoHealth, LagoSession } from "@/lib/lago/types";
 import { classifySessionTier } from "@/lib/lago/types";
 
 const LAGO_BASE =
-  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://lago.broomva.tech";
+  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://api.lago.arcan.la";
 
 export default function LagoPolicyPage() {
   const [health, setHealth] = useState<LagoHealth | null>(null);

--- a/apps/chat/app/(console)/console/lago/sessions/[id]/page.tsx
+++ b/apps/chat/app/(console)/console/lago/sessions/[id]/page.tsx
@@ -20,7 +20,7 @@ import type { LagoManifestEntry, LagoSession, LagoSnapshot } from "@/lib/lago/ty
 import { classifySessionTier, TIER_COLORS } from "@/lib/lago/types";
 
 const LAGO_BASE =
-  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://lago.broomva.tech";
+  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://api.lago.arcan.la";
 
 type Tab = "files" | "snapshots" | "branches";
 

--- a/apps/chat/app/(console)/console/lago/sessions/page.tsx
+++ b/apps/chat/app/(console)/console/lago/sessions/page.tsx
@@ -9,7 +9,7 @@ import type { LagoSession, SessionTier } from "@/lib/lago/types";
 import { classifySessionTier, TIER_COLORS } from "@/lib/lago/types";
 
 const LAGO_BASE =
-  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://lago.broomva.tech";
+  process.env.NEXT_PUBLIC_LAGO_URL ?? "https://api.lago.arcan.la";
 
 type FilterTier = "all" | SessionTier;
 

--- a/apps/chat/app/(console)/console/marketplace/page.tsx
+++ b/apps/chat/app/(console)/console/marketplace/page.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { usePostHog } from "posthog-js/react";
 
 import { EVENT_AGENT_DISCOVERED } from "@/lib/analytics/events";
+import { useFeatureFlag } from "@/hooks/use-feature-flag";
 import { POLL } from "@/lib/console/constants";
 import { MetricTile } from "@/components/console/metric-tile";
 import { Badge } from "@/components/ui/badge";
@@ -137,6 +138,7 @@ function trustBadgeVariant(
 
 export default function MarketplacePage() {
   const posthog = usePostHog();
+  const marketplaceEnabled = useFeatureFlag("marketplace_enabled");
   const discoveredFired = useRef(false);
   const [services, setServices] = useState<ServiceData[]>([]);
   const [myServices, setMyServices] = useState<ServiceData[]>([]);
@@ -291,6 +293,44 @@ export default function MarketplacePage() {
       posthog?.capture(EVENT_AGENT_DISCOVERED, { resultCount: services.length });
     }
   }, [loading, services.length, posthog]);
+
+  // ---------------------------------------------------------------------------
+  // Feature flag gate (BRO-393)
+  // ---------------------------------------------------------------------------
+  if (!marketplaceEnabled) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-8">
+        <div>
+          <h1 className="font-heading text-2xl font-semibold">Marketplace</h1>
+          <p className="mt-1 text-sm text-text-secondary">
+            Discover and offer agent services.
+          </p>
+        </div>
+        <div className="glass-card">
+          <div className="flex flex-col items-center gap-4 py-8 text-center">
+            <div className="rounded-full bg-[var(--ag-accent)]/10 p-4">
+              <Store className="size-8 text-[var(--ag-accent)]" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-text-primary">
+                Marketplace Access
+              </h2>
+              <p className="mx-auto mt-2 max-w-md text-sm text-text-secondary">
+                The agent marketplace is available on paid plans. Upgrade to
+                discover and offer agent services.
+              </p>
+            </div>
+            <a
+              href="/pricing"
+              className="glass-button inline-flex items-center gap-2"
+            >
+              View Pricing
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // Loading state

--- a/apps/chat/app/(console)/console/sandboxes/page.tsx
+++ b/apps/chat/app/(console)/console/sandboxes/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
+import { useFeatureFlag } from "@/hooks/use-feature-flag";
 import { MetricTile } from "@/components/console/metric-tile";
 import {
   AlertDialog,
@@ -138,6 +139,7 @@ function EmptyState() {
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function SandboxesPage() {
+  const sandboxEnabled = useFeatureFlag("sandbox");
   const [sandboxes, setSandboxes] = useState<SandboxInstanceView[]>([]);
   const [metrics, setMetrics] = useState<SandboxMetrics>({
     active: 0,
@@ -223,6 +225,36 @@ export default function SandboxesPage() {
       setActionLoading(null);
     }
   }, []);
+
+  // ── Feature flag gate (BRO-393) ─────────────────────────────────────
+  if (!sandboxEnabled) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-xl font-semibold text-text-primary">Sandboxes</h1>
+          <p className="text-sm text-text-secondary mt-0.5">
+            Active execution environments managed by Arcan
+          </p>
+        </div>
+        <div className="rounded-lg border border-border bg-card">
+          <div className="flex flex-col items-center justify-center py-20 text-center text-text-secondary gap-3">
+            <BoxIcon className="size-10 opacity-30" />
+            <p className="text-sm font-medium">Sandbox access requires a plan upgrade</p>
+            <p className="text-xs text-text-muted max-w-xs">
+              Code execution sandboxes are available on Pro plans and above.
+              Upgrade to enable agent sandbox environments.
+            </p>
+            <a
+              href="/pricing"
+              className="mt-2 inline-flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              View Pricing
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/chat/app/.well-known/agent-configuration/route.ts
+++ b/apps/chat/app/.well-known/agent-configuration/route.ts
@@ -116,8 +116,12 @@ export async function GET() {
 
       // Life services (for agents that want to connect to the Agent OS)
       services: {
+        arcan: {
+          url: (process.env.ARCAN_URL || "https://arcan.la").trim(),
+          description: "Agent runtime daemon",
+        },
         lago: {
-          url: (process.env.LAGO_URL || "https://lago.broomva.tech").trim(),
+          url: (process.env.LAGO_URL || "https://api.lago.arcan.la").trim(),
           description: "Event-sourced persistence substrate",
         },
         autonomic: {

--- a/apps/chat/app/api/stripe/checkout/route.ts
+++ b/apps/chat/app/api/stripe/checkout/route.ts
@@ -58,8 +58,8 @@ export const POST = withAuthAndValidation(
             quantity: 1,
           },
         ],
-        success_url: `${appUrl}/settings/billing?checkout=success`,
-        cancel_url: `${appUrl}/settings/billing?checkout=cancel`,
+        success_url: `${appUrl}/console/billing?checkout=success`,
+        cancel_url: `${appUrl}/console/billing?checkout=cancel`,
         metadata: {
           organizationId,
           plan,

--- a/apps/chat/app/api/stripe/portal/route.ts
+++ b/apps/chat/app/api/stripe/portal/route.ts
@@ -42,7 +42,7 @@ export const POST = withAuthAndValidation(
 
       const portalSession = await getStripe().billingPortal.sessions.create({
         customer: org.stripeCustomerId,
-        return_url: `${appUrl}/settings/billing`,
+        return_url: `${appUrl}/console/billing`,
       });
 
       logAudit({

--- a/apps/chat/app/error.tsx
+++ b/apps/chat/app/error.tsx
@@ -6,11 +6,11 @@ import { useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
 
-export default function Error({
+export default function ErrorPage({
   error,
   reset,
 }: {
-  error: Error & { digest?: string };
+  error: globalThis.Error & { digest?: string };
   reset: () => void;
 }) {
   useEffect(() => {

--- a/apps/chat/app/error.tsx
+++ b/apps/chat/app/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import { useEffect } from "react";
+
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto p-6">
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <div className="space-y-4 text-center">
+            <div className="mx-auto flex size-12 items-center justify-center rounded-lg bg-destructive/15">
+              <svg
+                className="size-6 text-destructive"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+            </div>
+            <h1 className="font-semibold text-2xl text-foreground">
+              Something went wrong
+            </h1>
+            <p className="max-w-md text-muted-foreground">
+              An unexpected error occurred. Our team has been notified.
+            </p>
+            <div className="flex items-center justify-center gap-3 pt-2">
+              <Button onClick={reset}>Try Again</Button>
+              <Button variant="outline" asChild>
+                <Link href="/">Go Home</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/global-error.tsx
+++ b/apps/chat/app/global-error.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+          background: "oklch(0.12 0.02 275)",
+          color: "oklch(0.98 0 0)",
+          minHeight: "100vh",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            padding: "2rem",
+          }}
+        >
+          <div
+            style={{
+              maxWidth: "28rem",
+              textAlign: "center",
+            }}
+          >
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "3rem",
+                height: "3rem",
+                borderRadius: "12px",
+                background: "oklch(0.58 0.24 27 / 0.15)",
+                marginBottom: "1.5rem",
+              }}
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="oklch(0.58 0.24 27)"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+            </div>
+
+            <h1
+              style={{
+                fontSize: "1.5rem",
+                fontWeight: 600,
+                marginBottom: "0.5rem",
+                lineHeight: 1.2,
+              }}
+            >
+              Something went wrong
+            </h1>
+
+            <p
+              style={{
+                color: "oklch(0.50 0.02 275)",
+                marginBottom: "2rem",
+                lineHeight: 1.5,
+                fontSize: "0.938rem",
+              }}
+            >
+              An unexpected error occurred. Our team has been notified.
+            </p>
+
+            <div style={{ display: "flex", gap: "0.75rem", justifyContent: "center" }}>
+              <button
+                type="button"
+                onClick={reset}
+                style={{
+                  padding: "0.5rem 1.25rem",
+                  borderRadius: "8px",
+                  background: "oklch(0.60 0.12 260)",
+                  color: "oklch(0.98 0 0)",
+                  border: "1px solid oklch(0.60 0.12 260 / 0.4)",
+                  cursor: "pointer",
+                  fontWeight: 500,
+                  fontSize: "0.875rem",
+                  transition: "background 150ms ease, box-shadow 150ms ease",
+                }}
+                onMouseOver={(e) => {
+                  e.currentTarget.style.background = "oklch(0.65 0.14 260)";
+                  e.currentTarget.style.boxShadow = "0 0 24px oklch(0.60 0.12 260 / 0.20)";
+                }}
+                onMouseOut={(e) => {
+                  e.currentTarget.style.background = "oklch(0.60 0.12 260)";
+                  e.currentTarget.style.boxShadow = "none";
+                }}
+              >
+                Try Again
+              </button>
+              <a
+                href="/"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  padding: "0.5rem 1.25rem",
+                  borderRadius: "8px",
+                  background: "oklch(0.22 0.03 275)",
+                  color: "oklch(0.98 0 0)",
+                  textDecoration: "none",
+                  border: "1px solid oklch(0.40 0.02 275 / 0.50)",
+                  fontWeight: 500,
+                  fontSize: "0.875rem",
+                  transition: "background 150ms ease, border-color 150ms ease",
+                }}
+                onMouseOver={(e) => {
+                  e.currentTarget.style.background = "oklch(0.26 0.03 275)";
+                  e.currentTarget.style.borderColor = "oklch(0.50 0.02 275 / 0.60)";
+                }}
+                onMouseOut={(e) => {
+                  e.currentTarget.style.background = "oklch(0.22 0.03 275)";
+                  e.currentTarget.style.borderColor = "oklch(0.40 0.02 275 / 0.50)";
+                }}
+              >
+                Go Home
+              </a>
+            </div>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/chat/app/global-error.tsx
+++ b/apps/chat/app/global-error.tsx
@@ -115,6 +115,14 @@ export default function GlobalError({
                   e.currentTarget.style.background = "oklch(0.60 0.12 260)";
                   e.currentTarget.style.boxShadow = "none";
                 }}
+                onFocus={(e) => {
+                  e.currentTarget.style.background = "oklch(0.65 0.14 260)";
+                  e.currentTarget.style.boxShadow = "0 0 24px oklch(0.60 0.12 260 / 0.20)";
+                }}
+                onBlur={(e) => {
+                  e.currentTarget.style.background = "oklch(0.60 0.12 260)";
+                  e.currentTarget.style.boxShadow = "none";
+                }}
               >
                 Try Again
               </button>
@@ -138,6 +146,14 @@ export default function GlobalError({
                   e.currentTarget.style.borderColor = "oklch(0.50 0.02 275 / 0.60)";
                 }}
                 onMouseOut={(e) => {
+                  e.currentTarget.style.background = "oklch(0.22 0.03 275)";
+                  e.currentTarget.style.borderColor = "oklch(0.40 0.02 275 / 0.50)";
+                }}
+                onFocus={(e) => {
+                  e.currentTarget.style.background = "oklch(0.26 0.03 275)";
+                  e.currentTarget.style.borderColor = "oklch(0.50 0.02 275 / 0.60)";
+                }}
+                onBlur={(e) => {
                   e.currentTarget.style.background = "oklch(0.22 0.03 275)";
                   e.currentTarget.style.borderColor = "oklch(0.40 0.02 275 / 0.50)";
                 }}

--- a/apps/chat/hooks/use-feature-flag.ts
+++ b/apps/chat/hooks/use-feature-flag.ts
@@ -8,8 +8,8 @@
  */
 
 import { useFeatureFlagEnabled } from "posthog-js/react";
-import type { FeatureFlag } from "@/lib/feature-flags";
-import { getStaticFeatureFlag } from "@/lib/feature-flags";
+import type { FeatureFlag } from "@/lib/feature-flags-shared";
+import { getStaticFeatureFlag } from "@/lib/feature-flags-shared";
 
 /**
  * Returns true if the feature flag is enabled for the current user.

--- a/apps/chat/lib/db/usage.ts
+++ b/apps/chat/lib/db/usage.ts
@@ -1,7 +1,32 @@
 import "server-only";
 import { and, eq, gte, lte, sql } from "drizzle-orm";
 import { db } from "./client";
-import { usageEvent } from "./schema";
+import { organization, usageEvent } from "./schema";
+
+/**
+ * Atomically deduct credits from an organization's planCreditsRemaining.
+ * Returns true if the deduction succeeded (org had enough credits), false otherwise.
+ */
+export async function deductOrgCredits(
+  orgId: string,
+  amount: number,
+): Promise<boolean> {
+  const rows = await db
+    .update(organization)
+    .set({
+      planCreditsRemaining: sql`${organization.planCreditsRemaining} - ${amount}`,
+    })
+    .where(
+      and(
+        eq(organization.id, orgId),
+        sql`${organization.planCreditsRemaining} >= ${amount}`,
+      ),
+    )
+    .returning({ id: organization.id });
+
+  // If the WHERE guard failed (insufficient credits), no rows are returned
+  return rows.length > 0;
+}
 
 /**
  * Record a single usage event.

--- a/apps/chat/lib/feature-flags-shared.ts
+++ b/apps/chat/lib/feature-flags-shared.ts
@@ -1,0 +1,56 @@
+/**
+ * Feature flags — shared types and static fallbacks (client-safe)
+ *
+ * This file is safe to import from both client and server code.
+ * Server-only PostHog evaluation lives in feature-flags.ts.
+ */
+
+import { config } from "@/lib/config";
+
+// ── Flag name union ───────────────────────────────────────────────────────────
+
+/** All feature flags. Names match PostHog flag keys. */
+export type FeatureFlag =
+  // Existing features (mirrors chat.config.ts features.*)
+  | "sandbox"
+  | "web_search"
+  | "url_retrieval"
+  | "deep_research"
+  | "mcp"
+  | "image_generation"
+  | "attachments"
+  | "followup_suggestions"
+  | "knowledge_graph"
+  | "memory_vault"
+  | "agent_auth"
+  // New plan-gated flags
+  | "marketplace_enabled"
+  | "trust_api_enabled"
+  | "managed_deployments";
+
+// ── Static fallback map ───────────────────────────────────────────────────────
+
+const STATIC_FALLBACKS: Record<FeatureFlag, boolean> = {
+  sandbox: config.features.sandbox,
+  web_search: config.features.webSearch,
+  url_retrieval: config.features.urlRetrieval,
+  deep_research: config.features.deepResearch,
+  mcp: config.features.mcp,
+  image_generation: config.features.imageGeneration,
+  attachments: config.features.attachments,
+  followup_suggestions: config.features.followupSuggestions,
+  knowledge_graph: config.features.knowledgeGraph,
+  memory_vault: config.features.memoryVault,
+  agent_auth: config.features.agentAuth,
+  marketplace_enabled: false,
+  trust_api_enabled: false,
+  managed_deployments: false,
+};
+
+/**
+ * Get the static fallback for a flag without making a network request.
+ * Safe to use in client components.
+ */
+export function getStaticFeatureFlag(flag: FeatureFlag): boolean {
+  return STATIC_FALLBACKS[flag];
+}

--- a/apps/chat/lib/feature-flags.ts
+++ b/apps/chat/lib/feature-flags.ts
@@ -1,58 +1,20 @@
 /**
- * Feature flags — BRO-207
+ * Feature flags — BRO-207 (server-only)
  *
  * Runtime feature flags backed by PostHog with fallback to chat.config.ts.
  * PostHog flag names map 1:1 to the keys below.
  * Plan-tier targeting is configured in the PostHog dashboard using the
  * 'organization' group property 'plan'.
+ *
+ * Client components should import from feature-flags-shared.ts instead.
  */
 
 import { PostHog } from "posthog-node";
-import { config } from "@/lib/config";
+import { getStaticFeatureFlag } from "./feature-flags-shared";
 
-// ── Flag name union ───────────────────────────────────────────────────────────
-
-/** All feature flags. Names match PostHog flag keys. */
-export type FeatureFlag =
-  // Existing features (mirrors chat.config.ts features.*)
-  | "sandbox"
-  | "web_search"
-  | "url_retrieval"
-  | "deep_research"
-  | "mcp"
-  | "image_generation"
-  | "attachments"
-  | "followup_suggestions"
-  | "knowledge_graph"
-  | "memory_vault"
-  | "agent_auth"
-  // New plan-gated flags
-  | "marketplace_enabled"
-  | "trust_api_enabled"
-  | "managed_deployments";
-
-// ── Static fallback map ───────────────────────────────────────────────────────
-
-/**
- * Fallback values from chat.config.ts for when PostHog is unavailable.
- * New flags default to false until explicitly enabled in PostHog.
- */
-const STATIC_FALLBACKS: Record<FeatureFlag, boolean> = {
-  sandbox: config.features.sandbox,
-  web_search: config.features.webSearch,
-  url_retrieval: config.features.urlRetrieval,
-  deep_research: config.features.deepResearch,
-  mcp: config.features.mcp,
-  image_generation: config.features.imageGeneration,
-  attachments: config.features.attachments,
-  followup_suggestions: config.features.followupSuggestions,
-  knowledge_graph: config.features.knowledgeGraph,
-  memory_vault: config.features.memoryVault,
-  agent_auth: config.features.agentAuth,
-  marketplace_enabled: false,
-  trust_api_enabled: false,
-  managed_deployments: false,
-};
+// Re-export shared types and helpers so server-side callers can use a single import
+export type { FeatureFlag } from "./feature-flags-shared";
+export { getStaticFeatureFlag } from "./feature-flags-shared";
 
 // ── Server-side client ────────────────────────────────────────────────────────
 
@@ -82,25 +44,17 @@ function getServerPostHog(): PostHog | null {
  * @param groups - Optional group memberships, e.g. { organization: orgId }
  */
 export async function getServerFeatureFlag(
-  flag: FeatureFlag,
+  flag: Parameters<typeof getStaticFeatureFlag>[0],
   userId: string,
   groups?: Record<string, string>,
 ): Promise<boolean> {
   const ph = getServerPostHog();
-  if (!ph) return STATIC_FALLBACKS[flag];
+  if (!ph) return getStaticFeatureFlag(flag);
 
   try {
     const enabled = await ph.isFeatureEnabled(flag, userId, { groups });
-    return enabled ?? STATIC_FALLBACKS[flag];
+    return enabled ?? getStaticFeatureFlag(flag);
   } catch {
-    return STATIC_FALLBACKS[flag];
+    return getStaticFeatureFlag(flag);
   }
-}
-
-/**
- * Get the static fallback for a flag without making a network request.
- * Use this in non-async contexts or as a synchronous default.
- */
-export function getStaticFeatureFlag(flag: FeatureFlag): boolean {
-  return STATIC_FALLBACKS[flag];
 }


### PR DESCRIPTION
## Summary

Comprehensive platform validation audit identified 4 critical, 4 high, and 6 medium issues across billing, observability, and infrastructure layers. This PR addresses the critical and high-priority fixes:

- **BRO-393** (Critical): Wire PostHog feature flag enforcement in chat route — gate premium tools (`deepResearch`, `mcp`, `sandbox`, `imageGeneration`) by plan tier. Add `useFeatureFlag()` gates on console pages (marketplace, deployments, sandboxes)
- **BRO-394** (Critical): Fix org credit deduction — `planCreditsRemaining` now decremented per-request via atomic SQL. Pass `organizationId` to `recordUsageEvent()` for accurate org-level billing aggregation
- **BRO-397** (High): Update Lago fallback URLs from `lago.broomva.tech` to `api.lago.arcan.la`. Add `arcan` service entry to `/.well-known/agent-configuration` with `arcan.la` domain
- **BRO-398** (High): Add `global-error.tsx` (inline styles for root layout failures) and `error.tsx` (Tailwind) with Sentry error capture and recovery UI
- **BRO-399** (High): Fix Stripe checkout/portal redirect from `/settings/billing` to `/console/billing`

## Files Changed (14 files, +573/-41)

| File | Change |
|------|--------|
| `(chat)/api/chat/route.ts` | Feature flag gating for premium tools + org credit deduction + orgId threading |
| `lib/db/usage.ts` | New `deductOrgCredits()` atomic function |
| `(console)/console/marketplace/page.tsx` | `useFeatureFlag("marketplace_enabled")` gate |
| `(console)/console/deployments/page.tsx` | `useFeatureFlag("managed_deployments")` gate |
| `(console)/console/sandboxes/page.tsx` | `useFeatureFlag("sandbox")` gate |
| `.well-known/agent-configuration/route.ts` | Added arcan.la service, fixed lago URL |
| 4x Lago console pages | `lago.broomva.tech` → `api.lago.arcan.la` |
| `api/stripe/checkout/route.ts` | `/settings/billing` → `/console/billing` |
| `api/stripe/portal/route.ts` | Same redirect fix |
| `app/error.tsx` | New route-level error boundary with Sentry |
| `app/global-error.tsx` | New root error boundary with Sentry |

## Test plan

- [ ] Verify Vercel preview deployment builds successfully
- [ ] Verify free-tier user cannot access deep_research, MCP, sandbox tools (403 with upgrade message)
- [ ] Verify paid-tier user can access all tools
- [ ] Verify console pages show upgrade prompts for ungated features
- [ ] Verify org `planCreditsRemaining` decreases after chat requests
- [ ] Verify `UsageEvent` rows have `organizationId` populated
- [ ] Verify Stripe checkout redirects to `/console/billing` after success/cancel
- [ ] Verify error boundaries render on simulated errors
- [ ] Verify Lago console pages load with `api.lago.arcan.la` URLs
- [ ] Verify `/.well-known/agent-configuration` includes arcan.la service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-flag gating added for advanced tools, managed deployments, marketplace, and sandboxes; gated access now shows upgrade/ pricing prompts and explicit errors when attempting disabled tools.

* **Improvements**
  * Updated backend service endpoints for Lago and agent runtime fallbacks.
  * Stripe checkout and billing portal now redirect to the console billing dashboard.
  * New client-side global and route-specific error pages with automatic error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->