### PR TITLE
fix(chat): null-safe tool header rendering + bump anon credits

### DIFF
--- a/apps/chat/chat.config.ts
+++ b/apps/chat/chat.config.ts
@@ -135,7 +135,9 @@ const config = {
     },
   },
   anonymous: {
-    credits: isProd ? 10 : 1000,
+    // Enough for a meaningful conversation on the public agent — visitors
+    // shouldn't hit the credit wall mid-discussion. Each message costs 1.
+    credits: isProd ? 50 : 1000,
     // The Arcan agent's whole purpose on broomva.tech is to surface the open
     // knowledge graph to anyone who interacts with it, signed in or not.
     // These three tools read public data (public/agent-knowledge.json generated
@@ -144,7 +146,7 @@ const config = {
     availableTools: ["searchKnowledge", "readKnowledgeNote", "traverseKnowledge"],
     rateLimit: {
       requestsPerMinute: isProd ? 5 : 60,
-      requestsPerMonth: isProd ? 10 : 1000,
+      requestsPerMonth: isProd ? 50 : 1000,
     },
   },
   authenticated: {

--- a/apps/chat/components/ai-elements/extra/mcp-tool-header.tsx
+++ b/apps/chat/components/ai-elements/extra/mcp-tool-header.tsx
@@ -33,7 +33,7 @@ export const McpToolHeader = ({
     <div className="flex items-center gap-2">
       {icon ?? <WrenchIcon className="size-4 text-muted-foreground" />}
       <span className="font-medium text-sm">
-        {title ?? type.split("-").slice(1).join("-")}
+        {title ?? (typeof type === "string" ? type.split("-").slice(1).join("-") : "")}
       </span>
       {getStatusBadge(state)}
     </div>

--- a/apps/chat/components/ai-elements/tool.tsx
+++ b/apps/chat/components/ai-elements/tool.tsx
@@ -82,7 +82,7 @@ export const ToolHeader = ({
     <div className="flex items-center gap-2">
       <WrenchIcon className="size-4 text-muted-foreground" />
       <span className="font-medium text-sm">
-        {title ?? type.split("-").slice(1).join("-")}
+        {title ?? (typeof type === "string" ? type.split("-").slice(1).join("-") : "")}
       </span>
       {getStatusBadge(state)}
     </div>


### PR DESCRIPTION
## Root cause

**"undefined is not an object (evaluating 'e.split')"** on iOS Safari comes from `components/ai-elements/tool.tsx:85` and `mcp-tool-header.tsx:36`:

```tsx
{title ?? type.split("-").slice(1).join("-")}
```

`type` is assumed to always be a string. For a mid-stream `ToolUIPart` where `type` hasn't been set yet — or when an error payload from `/api/chat` gets funneled into the tool-render path — `type` is undefined and Safari throws `undefined is not an object (evaluating 'e.split')`. Chrome/Firefox would say `Cannot read properties of undefined (reading 'split')`.

## Compounding issue: anon credit wall

The 403s visible in the Vercel logs just before the banner appeared are credit-exhausted responses. `chat.config.ts` had `anonymous.credits: 10` in prod — tight enough that regular users hit the wall after ~10 messages on a public agent. The HTTP error surfaces through the same render path as the Safari bug, so the user sees "Something went wrong" with the split error.

## Fix

1. Guard `type.split()` with a typeof check in both `ToolHeader` variants. Malformed parts render as an empty header instead of crashing the whole message.
2. Bump `anonymous.credits` (and monthly rate cap) from 10 → 50. Visitors should get a meaningful conversation before hitting the wall.

## Test plan

- [x] `bun test:types` — clean
- [ ] CI validate green
- [ ] Production smoke: send a multi-turn conversation on Mobile Safari (incognito) — no banner errors
- [ ] Production smoke: verify anon user can send ≥ 10 messages without a 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool rendering to safely display tools with non-standard data formats, preventing display errors

* **Configuration Updates**
  * Increased anonymous user limits in production: agent credits raised to 50 (from 10) and monthly request limit to 50 (from 10)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->