### PR TITLE
chore(chat): allow /api/debug in public prefix

### DIFF
--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -44,6 +44,7 @@ const PUBLIC_API_PREFIXES = [
   "/api/graph/public",
   "/api/relay",
   "/api/install",
+  "/api/debug",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */


### PR DESCRIPTION
Follow-up to #86 — the debug endpoint is being redirected to /login because it's not in the PUBLIC_API_PREFIXES list. Adding it so we can actually read the loader diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)