### PR TITLE
fix(chat): add generate:agent-knowledge to Vercel buildCommand

### DIFF
--- a/apps/chat/vercel.json
+++ b/apps/chat/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "bun install",
-  "buildCommand": "bun run generate:search-index && bun run vercel-build",
+  "buildCommand": "bun run generate:search-index && bun run generate:agent-knowledge && bun run vercel-build",
   "ignoreCommand": "npx turbo-ignore",
   "crons": [
     {


### PR DESCRIPTION
## Summary

Production deploy of #83 is missing \`public/agent-knowledge.json\` because \`apps/chat/vercel.json\`'s \`buildCommand\` explicitly runs \`generate:search-index\` but not its sibling \`generate:agent-knowledge\`. The \`prebuild\` hook in \`package.json\` chains both, but Vercel bypasses that hook when \`buildCommand\` is set.

Verified live on broomva.tech just now: \`curl https://broomva.tech/agent-knowledge.json\` → 404 while \`/search-index.json\` → 200.

Symptom: the agent on \`/\` and \`/chat\` falls back to Layer 2 (Live Index) for every question that needs retrieval. Tested with "Tell me about the agentic control loop essay" — the agent couldn't find it (it's not in the latest-3) and listed only the 3 most-recent writing posts from the Live Index. \`searchKnowledge\` / \`readKnowledgeNote\` / \`traverseKnowledge\` are all silently no-op in production.

## Change

```diff
-  "buildCommand": "bun run generate:search-index && bun run vercel-build",
+  "buildCommand": "bun run generate:search-index && bun run generate:agent-knowledge && bun run vercel-build",
```

## Test plan

- [x] Local: run the new build chain — both JSONs generated (search 49 KB, knowledge 2.1 MB)
- [ ] CI: validate job green
- [ ] Vercel preview: \`curl <preview>/agent-knowledge.json\` → 200
- [ ] Post-merge: \`curl https://broomva.tech/agent-knowledge.json\` → 200 and retest Q2/Q3 on the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->