### PR TITLE
fix: public /api/install endpoint + jose dep for Lago sync

### DIFF
--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -43,6 +43,7 @@ const PUBLIC_API_PREFIXES = [
   "/api/assets",
   "/api/graph/public",
   "/api/relay",
+  "/api/install",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@broomva/tech",
       "dependencies": {
+        "jose": "^6.2.2",
         "stripe": "^20.4.1",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "turbo": "^2.5.8"
   },
   "dependencies": {
+    "jose": "^6.2.2",
     "stripe": "^20.4.1"
   }
 }


### PR DESCRIPTION
## Summary
- **Add `/api/install` to public API prefixes** — the shell installer (`curl -fsSL https://broomva.tech/api/install | bash`) was redirecting to `/login` for unauthenticated users because the route wasn't in the proxy allowlist.
- **Add `jose` to root dependencies** — fixes Lago sync script import.

## Test plan
- [ ] Verify `curl -fsSL https://broomva.tech/api/install | bash` returns the shell script (not a login redirect) after deploy
- [ ] Verify authenticated routes still require login
- [ ] Verify Lago asset sync runs without missing `jose` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public installation endpoint is now available, enabling setup and configuration without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->