### PR TITLE
fix(chat): robust agent-knowledge loader + gate traverseKnowledge

### DIFF
--- a/apps/chat/app/(chat)/api/chat/route.ts
+++ b/apps/chat/app/(chat)/api/chat/route.ts
@@ -321,7 +321,7 @@ const FLAG_GATED_TOOLS: Partial<Record<FeatureFlag, ToolName[]>> = {
   image_generation: ["generateImage"],
   web_search: ["webSearch"],
   url_retrieval: ["retrieveUrl"],
-  knowledge_graph: ["searchKnowledge", "readKnowledgeNote"],
+  knowledge_graph: ["searchKnowledge", "readKnowledgeNote", "traverseKnowledge"],
 };
 
 /** The feature flags that gate premium chat tools. */
@@ -376,6 +376,8 @@ function getToolGateUpgradeMessage(toolName: ToolName): string {
       "Knowledge graph search requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
     readKnowledgeNote:
       "Knowledge graph access requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
+    traverseKnowledge:
+      "Knowledge graph traversal requires a Pro plan or higher. Upgrade at /pricing to unlock this feature.",
   };
   return (
     messages[toolName] ??

--- a/apps/chat/lib/ai/knowledge/site-content.ts
+++ b/apps/chat/lib/ai/knowledge/site-content.ts
@@ -35,8 +35,36 @@ let _warned = false;
 
 let _sourcePath: string | null = null;
 
-function defaultSourcePath(): string {
-  return path.join(process.cwd(), "public", "agent-knowledge.json");
+/**
+ * Candidate filesystem paths to try (in order), to be robust across:
+ *   • local dev (CWD = apps/chat)
+ *   • monorepo dev (CWD = repo root)
+ *   • Vercel serverless runtime (CWD = /var/task, with outputFileTracingIncludes)
+ */
+function candidateFilesystemPaths(): string[] {
+  return [
+    path.join(process.cwd(), "public", "agent-knowledge.json"),
+    path.join(process.cwd(), "apps", "chat", "public", "agent-knowledge.json"),
+    // Module-relative fallback (webpack will rewrite __dirname at build)
+    path.join(__dirname, "..", "..", "..", "public", "agent-knowledge.json"),
+  ];
+}
+
+/** Resolve the self-origin URL for fetch-based loading (production fallback). */
+function selfOriginUrl(): string | null {
+  // Explicit override (set in env or future build-time config)
+  const explicit = process.env.AGENT_KNOWLEDGE_URL;
+  if (explicit) return explicit;
+
+  // Vercel sets VERCEL_URL to the deployment's own domain (without protocol)
+  const vercelUrl = process.env.VERCEL_URL;
+  if (vercelUrl) return `https://${vercelUrl}/agent-knowledge.json`;
+
+  // Production site URL if exposed
+  const siteUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXT_PUBLIC_SITE_URL;
+  if (siteUrl) return `${siteUrl.replace(/\/$/, "")}/agent-knowledge.json`;
+
+  return null;
 }
 
 /** Test-only: override the JSON path for fixture-based unit tests. */
@@ -52,25 +80,79 @@ export function resetKnowledgeCacheForTests(): void {
 
 // ── Loader ───────────────────────────────────────────────────────────────────
 
+async function readFromFilesystem(paths: string[]): Promise<{ raw: string; path: string } | null> {
+  for (const p of paths) {
+    try {
+      const raw = await fs.readFile(p, "utf8");
+      return { raw, path: p };
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+async function readFromFetch(url: string): Promise<{ raw: string; path: string } | null> {
+  try {
+    const res = await fetch(url, { cache: "force-cache" });
+    if (!res.ok) return null;
+    const raw = await res.text();
+    return { raw, path: url };
+  } catch {
+    return null;
+  }
+}
+
 export async function loadAgentKnowledge(): Promise<AgentKnowledge> {
   if (_cache) return _cache;
 
-  const source = _sourcePath ?? defaultSourcePath();
-  try {
-    const raw = await fs.readFile(source, "utf8");
-    _cache = JSON.parse(raw) as AgentKnowledge;
-    return _cache;
-  } catch (err) {
-    if (!_warned) {
-      log.warn(
-        { err, source },
-        "agent-knowledge.json missing or unparseable — falling back to empty knowledge",
-      );
-      _warned = true;
+  // Test override: a single explicit path, no fallbacks.
+  if (_sourcePath) {
+    try {
+      const raw = await fs.readFile(_sourcePath, "utf8");
+      _cache = JSON.parse(raw) as AgentKnowledge;
+      return _cache;
+    } catch (err) {
+      if (!_warned) {
+        log.warn({ err, source: _sourcePath }, "test source unreadable");
+        _warned = true;
+      }
+      _cache = EMPTY_KNOWLEDGE;
+      return _cache;
     }
-    _cache = EMPTY_KNOWLEDGE;
-    return _cache;
   }
+
+  // Production/dev: try filesystem candidates first, then fall back to fetch.
+  const fsPaths = candidateFilesystemPaths();
+  let loaded = await readFromFilesystem(fsPaths);
+
+  if (!loaded) {
+    const url = selfOriginUrl();
+    if (url) loaded = await readFromFetch(url);
+  }
+
+  if (loaded) {
+    try {
+      _cache = JSON.parse(loaded.raw) as AgentKnowledge;
+      log.debug({ source: loaded.path, docs: _cache.documents.length }, "agent-knowledge loaded");
+      return _cache;
+    } catch (err) {
+      if (!_warned) {
+        log.warn({ err, source: loaded.path }, "agent-knowledge parse failed");
+        _warned = true;
+      }
+    }
+  }
+
+  if (!_warned) {
+    log.warn(
+      { cwd: process.cwd(), fsPaths, fetchUrl: selfOriginUrl() },
+      "agent-knowledge.json unreachable via filesystem or fetch — falling back to empty knowledge",
+    );
+    _warned = true;
+  }
+  _cache = EMPTY_KNOWLEDGE;
+  return _cache;
 }
 
 // ── Search ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

End-to-end testing on production revealed two issues in the PR #83 / #84 chain. Both surface when the agent tries to answer from the knowledge graph and silently returns empty results.

### 1. Loader path resolution (main bug)

On Vercel, \`/agent-knowledge.json\` is served correctly as a static asset (verified: 200 OK, 2.1 MB, commit \`09a550cd\`). But the serverless function couldn't \`fs.readFile\` it from \`process.cwd() + "public/agent-knowledge.json"\` in the monorepo layout, even with \`outputFileTracingIncludes\` set.

Symptom: \`searchKnowledge\` / \`readKnowledgeNote\` / \`traverseKnowledge\` all return no results. Agent falls back to Layer 2 (Live Index) for everything. Reproduced: asked "Call readKnowledgeNote with name \"agentic-control-loop\"" — agent reported not found for a slug that IS in the index.

Fix: the loader now tries three filesystem candidates in order, then falls back to \`fetch()\` against the site's own origin (\`VERCEL_URL\` / \`NEXT_PUBLIC_APP_URL\` / \`NEXT_PUBLIC_SITE_URL\` / explicit \`AGENT_KNOWLEDGE_URL\`). The static asset is already published and cacheable, so fetch is cheap. Logs the resolved source on success and the full candidate list on failure so Langfuse/OTel can surface the miss reason.

### 2. Feature-flag gating consistency

\`traverseKnowledge\` was registered as a tool (in tools.ts, tools-definitions.ts, types.ts) but missing from \`FLAG_GATED_TOOLS.knowledge_graph\` and the \`getToolGateUpgradeMessage\` map in the chat route. Consequence: on deployments where \`searchKnowledge\`/\`readKnowledgeNote\` are gated off, \`traverseKnowledge\` stayed available — inconsistent and a small privilege-escalation surface. Code review missed this. Now all three gate together.

## Test plan

- [x] \`bunx vitest run lib/ai/knowledge/site-content.test.ts\` — 15/15 pass
- [x] \`bun test:types\` — clean
- [ ] CI validate green
- [ ] Production smoke: ask agent "Call readKnowledgeNote with name 'agentic-control-loop'" → expect a successful fetch with frontmatter + body excerpt
- [ ] Production smoke: ask agent "What's connected to the Life Agent OS project?" → expect \`traverseKnowledge\` returns ≥3 neighbors with hop info

🤖 Generated with [Claude Code](https://claude.com/claude-code)