### PR TITLE
fix(chat): expose knowledge graph tools to anonymous users

### DIFF
--- a/apps/chat/chat.config.ts
+++ b/apps/chat/chat.config.ts
@@ -136,7 +136,12 @@ const config = {
   },
   anonymous: {
     credits: isProd ? 10 : 1000,
-    availableTools: [],
+    // The Arcan agent's whole purpose on broomva.tech is to surface the open
+    // knowledge graph to anyone who interacts with it, signed in or not.
+    // These three tools read public data (public/agent-knowledge.json generated
+    // at build time) and never write state or cost external APIs, so they're
+    // safe to expose anonymously.
+    availableTools: ["searchKnowledge", "readKnowledgeNote", "traverseKnowledge"],
     rateLimit: {
       requestsPerMinute: isProd ? 5 : 60,
       requestsPerMonth: isProd ? 10 : 1000,


### PR DESCRIPTION
## Root cause found via /api/debug/knowledge

End-to-end testing on production broomva.tech revealed the Arcan agent was saying "I can't call readKnowledgeNote from this chat instance — I don't have access to the live knowledge-tooling here." even though the server-side helpers all work correctly.

The debug endpoint confirmed:
- Loader works — 92 docs, 331 nodes, 460 edges loaded from `/var/task/apps/chat/public/agent-knowledge.json`
- `readSiteNote("agentic-control-loop")` returns the correct note
- `searchSiteContent("agentic control loop")` returns 5 ranked results (target #1, score 14)
- `traverseFrom("tag:agent-os")` returns 10 neighbors

But when asked to call `readKnowledgeNote` from the chat, the model reports "I don't have that tool." Earlier responses claiming "I called searchKnowledge and found nothing" were hallucinations.

Found it in `chat.config.ts:139`:

```ts
anonymous: {
  credits: isProd ? 10 : 1000,
  availableTools: [],  // ← THIS
  rateLimit: { ... },
},
```

Anonymous users get zero tools. Signed-in users get all tools minus gated ones. The whole point of the Arcan agent on broomva.tech is to surface the open knowledge graph to everyone — the three knowledge tools read only `public/agent-knowledge.json` (a build artifact of already-published content), never write state, never cost external APIs. They're safe anonymous.

## Change

```ts
availableTools: ["searchKnowledge", "readKnowledgeNote", "traverseKnowledge"],
```

## Test plan

- [x] `bun test:types` clean
- [ ] CI validate green
- [ ] Post-merge: ask anon visitor "Call readKnowledgeNote with name agentic-control-loop and quote the first section heading" → expect "## The Illusion of Competence" (proves tool actually ran)
- [ ] Follow-up: the debug endpoint `/api/debug/knowledge` should be gated behind admin auth or removed once the agent is verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anonymous chat users can now access knowledge-graph tools within the chat interface, including the ability to search knowledge bases, read knowledge notes, and traverse knowledge structures.

* **Configuration Changes**
  * Updated chat configuration to enable knowledge-graph tools for anonymous users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->