### PR TITLE
perf: optimize static asset delivery (CDN direct, WebP, cache headers)

### DIFF
--- a/apps/chat/components/site/prose-content.tsx
+++ b/apps/chat/components/site/prose-content.tsx
@@ -1,10 +1,39 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
 interface ProseContentProps {
   html: string;
 }
 
 export function ProseContent({ html }: ProseContentProps) {
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const imgs = ref.current.querySelectorAll<HTMLImageElement>(
+      "img[src^='/images/']"
+    );
+    for (const img of imgs) {
+      const src = img.getAttribute("src");
+      if (!src) continue;
+      const srcset = [640, 828, 1200]
+        .map(
+          (w) =>
+            `/_next/image?url=${encodeURIComponent(src)}&w=${w}&q=80 ${w}w`
+        )
+        .join(", ");
+      img.setAttribute("src", `/_next/image?url=${encodeURIComponent(src)}&w=1200&q=80`);
+      img.setAttribute("srcset", srcset);
+      img.setAttribute("sizes", "(max-width: 768px) 100vw, 800px");
+      img.setAttribute("loading", "lazy");
+      img.setAttribute("decoding", "async");
+    }
+  }, [html]);
+
   return (
     <article
+      ref={ref}
       className="prose prose-invert max-w-none prose-headings:font-display prose-headings:text-text-primary prose-a:text-ai-blue hover:prose-a:text-ai-blue/80 prose-strong:text-text-primary prose-table:w-full prose-table:border-collapse prose-table:text-sm prose-th:border prose-th:border-[var(--ag-border-default)] prose-th:bg-[var(--ag-bg-elevated)] prose-th:px-4 prose-th:py-2.5 prose-th:text-left prose-th:font-semibold prose-th:text-text-primary prose-td:border prose-td:border-[var(--ag-border-subtle)] prose-td:px-4 prose-td:py-2 prose-td:text-text-secondary prose-tr:transition-colors hover:prose-tr:bg-[var(--ag-bg-hover)] prose-code:rounded prose-code:bg-[var(--ag-bg-elevated)] prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[0.85em] prose-code:before:content-none prose-code:after:content-none prose-pre:rounded-xl prose-pre:border prose-pre:border-[var(--ag-border-subtle)] prose-pre:bg-[var(--ag-bg-dark)]"
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/apps/chat/lib/lago-assets.ts
+++ b/apps/chat/lib/lago-assets.ts
@@ -8,6 +8,7 @@
  */
 
 const LAGO_URL = process.env.LAGO_URL;
+const LAGO_ASSET_REWRITE = process.env.LAGO_ASSET_REWRITE === "true";
 
 /** Asset path prefixes that should be rewritten to Lago. */
 const REWRITABLE_PREFIXES = [
@@ -40,7 +41,7 @@ function isRewritable(path: string): boolean {
  * - The path is a brand/local-only asset
  */
 export function rewriteAssetUrl(path: string): string {
-  if (!LAGO_URL || !isRewritable(path)) {
+  if (!LAGO_ASSET_REWRITE || !LAGO_URL || !isRewritable(path)) {
     return path;
   }
   // Route through the Next.js proxy for edge caching
@@ -54,7 +55,7 @@ export function rewriteAssetUrl(path: string): string {
  * rewritable asset paths and replaces them with Lago proxy URLs.
  */
 export function rewriteAssetUrls(html: string): string {
-  if (!LAGO_URL) return html;
+  if (!LAGO_ASSET_REWRITE || !LAGO_URL) return html;
 
   // Match src="..." and href="..." with local asset paths
   return html.replace(
@@ -73,7 +74,7 @@ export function rewriteAssetUrls(html: string): string {
  * and HTML img tags within MDX.
  */
 export function rewriteMarkdownAssets(markdown: string): string {
-  if (!LAGO_URL) return markdown;
+  if (!LAGO_ASSET_REWRITE || !LAGO_URL) return markdown;
 
   // Markdown images: ![alt](/images/...)
   let result = markdown.replace(

--- a/apps/chat/next.config.ts
+++ b/apps/chat/next.config.ts
@@ -38,6 +38,24 @@ const nextConfig: NextConfig = {
         ],
       },
       {
+        source: "/images/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/audio/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
         source: "/api/:path*",
         headers: [
           {
@@ -73,6 +91,7 @@ const nextConfig: NextConfig = {
   },
   serverExternalPackages: ["pino", "pino-pretty"],
   images: {
+    formats: ["image/avif", "image/webp"],
     remotePatterns: [
       {
         hostname: "avatar.vercel.sh",


### PR DESCRIPTION
## Summary

Three optimizations for static asset delivery:

- **Disable Lago proxy rewrite**: Images/audio now serve directly from Vercel CDN instead of routing through `/api/assets/` serverless function → Lago manifest lookup (which was empty) → 302 redirect. Eliminates a serverless cold start per asset request. Re-enable later via `LAGO_ASSET_REWRITE=true`.
- **Enable AVIF/WebP**: Added `formats: ["image/avif", "image/webp"]` to Next.js image config. Updated `prose-content.tsx` to route inline article images through `/_next/image` for automatic format conversion, responsive `srcset`, and lazy loading.
- **Immutable cache headers**: Static `/images/*` and `/audio/*` paths now get `Cache-Control: public, max-age=31536000, immutable` — browsers cache for 1 year instead of `max-age=0, must-revalidate`.

### Before → After (per image request)
| | Before | After |
|---|---|---|
| Path | `/api/assets/images/...` → serverless → 302 → CDN | `/images/...` → CDN |
| Cold start | ~200ms serverless invocation | 0 |
| Format | PNG (500-800KB) | AVIF/WebP (~150-300KB) |
| Cache | `max-age=0` | `max-age=31536000, immutable` |

## Test plan
- [ ] Images render on all blog posts (CDN direct path)
- [ ] Audio player still works
- [ ] Check response headers on `/images/writing/cancer-pipeline-mini-pc/hero.png` for immutable cache
- [ ] Verify WebP delivery: `curl -H "Accept: image/webp" .../_next/image?url=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Images now load with responsive sizing and lazy loading optimization.
  * Added support for modern image formats (AVIF, WebP).

* **Performance Improvements**
  * Extended caching duration for images and audio files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->