### PR TITLE
fix: add jose to root deps for Lago sync pipeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@broomva/tech",
       "dependencies": {
+        "jose": "^6.2.2",
         "stripe": "^20.4.1",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "turbo": "^2.5.8"
   },
   "dependencies": {
+    "jose": "^6.2.2",
     "stripe": "^20.4.1"
   }
 }


### PR DESCRIPTION
## Summary

- Added `jose` (`^6.2.2`) to the root `package.json` dependencies
- `scripts/sync-assets-to-lago.ts` imports `SignJWT` from `jose` but runs from the repo root — Bun resolves packages relative to the script location, and `jose` was only in `apps/chat/package.json`
- Verified locally: script starts, signs JWT, connects to Lago, discovers 138 images + 44 audio files

## Root cause
The sync script at `scripts/sync-assets-to-lago.ts` is invoked as `bun scripts/sync-assets-to-lago.ts`. Bun resolves `jose` from `scripts/` → root `node_modules/` → not found. The package existed in `apps/chat/node_modules/` but that's not in the resolution path for root-level scripts.

## Test plan
- [ ] CI `Sync assets to Lago` job passes
- [ ] `bun install --frozen-lockfile` succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to support internal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->