### PR TITLE
feat(life): /life/[project] — three-column agent workspace (Life Interface port)

### DIFF
--- a/apps/chat/app/(site)/life/[project]/not-found.tsx
+++ b/apps/chat/app/(site)/life/[project]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function ProjectNotFound() {
+  return (
+    <div className="life-landing">
+      <div className="life-landing__inner life-landing__notfound">
+        <h1>Project not found</h1>
+        <p>
+          Only the seeded demo projects (sentinel, materiales) are available
+          today. User-created projects ship in Phase C.
+        </p>
+        <Link href="/life" className="life-landing__card-cta">
+          ◂ Back to /life
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/[project]/page.tsx
+++ b/apps/chat/app/(site)/life/[project]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { LifeShell } from "../_components/LifeShell";
 import { isProjectSlug, PROJECTS } from "../_lib/project-map";
 
 export async function generateStaticParams() {
@@ -29,17 +30,12 @@ export default async function LifeProjectPage({
   if (!isProjectSlug(project)) notFound();
   const info = PROJECTS[project];
 
-  // LifeShell mounts in a follow-up commit.
   return (
-    <div className="life-landing">
-      <div className="life-landing__inner">
-        <div className="life-landing__eyebrow">{info.eyebrow}</div>
-        <h1 className="life-landing__title">{info.displayName}</h1>
-        <p className="life-landing__sub">
-          The full three-column workspace mounts in the next commit. This stub
-          confirms the dynamic route + project map are wired correctly.
-        </p>
-      </div>
-    </div>
+    <LifeShell
+      projectSlug={project}
+      scenarioId={info.scenarioId}
+      displayName={info.displayName}
+      eyebrow={info.eyebrow}
+    />
   );
 }

--- a/apps/chat/app/(site)/life/[project]/page.tsx
+++ b/apps/chat/app/(site)/life/[project]/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { isProjectSlug, PROJECTS } from "../_lib/project-map";
+
+export async function generateStaticParams() {
+  return Object.keys(PROJECTS).map((project) => ({ project }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ project: string }>;
+}): Promise<Metadata> {
+  const { project } = await params;
+  if (!isProjectSlug(project)) return { title: "Project not found" };
+  const info = PROJECTS[project];
+  return {
+    title: info.displayName,
+    description: `Life agent workspace for ${info.eyebrow}.`,
+  };
+}
+
+export default async function LifeProjectPage({
+  params,
+}: {
+  params: Promise<{ project: string }>;
+}) {
+  const { project } = await params;
+  if (!isProjectSlug(project)) notFound();
+  const info = PROJECTS[project];
+
+  // LifeShell mounts in a follow-up commit.
+  return (
+    <div className="life-landing">
+      <div className="life-landing__inner">
+        <div className="life-landing__eyebrow">{info.eyebrow}</div>
+        <h1 className="life-landing__title">{info.displayName}</h1>
+        <p className="life-landing__sub">
+          The full three-column workspace mounts in the next commit. This stub
+          confirms the dynamic route + project map are wired correctly.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/AgentStatus.tsx
+++ b/apps/chat/app/(site)/life/_components/AgentStatus.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReplayState } from "../_lib/types";
+
+interface Props {
+  running: boolean;
+  state: ReplayState;
+}
+
+export function AgentStatus({ running, state }: Props) {
+  const last = state.messages[state.messages.length - 1];
+  let label = "Idle";
+  if (running) {
+    if (last?.streamingThinking) label = "Arcan · thinking";
+    else if ((last?.tools || []).some((t) => t.status === "running"))
+      label = "Arcan · executing tool";
+    else if (last?.streamingText) label = "Arcan · streaming";
+    else label = "Arcan · ticking";
+  }
+  const tick = (state.t / 1000).toFixed(1);
+  return (
+    <div className={`agent-status ${running ? "" : "agent-status--idle"}`}>
+      <span className="agent-status__pulse" />
+      <span>{label}</span>
+      <span style={{ marginLeft: "auto", color: "var(--ag-text-muted)" }}>
+        tick · {tick}s
+      </span>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/AnimaPane.tsx
+++ b/apps/chat/app/(site)/life/_components/AnimaPane.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { LIFE_ANIMA } from "../_lib/mock-workspace";
+
+export function AnimaPane() {
+  const a = LIFE_ANIMA;
+  return (
+    <div className="right-pane">
+      <div
+        className="row"
+        style={{ justifyContent: "space-between", marginBottom: 10 }}
+      >
+        <div className="eyebrow">Anima · identity</div>
+        <span className="pill pill--accent">{a.tier}</span>
+      </div>
+      <div
+        className="gauge"
+        style={{ display: "flex", gap: 12, alignItems: "center" }}
+      >
+        <div className="anima-avatar" style={{ width: 54, height: 54 }} />
+        <div>
+          <div style={{ fontFamily: "var(--ag-font-heading)", fontSize: 18 }}>
+            {a.name}
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--ag-font-mono)",
+              fontSize: 10.5,
+              color: "var(--ag-text-muted)",
+            }}
+          >
+            {a.soul}
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--ag-font-mono)",
+              fontSize: 10.5,
+              color: "var(--ag-text-muted)",
+            }}
+          >
+            {a.did}
+          </div>
+        </div>
+      </div>
+      <div className="section">Beliefs (active)</div>
+      {a.beliefs.map((b) => (
+        <div
+          key={b}
+          className="judge-card"
+          style={{ fontSize: 12, marginTop: 6 }}
+        >
+          <div style={{ color: "var(--ag-text-primary)", lineHeight: 1.55 }}>
+            {b}
+          </div>
+        </div>
+      ))}
+      <div className="section">Trust vector</div>
+      {Object.entries(a.trust).map(([k, v]) => (
+        <div className="judge-card" key={k} style={{ marginTop: 6 }}>
+          <div className="judge-card__head">
+            <div
+              style={{
+                fontFamily: "var(--ag-font-mono)",
+                fontSize: 11.5,
+                color: "var(--ag-text-secondary)",
+              }}
+            >
+              {k}
+            </div>
+            <div
+              style={{ fontFamily: "var(--ag-font-heading)", fontSize: 14 }}
+            >
+              {v.toFixed(2)}
+            </div>
+          </div>
+          <div className="bar">
+            <div
+              className="bar__fill"
+              style={{ width: `${v * 100}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/AnimaPopover.tsx
+++ b/apps/chat/app/(site)/life/_components/AnimaPopover.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { LIFE_ANIMA } from "../_lib/mock-workspace";
+
+interface Props {
+  onClose: () => void;
+}
+
+export function AnimaPopover({ onClose }: Props) {
+  const a = LIFE_ANIMA;
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close Anima popover"
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 50,
+          background: "transparent",
+          border: 0,
+          cursor: "default",
+        }}
+      />
+      <div
+        style={{
+          position: "fixed",
+          top: 58,
+          left: 16,
+          width: 360,
+          zIndex: 51,
+          padding: 16,
+          border: "1px solid var(--ag-border-default)",
+          borderRadius: 14,
+          background:
+            "color-mix(in oklab, var(--ag-bg-surface) 78%, transparent)",
+          backdropFilter: "blur(20px) saturate(1.4) brightness(1.05)",
+          boxShadow:
+            "inset 0 1px 0 oklch(1 0 0 / 0.06), var(--ag-shadow-xl)",
+        }}
+      >
+        <div className="row" style={{ gap: 12, marginBottom: 12 }}>
+          <div className="anima-avatar" style={{ width: 46, height: 46 }} />
+          <div>
+            <div style={{ fontFamily: "var(--ag-font-heading)", fontSize: 16 }}>
+              {a.name}
+            </div>
+            <div
+              className="mono"
+              style={{ fontSize: 10.5, color: "var(--ag-text-muted)" }}
+            >
+              {a.soul}
+            </div>
+          </div>
+          <span className="pill pill--accent" style={{ marginLeft: "auto" }}>
+            {a.tier}
+          </span>
+        </div>
+        <div
+          className="mono"
+          style={{
+            fontSize: 11,
+            color: "var(--ag-text-secondary)",
+            marginBottom: 8,
+          }}
+        >
+          {a.did}
+        </div>
+        <div
+          className="mono"
+          style={{
+            fontSize: 10.5,
+            color: "var(--ag-text-muted)",
+            marginBottom: 12,
+          }}
+        >
+          session · {a.session}
+        </div>
+        <div className="eyebrow" style={{ marginBottom: 6 }}>
+          Beliefs
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            lineHeight: 1.55,
+            color: "var(--ag-text-secondary)",
+          }}
+        >
+          {a.beliefs.slice(0, 3).map((b) => (
+            <div key={b} style={{ padding: "4px 0" }}>
+              · {b}
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/AutonomicPane.tsx
+++ b/apps/chat/app/(site)/life/_components/AutonomicPane.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { LIFE_HOMEO } from "../_lib/mock-workspace";
+
+interface ArcProps {
+  label: string;
+  value: number;
+  target: number;
+  sub: string;
+}
+
+function HomeoArc({ label, value, target, sub }: ArcProps) {
+  const r = 42;
+  const C = 2 * Math.PI * r;
+  const pct = Math.min(1, value);
+  const color =
+    value >= target * 0.95
+      ? "oklch(0.78 0.15 155)"
+      : value >= target * 0.7
+        ? "oklch(0.87 0.18 85)"
+        : "oklch(0.72 0.20 27)";
+  return (
+    <div>
+      <div className="homeo-arc">
+        <svg viewBox="0 0 110 110" width="110" height="110">
+          <title>{label}</title>
+          <circle
+            cx="55"
+            cy="55"
+            r={r}
+            fill="none"
+            stroke="oklch(0.22 0.03 275)"
+            strokeWidth="8"
+          />
+          <circle
+            cx="55"
+            cy="55"
+            r={r}
+            fill="none"
+            stroke={color}
+            strokeWidth="8"
+            strokeLinecap="round"
+            strokeDasharray={`${pct * C} ${C}`}
+            transform="rotate(-90 55 55)"
+            style={{
+              filter: `drop-shadow(0 0 6px ${color})`,
+              transition: "stroke-dasharray 500ms ease",
+            }}
+          />
+          <text
+            x="55"
+            y="58"
+            textAnchor="middle"
+            fontFamily="var(--ag-font-heading)"
+            fontSize="20"
+            fill="oklch(0.98 0 0)"
+          >
+            {(value * 100).toFixed(0)}
+          </text>
+          <text
+            x="55"
+            y="72"
+            textAnchor="middle"
+            fontFamily="var(--ag-font-mono)"
+            fontSize="9"
+            fill="oklch(0.50 0.02 275)"
+          >
+            / {(target * 100).toFixed(0)}
+          </text>
+        </svg>
+      </div>
+      <div className="homeo-label">{label}</div>
+      <div className="homeo-val">{sub}</div>
+    </div>
+  );
+}
+
+const SETPOINTS = [
+  { k: "pass_at_1", v: "1.00", t: "≥ 0.90", good: true },
+  { k: "shield_intervention_rate", v: "0.03", t: "≤ 0.10", good: true },
+  { k: "retry_rate", v: "0.08", t: "≤ 0.30", good: true },
+  { k: "revert_rate", v: "0.02", t: "≤ 0.08", good: true },
+  { k: "human_intervention_rate", v: "0.18", t: "≤ 0.35", good: true },
+];
+
+export function AutonomicPane() {
+  const h = LIFE_HOMEO;
+  return (
+    <div className="right-pane">
+      <div
+        className="row"
+        style={{ justifyContent: "space-between", marginBottom: 8 }}
+      >
+        <div className="eyebrow">Autonomic · three pillars</div>
+        <span className="pill">mode · Autonomous</span>
+      </div>
+      <div className="gauge-grid gauge-grid--3" style={{ padding: 6 }}>
+        <HomeoArc label="Operational" {...h.operational} />
+        <HomeoArc label="Cognitive" {...h.cognitive} />
+        <HomeoArc label="Economic" {...h.economic} />
+      </div>
+      <div className="section">Setpoints</div>
+      {SETPOINTS.map((r) => (
+        <div className="judge-card" key={r.k} style={{ marginTop: 6 }}>
+          <div className="judge-card__head">
+            <div
+              style={{
+                fontFamily: "var(--ag-font-mono)",
+                fontSize: 11.5,
+                color: "var(--ag-text-secondary)",
+              }}
+            >
+              {r.k}
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--ag-font-heading)",
+                fontSize: 14,
+                color: r.good
+                  ? "oklch(0.78 0.15 155)"
+                  : "oklch(0.87 0.18 85)",
+              }}
+            >
+              {r.v}
+            </div>
+          </div>
+          <div
+            style={{
+              fontFamily: "var(--ag-font-mono)",
+              fontSize: 10,
+              color: "var(--ag-text-muted)",
+              marginTop: 2,
+            }}
+          >
+            target {r.t}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/ChatColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/ChatColumn.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useRef } from "react";
+import type { ReplayState } from "../_lib/types";
+import { AgentStatus } from "./AgentStatus";
+import { ChatComposer } from "./ChatComposer";
+import { ChatMessage } from "./ChatMessage";
+
+interface Props {
+  state: ReplayState;
+  setState: Dispatch<SetStateAction<ReplayState>>;
+  running: boolean;
+  toolHighlight: string | null;
+  setToolHighlight: (id: string | null) => void;
+}
+
+export function ChatColumn({
+  state,
+  setState,
+  running,
+  toolHighlight,
+  setToolHighlight,
+}: Props) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-scroll on any text/tool change.
+  // Build a cheap dependency string so we re-run on token-level updates too.
+  const scrollDep = state.messages
+    .map(
+      (m) =>
+        (m.text || "").length +
+        (m.thinking || "").length +
+        (m.tools || []).length,
+    )
+    .join(",");
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [scrollDep]);
+
+  const toggleThinking = (id: string) => {
+    setState((s) => ({
+      ...s,
+      messages: s.messages.map((m) =>
+        m.id === id ? { ...m, thinkingOpen: !m.thinkingOpen } : m,
+      ),
+    }));
+  };
+
+  return (
+    <div className="col col--chat">
+      <div className="col__header">
+        <div className="row" style={{ gap: 10 }}>
+          <span className="eyebrow">Chat · Arcan</span>
+          <span className="pill">mock</span>
+        </div>
+        <div className="row" style={{ gap: 4 }}>
+          <button
+            type="button"
+            className="btn btn--ghost btn--icon"
+            title="New session"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            className="btn btn--ghost btn--icon"
+            title="Sessions"
+          >
+            ☰
+          </button>
+        </div>
+      </div>
+      <div className="chat-scroll" ref={scrollRef}>
+        {state.messages.length === 0 && (
+          <div
+            style={{
+              padding: "80px 12px",
+              textAlign: "center",
+              color: "var(--ag-text-muted)",
+              fontSize: 12,
+              lineHeight: 1.7,
+            }}
+          >
+            <div className="eyebrow" style={{ marginBottom: 10 }}>
+              Session
+            </div>
+            <div
+              style={{
+                fontFamily: "var(--ag-font-heading)",
+                fontSize: 18,
+                color: "var(--ag-text-primary)",
+                letterSpacing: "-0.01em",
+                marginBottom: 10,
+              }}
+            >
+              What are we making today?
+            </div>
+            <div>
+              Arcan is wired to your workspace — filesystem, Lago journal, Nous,
+              Autonomic, Haima.
+            </div>
+          </div>
+        )}
+        {state.messages.map((m) => (
+          <ChatMessage
+            key={m.id}
+            message={m}
+            toolHighlight={toolHighlight}
+            setToolHighlight={setToolHighlight}
+            onToggleThinking={toggleThinking}
+            running={running}
+          />
+        ))}
+      </div>
+      <AgentStatus running={running} state={state} />
+      <ChatComposer />
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/ChatComposer.tsx
+++ b/apps/chat/app/(site)/life/_components/ChatComposer.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+
+export function ChatComposer() {
+  const [v, setV] = useState("");
+  return (
+    <div className="composer">
+      <textarea
+        className="composer__input"
+        placeholder="Ask Arcan anything. Shift+Enter for newline."
+        value={v}
+        onChange={(e) => setV(e.target.value)}
+      />
+      <div className="composer__footer">
+        <div className="row" style={{ gap: 10 }}>
+          <span>claude-haiku-4-5</span>
+          <span>·</span>
+          <span>praxis · 14 tools</span>
+          <span>·</span>
+          <span>ctx 68%</span>
+        </div>
+        <div className="composer__actions">
+          <button type="button" className="btn btn--ghost">
+            @attach
+          </button>
+          <button type="button" className="btn btn--ghost">
+            /slash
+          </button>
+          <button type="button" className="btn btn--primary">
+            Send ⏎
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/ChatMessage.tsx
+++ b/apps/chat/app/(site)/life/_components/ChatMessage.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import type { LifeMessage } from "../_lib/types";
+import { ThinkingBlock } from "./ThinkingBlock";
+import { ToolCallBlock } from "./ToolCallBlock";
+
+interface Props {
+  message: LifeMessage;
+  toolHighlight: string | null;
+  setToolHighlight: (id: string | null) => void;
+  onToggleThinking: (id: string) => void;
+  running: boolean;
+}
+
+// TODO: replace renderMarkdownLite with `streamdown` (already a dep) for
+// production-grade streaming markdown. Until then this is a tiny inline
+// renderer for the mock-replay scenarios that ship trusted strings only.
+function renderMarkdownLite(text: string): React.ReactNode[] {
+  if (!text) return [];
+  const parts: { kind: "p" | "pre"; s: string }[] = [];
+  const fence = /```([\s\S]*?)```/g;
+  let i = 0;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: classic regex loop
+  while ((m = fence.exec(text))) {
+    if (m.index > i) parts.push({ kind: "p", s: text.slice(i, m.index) });
+    parts.push({ kind: "pre", s: m[1] ?? "" });
+    i = fence.lastIndex;
+  }
+  if (i < text.length) parts.push({ kind: "p", s: text.slice(i) });
+
+  return parts.map((part, idx) => {
+    if (part.kind === "pre") {
+      return <pre key={`pre-${idx}-${part.s.length}`}>{part.s}</pre>;
+    }
+    const html = part.s
+      .replace(/`([^`]+)`/g, "<code>$1</code>")
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/\n/g, "<br/>");
+    return (
+      <span
+        key={`p-${idx}-${part.s.length}`}
+        // Mock-replay strings only — no untrusted user input reaches here.
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: trusted mock
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  });
+}
+
+export function ChatMessage({
+  message,
+  toolHighlight,
+  setToolHighlight,
+  onToggleThinking,
+  running,
+}: Props) {
+  const [openTools, setOpenTools] = useState<Record<string, boolean>>({});
+
+  return (
+    <div className={`msg msg--${message.role}`}>
+      <div className="msg__role">
+        <span className="swatch" />
+        {message.role === "user" ? "YOU" : "ARCAN"}
+      </div>
+      <div className="msg__body">
+        {message.thinking && (
+          <ThinkingBlock
+            text={message.thinking}
+            open={message.thinkingOpen ?? false}
+            streaming={message.streamingThinking}
+            onToggle={() => onToggleThinking(message.id)}
+          />
+        )}
+        {(message.tools || []).map((tool) => (
+          <ToolCallBlock
+            key={tool.id}
+            tool={tool}
+            highlighted={toolHighlight === tool.id}
+            onClick={() => setToolHighlight(tool.id)}
+            open={!!openTools[tool.id]}
+            onToggle={() =>
+              setOpenTools((o) => ({ ...o, [tool.id]: !o[tool.id] }))
+            }
+          />
+        ))}
+        <div>
+          {renderMarkdownLite(message.text)}
+          {message.streamingText && running && <span className="caret" />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/Constellation.tsx
+++ b/apps/chat/app/(site)/life/_components/Constellation.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type { ReplayState } from "../_lib/types";
+
+interface Props {
+  state: ReplayState;
+  lastOpTs: number;
+}
+
+const MODULES = [
+  { id: "arcan", x: 0.28, y: 0.45, label: "arcan", color: "oklch(0.60 0.12 260)" },
+  { id: "lago", x: 0.7, y: 0.32, label: "lago", color: "oklch(0.78 0.15 155)" },
+  {
+    id: "autonomic",
+    x: 0.78,
+    y: 0.72,
+    label: "autonomic",
+    color: "oklch(0.65 0.14 235)",
+  },
+  { id: "anima", x: 0.18, y: 0.75, label: "anima", color: "oklch(0.70 0.15 300)" },
+  { id: "nous", x: 0.48, y: 0.18, label: "nous", color: "oklch(0.87 0.18 85)" },
+] as const;
+
+const W = 900;
+const H = 480;
+
+export function Constellation({ state, lastOpTs }: Props) {
+  const ops = state.fsOps.slice(-16);
+  const lastOp = ops[ops.length - 1];
+  const opPos = ops.map((o, i) => {
+    const mod = MODULES.find((m) => o.path.includes(m.id)) ?? MODULES[0];
+    const ang = (i * 0.87 + 0.2) % (Math.PI * 2);
+    const rad = 60 + (i % 3) * 22;
+    return {
+      o,
+      mod,
+      x: mod.x * W + Math.cos(ang) * rad,
+      y: mod.y * H + Math.sin(ang) * rad,
+      fresh: o === lastOp && Date.now() - lastOpTs < 1500,
+    };
+  });
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      style={{ width: "100%", height: "100%" }}
+      preserveAspectRatio="xMidYMid slice"
+    >
+      <title>Filesystem constellation</title>
+      <defs>
+        <radialGradient id="modGlow" cx="0.5" cy="0.5" r="0.5">
+          <stop offset="0%" stopColor="oklch(0.60 0.12 260 / 0.45)" />
+          <stop offset="100%" stopColor="oklch(0.60 0.12 260 / 0)" />
+        </radialGradient>
+      </defs>
+      {MODULES.map((m) => (
+        <circle
+          key={`orb-${m.id}`}
+          cx={m.x * W}
+          cy={m.y * H}
+          r="90"
+          fill="none"
+          stroke="oklch(0.40 0.02 275 / 0.2)"
+          strokeDasharray="2 6"
+        />
+      ))}
+      {MODULES.map((m, i) =>
+        MODULES.slice(i + 1).map((n) => (
+          <line
+            key={`link-${m.id}-${n.id}`}
+            x1={m.x * W}
+            y1={m.y * H}
+            x2={n.x * W}
+            y2={n.y * H}
+            stroke="oklch(0.40 0.02 275 / 0.15)"
+            strokeWidth="1"
+          />
+        )),
+      )}
+      {MODULES.map((m) => (
+        <g key={m.id} transform={`translate(${m.x * W} ${m.y * H})`}>
+          <circle r="38" fill="url(#modGlow)" />
+          <circle
+            r="18"
+            fill="oklch(0.17 0.03 275)"
+            stroke={m.color}
+            strokeWidth="1.5"
+            style={{ filter: `drop-shadow(0 0 6px ${m.color})` }}
+          />
+          <text
+            y="4"
+            textAnchor="middle"
+            fill="oklch(0.98 0 0)"
+            fontFamily="var(--ag-font-heading)"
+            fontSize="12"
+          >
+            {m.label}
+          </text>
+        </g>
+      ))}
+      {opPos.map((p) => (
+        <g key={p.o.id}>
+          <line
+            x1={p.mod.x * W}
+            y1={p.mod.y * H}
+            x2={p.x}
+            y2={p.y}
+            stroke={p.fresh ? p.mod.color : "oklch(0.40 0.02 275 / 0.35)"}
+            strokeWidth={p.fresh ? 1.5 : 0.8}
+          />
+          <circle
+            cx={p.x}
+            cy={p.y}
+            r={p.fresh ? 8 : 4}
+            fill={
+              p.o.op === "read"
+                ? "oklch(0.26 0.03 275)"
+                : p.o.op === "create"
+                  ? "oklch(0.78 0.15 155)"
+                  : p.mod.color
+            }
+            stroke={p.mod.color}
+            strokeWidth="1"
+            style={
+              p.fresh
+                ? { filter: `drop-shadow(0 0 8px ${p.mod.color})` }
+                : undefined
+            }
+          />
+          {p.fresh && (
+            <text
+              x={p.x + 10}
+              y={p.y + 3}
+              fontFamily="var(--ag-font-mono)"
+              fontSize="9.5"
+              fill="oklch(0.98 0 0)"
+            >
+              {p.o.path.split("/").pop()}
+            </text>
+          )}
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/Dock.tsx
+++ b/apps/chat/app/(site)/life/_components/Dock.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReplayState } from "../_lib/types";
+
+interface Props {
+  state: ReplayState;
+}
+
+export function Dock({ state }: Props) {
+  const events = state.journal.length;
+  const tools = (state.journal || []).filter(
+    (e) => e.kind === "tool" && e.label === "TOOL",
+  ).length;
+  const ctx = 68;
+  return (
+    <div className="dock">
+      <div className="dock__group">
+        <span className="dock__item">
+          <span className="dock__dot" /> <strong>Arcan</strong> :3000
+        </span>
+        <span className="dock__item">
+          <span className="dock__dot" /> <strong>Lago</strong> :8080
+        </span>
+        <span className="dock__item">
+          <span className="dock__dot" /> <strong>Autonomic</strong> :3002
+        </span>
+        <span className="dock__item">
+          <span className="dock__dot" /> <strong>Haima</strong> :3003
+        </span>
+        <span className="dock__item">
+          <span className="dock__dot dock__dot--warn" />{" "}
+          <strong>Nous</strong> :3004
+        </span>
+      </div>
+      <div className="dock__group">
+        <span className="dock__item">
+          events <strong>{events}</strong>
+        </span>
+        <span className="dock__item">
+          tool calls <strong>{tools}</strong>
+        </span>
+        <span className="dock__item">
+          ctx <strong>{ctx}%</strong>
+        </span>
+        <span className="dock__item">v0.9.2</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/ExperimentalCanvas.tsx
+++ b/apps/chat/app/(site)/life/_components/ExperimentalCanvas.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import type { ReplayState, TweaksState } from "../_lib/types";
+import { ChatColumn } from "./ChatColumn";
+import { Constellation } from "./Constellation";
+import { MiddleColumn } from "./MiddleColumn";
+import { RightColumn } from "./RightColumn";
+
+interface Props {
+  state: ReplayState;
+  setState: Dispatch<SetStateAction<ReplayState>>;
+  running: boolean;
+  tweaks: TweaksState;
+  setTweaks: (patch: Partial<TweaksState>) => void;
+  toolHighlight: string | null;
+  setToolHighlight: (id: string | null) => void;
+  lastOpTs: number;
+}
+
+export function ExperimentalCanvas({
+  state,
+  setState,
+  running,
+  tweaks,
+  setTweaks,
+  toolHighlight,
+  setToolHighlight,
+  lastOpTs,
+}: Props) {
+  return (
+    <div className="col col--experimental" style={{ position: "relative" }}>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "grid",
+          gridTemplateColumns: "360px 1fr",
+          gap: 14,
+          padding: 14,
+        }}
+      >
+        <div
+          className="ag-glass"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            borderRadius: 16,
+          }}
+        >
+          <ChatColumn
+            state={state}
+            setState={setState}
+            running={running}
+            setToolHighlight={setToolHighlight}
+            toolHighlight={toolHighlight}
+          />
+        </div>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateRows: "1fr 1fr",
+            gap: 14,
+          }}
+        >
+          <div
+            className="ag-glass"
+            style={{
+              position: "relative",
+              overflow: "hidden",
+              borderRadius: 16,
+            }}
+          >
+            <div
+              style={{
+                position: "absolute",
+                top: 10,
+                left: 14,
+                zIndex: 2,
+              }}
+            >
+              <span className="eyebrow">Filesystem · live constellation</span>
+            </div>
+            <Constellation state={state} lastOpTs={lastOpTs} />
+          </div>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 14,
+            }}
+          >
+            <div
+              className="ag-glass"
+              style={{
+                overflow: "hidden",
+                borderRadius: 16,
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <div
+                style={{
+                  padding: "10px 14px",
+                  borderBottom: "1px solid var(--ag-border-subtle)",
+                }}
+              >
+                <span className="eyebrow">Journal · stream</span>
+              </div>
+              <div style={{ flex: 1, overflow: "hidden" }}>
+                <MiddleColumn
+                  mode="journal"
+                  setMode={() => {}}
+                  state={state}
+                  toolHighlight={toolHighlight}
+                  setToolHighlight={setToolHighlight}
+                  fsStyle="heartbeat"
+                  journalRich={false}
+                  lastOpTs={lastOpTs}
+                />
+              </div>
+            </div>
+            <div
+              className="ag-glass"
+              style={{
+                overflow: "hidden",
+                borderRadius: 16,
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <div
+                style={{
+                  padding: "10px 14px",
+                  borderBottom: "1px solid var(--ag-border-subtle)",
+                }}
+              >
+                <span className="eyebrow">Inspector · {tweaks.rightMode}</span>
+              </div>
+              <div style={{ flex: 1, overflow: "hidden" }}>
+                <RightColumn
+                  mode={tweaks.rightMode}
+                  setMode={(m) => setTweaks({ rightMode: m })}
+                  state={state}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/FileTree.tsx
+++ b/apps/chat/app/(site)/life/_components/FileTree.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { LIFE_FS } from "../_lib/mock-workspace";
+import type { FsStyle, LifeFsNode, LifeFsOp } from "../_lib/types";
+
+interface Props {
+  fsOps: LifeFsOp[];
+  fsStyle: FsStyle;
+  lastOpTs: number;
+}
+
+interface FlatRow extends LifeFsNode {
+  depth: number;
+  op?: { op: string; path: string; childOnly?: boolean };
+  isExpanded: boolean;
+}
+
+function flattenTree(
+  tree: LifeFsNode[],
+  opsByPath: Record<string, { op: string; path: string; childOnly?: boolean }>,
+  expanded: Record<string, boolean>,
+  depth = 0,
+  out: FlatRow[] = [],
+): FlatRow[] {
+  for (const node of tree) {
+    const op = opsByPath[node.path];
+    out.push({
+      ...node,
+      depth,
+      op,
+      isExpanded: expanded[node.path] !== false,
+    });
+    if (
+      node.type === "dir" &&
+      expanded[node.path] !== false &&
+      node.children
+    ) {
+      flattenTree(node.children, opsByPath, expanded, depth + 1, out);
+    }
+  }
+  return out;
+}
+
+export function FileTree({ fsOps, fsStyle, lastOpTs }: Props) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const opsByPath = useMemo(() => {
+    const m: Record<string, { op: string; path: string; childOnly?: boolean }> =
+      {};
+    for (const o of fsOps) m[o.path] = { op: o.op, path: o.path };
+    for (const p of Object.keys(m)) {
+      const parts = p.split("/");
+      for (let i = parts.length - 1; i > 0; i--) {
+        const parent = parts.slice(0, i).join("/");
+        if (!m[parent]) {
+          m[parent] = { op: "touched", path: parent, childOnly: true };
+        }
+      }
+    }
+    return m;
+  }, [fsOps]);
+
+  // Auto-expand directories whose children have ops.
+  useEffect(() => {
+    setExpanded((prev) => {
+      const next = { ...prev };
+      for (const o of fsOps) {
+        const parts = o.path.split("/");
+        for (let i = 1; i < parts.length; i++) {
+          next[parts.slice(0, i).join("/")] = true;
+        }
+      }
+      return next;
+    });
+  }, [fsOps]);
+
+  const rows = flattenTree(LIFE_FS.tree, opsByPath, expanded);
+  const toggle = (p: string) =>
+    setExpanded((e) => ({ ...e, [p]: e[p] === false ? true : false }));
+
+  const lastOp = fsOps[fsOps.length - 1];
+  const isRecent = (path: string) =>
+    !!lastOp && lastOp.path === path && Date.now() - lastOpTs < 1400;
+
+  const writingPaths = fsOps
+    .filter((o) => o.op === "write" || o.op === "create")
+    .slice(-1)
+    .map((o) => o.path);
+
+  return (
+    <div className="filetree">
+      <div className="filetree__sect">Workspace · /workspace</div>
+      {rows.map((row) => {
+        const badge = row.op && !row.op.childOnly ? row.op.op : null;
+        const writing =
+          (fsStyle === "heartbeat" || fsStyle === "shimmer") &&
+          writingPaths.includes(row.path) &&
+          row.type === "file";
+        const pulsing =
+          (fsStyle === "heartbeat" || fsStyle === "finder") &&
+          isRecent(row.path) &&
+          row.type === "file";
+        const isActive =
+          row.op?.op === "write" || row.op?.op === "create";
+        return (
+          <div
+            key={row.path}
+            className={`fnode ${isActive ? "is-active" : ""} ${
+              writing && fsStyle === "shimmer" ? "is-writing" : ""
+            } ${pulsing ? "is-pulsing" : ""}`}
+            style={{ paddingLeft: 10 + row.depth * 14 }}
+            onClick={() => row.type === "dir" && toggle(row.path)}
+            onKeyDown={(e) => {
+              if (
+                (e.key === "Enter" || e.key === " ") &&
+                row.type === "dir"
+              ) {
+                e.preventDefault();
+                toggle(row.path);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            <span className="fnode__chev">
+              {row.type === "dir" ? (row.isExpanded ? "▾" : "▸") : ""}
+            </span>
+            <span className="fnode__icon">
+              {row.type === "dir" ? "▨" : "◻"}
+            </span>
+            <span className="fnode__name">{row.path.split("/").pop()}</span>
+            {badge === "write" && (
+              <span className="fnode__badge fnode__badge--mod">mod</span>
+            )}
+            {badge === "create" && (
+              <span className="fnode__badge fnode__badge--add">new</span>
+            )}
+            {badge === "read" && (
+              <span className="fnode__badge fnode__badge--read">read</span>
+            )}
+            {badge === "delete" && (
+              <span className="fnode__badge fnode__badge--del">del</span>
+            )}
+          </div>
+        );
+      })}
+      {fsStyle === "ticker" && (
+        <>
+          <div className="filetree__sect" style={{ marginTop: 16 }}>
+            Recent ops
+          </div>
+          {fsOps
+            .slice(-8)
+            .reverse()
+            .map((o) => (
+              <div
+                key={o.id}
+                className="fnode"
+                style={{ fontSize: 11 }}
+              >
+                <span
+                  className={`fnode__badge fnode__badge--${
+                    o.op === "read" ? "read" : o.op === "create" ? "add" : "mod"
+                  }`}
+                >
+                  {o.op}
+                </span>
+                <span style={{ color: "var(--ag-text-secondary)" }}>
+                  {o.path}
+                </span>
+              </div>
+            ))}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/HaimaPane.tsx
+++ b/apps/chat/app/(site)/life/_components/HaimaPane.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { LIFE_HAIMA } from "../_lib/mock-workspace";
+
+export function HaimaPane() {
+  const h = LIFE_HAIMA;
+  const pct = h.session_spend / h.session_budget;
+  return (
+    <div className="right-pane">
+      <div
+        className="row"
+        style={{ justifyContent: "space-between", marginBottom: 8 }}
+      >
+        <div className="eyebrow">Haima · circulatory</div>
+        <span className="pill">x402</span>
+      </div>
+      <div className="gauge">
+        <div className="gauge__label">Session spend</div>
+        <div className="gauge__value">
+          ${h.session_spend.toFixed(2)}{" "}
+          <span style={{ color: "var(--ag-text-muted)", fontSize: 13 }}>
+            / ${h.session_budget.toFixed(2)}
+          </span>
+        </div>
+        <div className="bar">
+          <div
+            className={`bar__fill ${pct > 0.85 ? "bar__fill--warn" : ""}`}
+            style={{ width: `${pct * 100}%` }}
+          />
+        </div>
+        <div className="gauge__sub" style={{ marginTop: 8 }}>
+          burn rate · $0.012 / min · eta ~48m to ceiling
+        </div>
+      </div>
+      <div className="gauge-grid" style={{ marginTop: 12 }}>
+        <div className="gauge">
+          <div className="gauge__label">Tokens in</div>
+          <div className="gauge__value">{h.tokens_in.toLocaleString()}</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">Tokens out</div>
+          <div className="gauge__value">{h.tokens_out.toLocaleString()}</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">x402 txs</div>
+          <div className="gauge__value">{h.x402_txs}</div>
+          <div className="gauge__sub">{h.last_pay}</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">Wallet</div>
+          <div
+            className="gauge__value"
+            style={{ fontSize: 13, fontFamily: "var(--ag-font-mono)" }}
+          >
+            0x9f4…b21
+          </div>
+          <div className="gauge__sub">secp256k1 · haima</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/Journal.tsx
+++ b/apps/chat/app/(site)/life/_components/Journal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Fragment, useEffect, useRef, useState } from "react";
+import type { LifeJournalEntry } from "../_lib/types";
+
+interface Props {
+  events: LifeJournalEntry[];
+  rich: boolean;
+  highlight: string | null;
+  setHighlight: (id: string | null) => void;
+}
+
+export function Journal({ events, rich, highlight, setHighlight }: Props) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    if (scrollRef.current)
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [events.length]);
+  return (
+    <div
+      className={`journal ${rich ? "journal--rich" : ""}`}
+      ref={scrollRef}
+    >
+      {events.length === 0 && (
+        <div
+          style={{
+            padding: 24,
+            color: "var(--ag-text-muted)",
+            fontSize: 11.5,
+            textAlign: "center",
+          }}
+        >
+          <div className="eyebrow" style={{ marginBottom: 8 }}>
+            Lago · journal
+          </div>
+          Events from the current tick will stream here.
+        </div>
+      )}
+      {events.map((e) => {
+        const isOpen = !!open[e.id];
+        const hl = !!highlight && e.linkToolId === highlight;
+        return (
+          <Fragment key={e.id}>
+            <div
+              className={`journal__row ${isOpen ? "is-open" : ""} ${
+                hl ? "is-highlighted" : ""
+              }`}
+              onClick={() => {
+                setOpen((o) => ({ ...o, [e.id]: !o[e.id] }));
+                if (e.linkToolId) setHighlight(e.linkToolId);
+              }}
+              onKeyDown={(ev) => {
+                if (ev.key === "Enter" || ev.key === " ") {
+                  ev.preventDefault();
+                  setOpen((o) => ({ ...o, [e.id]: !o[e.id] }));
+                  if (e.linkToolId) setHighlight(e.linkToolId);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <span className="journal__ts">{e.ts}</span>
+              <span className={`journal__kind journal__kind--${e.kind}`}>
+                {e.label}
+              </span>
+              <span className="journal__msg">
+                <span className="journal__actor">{e.actor}</span> · {e.msg}
+              </span>
+              <span style={{ color: "var(--ag-text-muted)", fontSize: 10 }}>
+                ▾
+              </span>
+            </div>
+            {isOpen && <div className="journal__payload">{e.payload}</div>}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/KnowledgeGraph.tsx
+++ b/apps/chat/app/(site)/life/_components/KnowledgeGraph.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useMemo } from "react";
+import { LIFE_GRAPH } from "../_lib/mock-workspace";
+
+const W = 600;
+const H = 480;
+
+export function KnowledgeGraph() {
+  const { nodes, edges } = LIFE_GRAPH;
+  const pos = useMemo(() => {
+    const m: Record<string, { x: number; y: number }> = {};
+    for (const n of nodes) m[n.id] = { x: n.x * W, y: n.y * H };
+    return m;
+  }, [nodes]);
+
+  return (
+    <div className="graph-wrap">
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="xMidYMid meet">
+        <title>Lago knowledge graph</title>
+        <defs>
+          <radialGradient id="nglow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0%" stopColor="oklch(0.60 0.12 260 / 0.7)" />
+            <stop offset="100%" stopColor="oklch(0.60 0.12 260 / 0)" />
+          </radialGradient>
+          <radialGradient id="nglowFresh" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0%" stopColor="oklch(0.65 0.14 235 / 0.9)" />
+            <stop offset="100%" stopColor="oklch(0.65 0.14 235 / 0)" />
+          </radialGradient>
+        </defs>
+        {edges.map((e) => {
+          const a = pos[e.a];
+          const b = pos[e.b];
+          if (!a || !b) return null;
+          return (
+            <line
+              key={`${e.a}-${e.b}`}
+              x1={a.x}
+              y1={a.y}
+              x2={b.x}
+              y2={b.y}
+              stroke={
+                e.fresh
+                  ? "oklch(0.65 0.14 235 / 0.6)"
+                  : "oklch(0.40 0.02 275 / 0.45)"
+              }
+              strokeWidth={e.fresh ? 1.5 : 1}
+              strokeDasharray={e.fresh ? "none" : "3 3"}
+            />
+          );
+        })}
+        {nodes.map((n) => {
+          const p = pos[n.id];
+          if (!p) return null;
+          return (
+            <g key={n.id} transform={`translate(${p.x} ${p.y})`}>
+              <circle
+                r={n.r + 10}
+                fill={n.fresh ? "url(#nglowFresh)" : "url(#nglow)"}
+              />
+              <circle
+                r={n.r}
+                fill={
+                  n.kind === "paper"
+                    ? "oklch(0.65 0.14 235 / 0.3)"
+                    : n.kind === "artifact"
+                      ? "oklch(0.70 0.15 300 / 0.25)"
+                      : "oklch(0.22 0.03 275)"
+                }
+                stroke={
+                  n.fresh
+                    ? "oklch(0.65 0.14 235)"
+                    : "oklch(0.50 0.02 275 / 0.7)"
+                }
+                strokeWidth={n.fresh ? 1.5 : 1}
+              />
+              <text
+                y={n.r + 14}
+                textAnchor="middle"
+                fill="oklch(0.70 0.02 275)"
+                fontSize="10"
+                fontFamily="var(--ag-font-mono)"
+                style={{ letterSpacing: "0.03em" }}
+              >
+                {n.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <div className="graph-legend">
+        <span>
+          <i style={{ background: "oklch(0.65 0.14 235)" }} /> paper
+        </span>
+        <span>
+          <i
+            style={{
+              background: "oklch(0.22 0.03 275)",
+              border: "1px solid oklch(0.50 0.02 275)",
+            }}
+          />{" "}
+          concept
+        </span>
+        <span>
+          <i style={{ background: "oklch(0.70 0.15 300 / 0.5)" }} /> artifact
+        </span>
+        <span>
+          <i
+            style={{
+              background: "oklch(0.65 0.14 235)",
+              boxShadow: "0 0 6px oklch(0.65 0.14 235)",
+            }}
+          />{" "}
+          new this tick
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/LifeShell.tsx
+++ b/apps/chat/app/(site)/life/_components/LifeShell.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { SCENARIO_LABELS, SCENARIOS } from "../_lib/scenarios";
+import {
+  DEFAULT_TWEAKS,
+  readTweaks,
+  writeTweaks,
+} from "../_lib/tweaks";
+import type { ScenarioId, TweaksState } from "../_lib/types";
+import { useReplay } from "../_lib/use-replay";
+import { AnimaPopover } from "./AnimaPopover";
+import { ChatColumn } from "./ChatColumn";
+import { Dock } from "./Dock";
+import { ExperimentalCanvas } from "./ExperimentalCanvas";
+import { MiddleColumn } from "./MiddleColumn";
+import { RightColumn } from "./RightColumn";
+import { Topbar } from "./Topbar";
+import { TweaksPanel } from "./TweaksPanel";
+
+interface Props {
+  projectSlug: string;
+  scenarioId: ScenarioId;
+  displayName: string;
+  eyebrow: string;
+}
+
+function usePersistedTweaks(initialScenario: ScenarioId): {
+  tweaks: TweaksState;
+  setTweaks: (patch: Partial<TweaksState>) => void;
+} {
+  // Default the in-memory tweaks to the project's scenario; localStorage,
+  // if present, overrides — but we hydrate on mount so the SSR snapshot
+  // matches DEFAULT_TWEAKS for the first render.
+  const [tweaks, setTweaksState] = useState<TweaksState>({
+    ...DEFAULT_TWEAKS,
+    scenario: initialScenario,
+  });
+
+  useEffect(() => {
+    const stored = readTweaks();
+    setTweaksState({ ...stored, scenario: initialScenario });
+    // Only run once on mount per project — if the user changes projects the
+    // dynamic route remounts the shell.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const setTweaks = useCallback((patch: Partial<TweaksState>) => {
+    setTweaksState((prev) => {
+      const next = { ...prev, ...patch };
+      writeTweaks(next);
+      return next;
+    });
+  }, []);
+
+  return { tweaks, setTweaks };
+}
+
+export function LifeShell({
+  projectSlug,
+  scenarioId,
+  displayName,
+  eyebrow,
+}: Props) {
+  const { tweaks, setTweaks } = usePersistedTweaks(scenarioId);
+  const [tweaksOpen, setTweaksOpen] = useState(false);
+  const [animaOpen, setAnimaOpen] = useState(false);
+
+  const script = useMemo(
+    () => SCENARIOS[tweaks.scenario] ?? SCENARIOS.refactor,
+    [tweaks.scenario],
+  );
+
+  const [playing, setPlaying] = useState<boolean>(tweaks.autoplay);
+  // When the user changes scenario in tweaks, restart the clock.
+  useEffect(() => {
+    setPlaying(tweaks.autoplay);
+  }, [tweaks.scenario, tweaks.autoplay]);
+
+  const [state, setState] = useReplay(script, playing);
+
+  // Cross-link highlight between chat tool calls and journal rows.
+  const [toolHighlight, setToolHighlight] = useState<string | null>(null);
+  useEffect(() => {
+    if (!toolHighlight) return;
+    const t = setTimeout(() => setToolHighlight(null), 2200);
+    return () => clearTimeout(t);
+  }, [toolHighlight]);
+
+  // Track last fs op timestamp for pulse animations.
+  const [lastOpTs, setLastOpTs] = useState(0);
+  useEffect(() => {
+    if (state.fsOps.length) setLastOpTs(Date.now());
+  }, [state.fsOps.length]);
+
+  const running =
+    playing &&
+    state.messages.length > 0 &&
+    state.messages.some(
+      (m) =>
+        m.streamingText ||
+        m.streamingThinking ||
+        (m.tools || []).some((t) => t.status === "running"),
+    );
+
+  // Hotkey: ⌘. or Ctrl+. toggles tweaks panel.
+  const tweaksHotkeyRef = useRef(setTweaksOpen);
+  tweaksHotkeyRef.current = setTweaksOpen;
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === ".") {
+        e.preventDefault();
+        tweaksHotkeyRef.current((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const setMiddleMode = useCallback(
+    (m: TweaksState["middleMode"]) => setTweaks({ middleMode: m }),
+    [setTweaks],
+  );
+  const setRightMode = useCallback(
+    (m: TweaksState["rightMode"]) => setTweaks({ rightMode: m }),
+    [setTweaks],
+  );
+
+  const crumb = {
+    brand: "broomva.tech",
+    project: `${projectSlug} — ${displayName.split(" — ")[1] ?? displayName}`,
+    scenarioLabel: SCENARIO_LABELS[tweaks.scenario],
+  };
+
+  const rootClass = `life-shell-root ${tweaks.orbs ? "life-shell-root--orbs" : ""}`;
+
+  return (
+    <div className={rootClass} data-project={projectSlug} data-eyebrow={eyebrow}>
+      <div
+        className={`shell ${tweaks.layout === "experimental" ? "shell--experimental" : ""}`}
+      >
+        <Topbar
+          setAnimaOpen={(fn) => setAnimaOpen(fn(animaOpen))}
+          tweaks={tweaks}
+          setTweaks={setTweaks}
+          playing={playing}
+          setPlaying={setPlaying}
+          crumb={crumb}
+        />
+        {tweaks.layout === "classic" ? (
+          <>
+            <ChatColumn
+              state={state}
+              setState={setState}
+              running={running}
+              setToolHighlight={setToolHighlight}
+              toolHighlight={toolHighlight}
+            />
+            <MiddleColumn
+              mode={tweaks.middleMode}
+              setMode={setMiddleMode}
+              state={state}
+              toolHighlight={toolHighlight}
+              setToolHighlight={setToolHighlight}
+              fsStyle={tweaks.fsStyle}
+              journalRich={tweaks.journalRich}
+              lastOpTs={lastOpTs}
+            />
+            <RightColumn
+              mode={tweaks.rightMode}
+              setMode={setRightMode}
+              state={state}
+            />
+          </>
+        ) : (
+          <ExperimentalCanvas
+            state={state}
+            setState={setState}
+            running={running}
+            tweaks={tweaks}
+            setTweaks={setTweaks}
+            toolHighlight={toolHighlight}
+            setToolHighlight={setToolHighlight}
+            lastOpTs={lastOpTs}
+          />
+        )}
+        <Dock state={state} />
+      </div>
+
+      {animaOpen && <AnimaPopover onClose={() => setAnimaOpen(false)} />}
+
+      <TweaksPanel
+        tweaks={tweaks}
+        setTweaks={setTweaks}
+        open={tweaksOpen}
+        onClose={() => setTweaksOpen(false)}
+        playing={playing}
+        setPlaying={setPlaying}
+      />
+
+      {/* Floating button to open tweaks (replaces the prototype's edit-mode
+          activation via window.parent.postMessage). */}
+      <button
+        type="button"
+        aria-label="Open tweaks panel"
+        onClick={() => setTweaksOpen((v) => !v)}
+        style={{
+          position: "fixed",
+          right: 18,
+          bottom: 18,
+          zIndex: 70,
+          width: 36,
+          height: 36,
+          borderRadius: 9999,
+          border: "1px solid var(--ag-border-default)",
+          background: "color-mix(in oklab, var(--ag-bg-surface) 80%, transparent)",
+          backdropFilter: "blur(20px) saturate(1.4) brightness(1.05)",
+          color: "var(--ag-text-primary)",
+          fontFamily: "var(--ag-font-mono)",
+          fontSize: 14,
+          cursor: "pointer",
+          boxShadow: "var(--ag-shadow-lg)",
+        }}
+      >
+        ⚙
+      </button>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/MiddleColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/MiddleColumn.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { LIFE_GRAPH } from "../_lib/mock-workspace";
+import type { FsStyle, MiddleMode, ReplayState } from "../_lib/types";
+import { FileTree } from "./FileTree";
+import { Journal } from "./Journal";
+import { KnowledgeGraph } from "./KnowledgeGraph";
+import { Peers } from "./Peers";
+import { Timeline } from "./Timeline";
+
+interface Props {
+  mode: MiddleMode;
+  setMode: (mode: MiddleMode) => void;
+  state: ReplayState;
+  toolHighlight: string | null;
+  setToolHighlight: (id: string | null) => void;
+  fsStyle: FsStyle;
+  journalRich: boolean;
+  lastOpTs: number;
+}
+
+const TABS: { id: MiddleMode; label: string }[] = [
+  { id: "files", label: "Files" },
+  { id: "journal", label: "Journal" },
+  { id: "timeline", label: "Timeline" },
+  { id: "graph", label: "Graph" },
+  { id: "spaces", label: "Spaces" },
+];
+
+export function MiddleColumn({
+  mode,
+  setMode,
+  state,
+  toolHighlight,
+  setToolHighlight,
+  fsStyle,
+  journalRich,
+  lastOpTs,
+}: Props) {
+  const dotByMode: Record<MiddleMode, boolean> = {
+    files: state.fsOps.length > 0,
+    journal: state.journal.length > 0,
+    timeline: false,
+    graph: false,
+    spaces: true,
+  };
+  return (
+    <div className="col col--middle">
+      <div className="col__header">
+        <div className="tabs" role="tablist">
+          {TABS.map((t) => (
+            <button
+              type="button"
+              key={t.id}
+              className="tab"
+              aria-selected={mode === t.id}
+              onClick={() => setMode(t.id)}
+            >
+              {t.label}
+              {dotByMode[t.id] && mode !== t.id && <span className="dot" />}
+            </button>
+          ))}
+        </div>
+        <div
+          className="row"
+          style={{
+            gap: 8,
+            color: "var(--ag-text-muted)",
+            fontFamily: "var(--ag-font-mono)",
+            fontSize: 10.5,
+          }}
+        >
+          {mode === "files" && <>{state.fsOps.length} ops</>}
+          {mode === "journal" && <>{state.journal.length} events</>}
+          {mode === "graph" && (
+            <>
+              {LIFE_GRAPH.nodes.length} nodes · {LIFE_GRAPH.edges.length} edges
+            </>
+          )}
+        </div>
+      </div>
+      <div className="col__body">
+        {mode === "files" && (
+          <FileTree
+            fsOps={state.fsOps}
+            fsStyle={fsStyle}
+            lastOpTs={lastOpTs}
+          />
+        )}
+        {mode === "journal" && (
+          <Journal
+            events={state.journal}
+            rich={journalRich}
+            highlight={toolHighlight}
+            setHighlight={setToolHighlight}
+          />
+        )}
+        {mode === "timeline" && <Timeline events={state.journal} />}
+        {mode === "graph" && <KnowledgeGraph />}
+        {mode === "spaces" && <Peers />}
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/MiddleColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/MiddleColumn.tsx
@@ -53,6 +53,7 @@ export function MiddleColumn({
               type="button"
               key={t.id}
               className="tab"
+              role="tab"
               aria-selected={mode === t.id}
               onClick={() => setMode(t.id)}
             >

--- a/apps/chat/app/(site)/life/_components/NousPane.tsx
+++ b/apps/chat/app/(site)/life/_components/NousPane.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { LIFE_JUDGES } from "../_lib/mock-workspace";
+import type { ReplayState } from "../_lib/types";
+
+interface Props {
+  state: ReplayState;
+}
+
+export function NousPane({ state }: Props) {
+  const judges = LIFE_JUDGES;
+  const agg = state.nous;
+  return (
+    <div className="right-pane">
+      <div
+        className="row"
+        style={{ justifyContent: "space-between", marginBottom: 8 }}
+      >
+        <div className="eyebrow">Nous · metacognition</div>
+        {agg && (
+          <span
+            className={`pill ${agg.band === "good" ? "pill--accent" : ""}`}
+          >
+            live · {agg.score.toFixed(2)}
+          </span>
+        )}
+      </div>
+      <div className="gauge">
+        <div className="gauge__label">Composite score</div>
+        <div
+          className="gauge__value"
+          style={{
+            color:
+              agg?.band === "good"
+                ? "oklch(0.78 0.15 155)"
+                : agg?.band === "warn"
+                  ? "oklch(0.87 0.18 85)"
+                  : "var(--ag-text-primary)",
+          }}
+        >
+          {agg ? agg.score.toFixed(2) : "—"}
+        </div>
+        <div className="gauge__sub">
+          {agg?.note || "Waiting for turn to close."}
+        </div>
+        <div className="bar">
+          <div
+            className={`bar__fill ${
+              agg?.band === "good" ? "bar__fill--good" : "bar__fill--warn"
+            }`}
+            style={{ width: `${(agg?.score || 0) * 100}%` }}
+          />
+        </div>
+      </div>
+      <div className="section">Per-axis judges</div>
+      {judges.map((j) => (
+        <div className="judge-card" key={j.axis}>
+          <div className="judge-card__head">
+            <div style={{ fontFamily: "var(--ag-font-heading)", fontSize: 13 }}>
+              {j.axis}
+            </div>
+            <div className={`judge-card__score judge-card__score--${j.band}`}>
+              {j.score.toFixed(2)}
+            </div>
+          </div>
+          <div className="bar">
+            <div
+              className={`bar__fill bar__fill--${
+                j.band === "good" ? "good" : "warn"
+              }`}
+              style={{ width: `${j.score * 100}%` }}
+            />
+          </div>
+          <div className="judge-card__body">{j.note}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/Peers.tsx
+++ b/apps/chat/app/(site)/life/_components/Peers.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { LIFE_PEERS } from "../_lib/mock-workspace";
+
+export function Peers() {
+  return (
+    <div className="peers">
+      {LIFE_PEERS.map((p) => (
+        <div key={p.name} className="peer-card">
+          <div className="peer-card__head">
+            <div
+              className="peer-avatar"
+              style={{ ["--h" as string]: p.hue } as React.CSSProperties}
+            />
+            <div>
+              <div className="peer-card__name">{p.name}</div>
+              <div className="peer-card__role">{p.role}</div>
+            </div>
+          </div>
+          <div className="peer-card__status">{p.status}</div>
+          <div className="peer-card__latency">{p.lat}ms</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/PreviewPane.tsx
+++ b/apps/chat/app/(site)/life/_components/PreviewPane.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { DEMO_DIFFS } from "../_lib/mock-workspace";
+import type { ReplayState } from "../_lib/types";
+
+interface Props {
+  state: ReplayState;
+}
+
+export function PreviewPane({ state }: Props) {
+  const lastWrite = [...state.fsOps]
+    .reverse()
+    .find((o) => o.op === "write" || o.op === "create");
+  if (!lastWrite) {
+    return (
+      <div className="right-pane">
+        <div className="eyebrow" style={{ marginBottom: 10 }}>
+          Preview
+        </div>
+        <div
+          className="preview-frame"
+          style={{ fontStyle: "italic", color: "var(--ag-text-muted)" }}
+        >
+          No artifact yet. Preview will mount here when Arcan writes or opens
+          a file.
+        </div>
+      </div>
+    );
+  }
+  const diff = DEMO_DIFFS[lastWrite.path] ?? DEMO_DIFFS.__default!;
+  return (
+    <div className="right-pane">
+      <div
+        className="row"
+        style={{ justifyContent: "space-between", marginBottom: 8 }}
+      >
+        <div className="eyebrow">Preview · {lastWrite.op}</div>
+        <div className="pill pill--accent">{diff.stat}</div>
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--ag-font-mono)",
+          fontSize: 11,
+          color: "var(--ag-text-secondary)",
+          marginBottom: 10,
+        }}
+      >
+        {lastWrite.path}
+      </div>
+      <div className="preview-frame">
+        {diff.lines.map((l, i) => (
+          <div
+            key={`${l.n ?? "x"}-${i}`}
+            className={`diff-line ${l.kind ? `diff-line--${l.kind}` : ""}`}
+          >
+            <span className="diff-line__gut">{l.n ?? ""}</span>
+            <span>
+              {l.kind === "add" ? "+ " : l.kind === "del" ? "- " : "  "}
+              {l.s}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/RightColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/RightColumn.tsx
@@ -37,6 +37,7 @@ export function RightColumn({ mode, setMode, state }: Props) {
               type="button"
               key={t.id}
               className="tab"
+              role="tab"
               aria-selected={mode === t.id}
               onClick={() => setMode(t.id)}
             >

--- a/apps/chat/app/(site)/life/_components/RightColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/RightColumn.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import type { ReplayState, RightMode } from "../_lib/types";
+import { AnimaPane } from "./AnimaPane";
+import { AutonomicPane } from "./AutonomicPane";
+import { HaimaPane } from "./HaimaPane";
+import { NousPane } from "./NousPane";
+import { PreviewPane } from "./PreviewPane";
+import { VigilPane } from "./VigilPane";
+
+interface Props {
+  mode: RightMode;
+  setMode: (mode: RightMode) => void;
+  state: ReplayState;
+}
+
+const TABS: { id: RightMode; label: string }[] = [
+  { id: "preview", label: "Preview" },
+  { id: "vigil", label: "Vigil" },
+  { id: "nous", label: "Nous" },
+  { id: "autonomic", label: "Autonomic" },
+  { id: "haima", label: "Haima" },
+  { id: "anima", label: "Anima" },
+];
+
+export function RightColumn({ mode, setMode, state }: Props) {
+  return (
+    <div className="col col--right">
+      <div className="col__header">
+        <div
+          className="tabs"
+          style={{ flexWrap: "wrap", gap: 0 }}
+          role="tablist"
+        >
+          {TABS.map((t) => (
+            <button
+              type="button"
+              key={t.id}
+              className="tab"
+              aria-selected={mode === t.id}
+              onClick={() => setMode(t.id)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="col__body">
+        {mode === "preview" && <PreviewPane state={state} />}
+        {mode === "vigil" && <VigilPane state={state} />}
+        {mode === "nous" && <NousPane state={state} />}
+        {mode === "autonomic" && <AutonomicPane />}
+        {mode === "haima" && <HaimaPane />}
+        {mode === "anima" && <AnimaPane />}
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/ThinkingBlock.tsx
+++ b/apps/chat/app/(site)/life/_components/ThinkingBlock.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+interface Props {
+  text: string;
+  open: boolean;
+  streaming?: boolean;
+  onToggle: () => void;
+}
+
+export function ThinkingBlock({ text, open, streaming, onToggle }: Props) {
+  return (
+    <div className="thinking" data-open={open ? "true" : "false"}>
+      <button
+        type="button"
+        className="thinking__head"
+        onClick={onToggle}
+        style={{
+          width: "100%",
+          appearance: "none",
+          border: 0,
+          background: "transparent",
+          color: "inherit",
+          textAlign: "left",
+          cursor: "pointer",
+        }}
+      >
+        <span className="eyebrow">{streaming ? "Thinking…" : "Thought"}</span>
+        <span className="row" style={{ gap: 10 }}>
+          {streaming && <span className="caret" style={{ height: 10, width: 5 }} />}
+          <span className="chev">▾</span>
+        </span>
+      </button>
+      <div className="thinking__body">{text || "…"}</div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/Timeline.tsx
+++ b/apps/chat/app/(site)/life/_components/Timeline.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { LifeJournalEntry } from "../_lib/types";
+
+interface Props {
+  events: LifeJournalEntry[];
+}
+
+function prettyLabel(e: LifeJournalEntry): string {
+  if (e.kind === "llm" && e.label === "USER") return "You asked";
+  if (e.kind === "tool" && e.label === "TOOL") return `Arcan ran ${e.actor}`;
+  if (e.kind === "fs") return `Filesystem · ${e.label.toLowerCase()}`;
+  if (e.kind === "nous") return "Nous judged the turn";
+  if (e.kind === "autonomic")
+    return `Autonomic · ${e.label.toLowerCase()} regulation`;
+  return e.label;
+}
+
+export function Timeline({ events }: Props) {
+  // Hide raw RESULT rows for a cleaner narrative view.
+  const items = events.filter((e) => e.label !== "RESULT");
+  return (
+    <div className="timeline">
+      {items.length === 0 && (
+        <div style={{ color: "var(--ag-text-muted)", fontSize: 12 }}>
+          Nothing yet.
+        </div>
+      )}
+      {items.map((e) => (
+        <div
+          key={e.id}
+          className={`tl-item ${e.kind === "llm" ? "is-agent" : ""}`}
+        >
+          <div className="tl-item__head">
+            <span style={{ fontFamily: "var(--ag-font-heading)" }}>
+              {prettyLabel(e)}
+            </span>
+            <span className="tl-item__ts">{e.ts}</span>
+          </div>
+          <div className="tl-item__body">{e.msg}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/ToolCallBlock.tsx
+++ b/apps/chat/app/(site)/life/_components/ToolCallBlock.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { LifeTool } from "../_lib/types";
+
+interface Props {
+  tool: LifeTool;
+  highlighted: boolean;
+  onClick: () => void;
+  open: boolean;
+  onToggle: () => void;
+}
+
+function toolIcon(name: string): string {
+  if (name.startsWith("praxis.read")) return "R";
+  if (name.startsWith("praxis.edit")) return "E";
+  if (name.startsWith("praxis.shell")) return "$";
+  if (name.startsWith("vigil")) return "V";
+  if (name.startsWith("lago")) return "L";
+  if (name.startsWith("haima")) return "¤";
+  if (name.startsWith("spaces")) return "S";
+  if (name.startsWith("nous")) return "N";
+  return "•";
+}
+
+export function ToolCallBlock({
+  tool,
+  highlighted,
+  onClick,
+  open,
+  onToggle,
+}: Props) {
+  const iconChar = toolIcon(tool.name);
+  return (
+    <div
+      className={`toolcall ${highlighted ? "is-highlighted" : ""}`}
+      data-open={open ? "true" : "false"}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div
+        className="toolcall__head"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onToggle();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        <div className="toolcall__icon">{iconChar}</div>
+        <div className="toolcall__name">{tool.name}</div>
+        <div className="toolcall__target">{tool.target}</div>
+        <div className="toolcall__meta">
+          {tool.status === "running" ? (
+            <>
+              <span className="caret" style={{ height: 9, width: 4 }} /> running
+            </>
+          ) : (
+            <>
+              <span
+                className="dock__dot"
+                style={{ background: "oklch(0.72 0.19 155)" }}
+              />{" "}
+              ok
+            </>
+          )}
+          <span>▾</span>
+        </div>
+      </div>
+      <div className="toolcall__body">
+        <div style={{ color: "var(--ag-text-muted)", marginBottom: 6 }}>args:</div>
+        <div style={{ color: "var(--ag-text-secondary)" }}>{tool.args}</div>
+        {tool.result && (
+          <>
+            <div style={{ color: "var(--ag-text-muted)", margin: "10px 0 6px" }}>
+              result:
+            </div>
+            <div
+              style={{
+                whiteSpace: "pre-wrap",
+                color: "var(--ag-text-primary)",
+              }}
+            >
+              {tool.result}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/Topbar.tsx
+++ b/apps/chat/app/(site)/life/_components/Topbar.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { TweaksState } from "../_lib/types";
+
+interface Props {
+  setAnimaOpen: (next: (v: boolean) => boolean) => void;
+  tweaks: TweaksState;
+  setTweaks: (patch: Partial<TweaksState>) => void;
+  playing: boolean;
+  setPlaying: (next: boolean | ((p: boolean) => boolean)) => void;
+  crumb: { brand: string; project: string; scenarioLabel: string };
+}
+
+export function Topbar({
+  setAnimaOpen,
+  tweaks,
+  setTweaks,
+  playing,
+  setPlaying,
+  crumb,
+}: Props) {
+  return (
+    <div className="topbar">
+      <div className="topbar__left">
+        <button
+          type="button"
+          className="anima-badge"
+          onClick={() => setAnimaOpen((v) => !v)}
+          title="Anima · identity"
+        >
+          <div className="anima-avatar" />
+          <div>
+            <div className="anima-name">Arcan</div>
+            <div className="anima-soul">soul:life.arcan.broomva</div>
+          </div>
+        </button>
+        <div className="topbar__crumb">
+          <strong>{crumb.brand}</strong>
+          <span className="sep">/</span>
+          life
+          <span className="sep">/</span>
+          {crumb.project}
+          <span className="sep">·</span>
+          {crumb.scenarioLabel}
+        </div>
+      </div>
+      <div className="topbar__right">
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setTweaks({ scenario: "refactor" })}
+          style={{ opacity: tweaks.scenario === "refactor" ? 1 : 0.6 }}
+        >
+          Refactor
+        </button>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setTweaks({ scenario: "ingest" })}
+          style={{ opacity: tweaks.scenario === "ingest" ? 1 : 0.6 }}
+        >
+          Ingest
+        </button>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setTweaks({ scenario: "research" })}
+          style={{ opacity: tweaks.scenario === "research" ? 1 : 0.6 }}
+        >
+          Research
+        </button>
+        <span
+          style={{
+            width: 1,
+            height: 20,
+            background: "var(--ag-border-subtle)",
+          }}
+        />
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setPlaying((p) => !p)}
+        >
+          {playing ? "❚❚ Pause" : "▶ Play"}
+        </button>
+        <button
+          type="button"
+          className="btn"
+          onClick={() =>
+            setTweaks({
+              layout: tweaks.layout === "classic" ? "experimental" : "classic",
+            })
+          }
+        >
+          {tweaks.layout === "classic" ? "Experimental" : "Classic"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/TweaksPanel.tsx
+++ b/apps/chat/app/(site)/life/_components/TweaksPanel.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import type { TweaksState } from "../_lib/types";
+
+interface Props {
+  tweaks: TweaksState;
+  setTweaks: (patch: Partial<TweaksState>) => void;
+  open: boolean;
+  onClose: () => void;
+  playing: boolean;
+  setPlaying: (next: boolean | ((p: boolean) => boolean)) => void;
+}
+
+interface SegmentedProps<V extends string> {
+  label: string;
+  value: V;
+  options: [V, string][];
+  onChange: (value: V) => void;
+  wrap?: boolean;
+}
+
+function Segmented<V extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  wrap,
+}: SegmentedProps<V>) {
+  return (
+    <div className="tweaks__row">
+      <div className="tweaks__label">{label}</div>
+      <div
+        className="segmented"
+        style={wrap ? { flexWrap: "wrap", gap: 2 } : {}}
+      >
+        {options.map(([v, l]) => (
+          <button
+            type="button"
+            key={v}
+            className={value === v ? "is-active" : ""}
+            onClick={() => onChange(v)}
+          >
+            {l}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function TweaksPanel({
+  tweaks,
+  setTweaks,
+  open,
+  onClose,
+  playing,
+  setPlaying,
+}: Props) {
+  return (
+    <div className={`tweaks ${open ? "is-open" : ""}`}>
+      <div className="tweaks__head">
+        <div className="tweaks__title">Tweaks</div>
+        <button
+          type="button"
+          className="btn btn--ghost btn--icon"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+      <Segmented
+        label="Layout"
+        value={tweaks.layout}
+        options={[
+          ["classic", "Classic"],
+          ["experimental", "Experimental"],
+        ]}
+        onChange={(v) => setTweaks({ layout: v })}
+      />
+      <Segmented
+        label="Middle pane"
+        value={tweaks.middleMode}
+        options={[
+          ["files", "Files"],
+          ["journal", "Journal"],
+          ["timeline", "Timeline"],
+          ["graph", "Graph"],
+          ["spaces", "Spaces"],
+        ]}
+        onChange={(v) => setTweaks({ middleMode: v })}
+      />
+      <Segmented
+        label="Right pane"
+        value={tweaks.rightMode}
+        options={[
+          ["preview", "Preview"],
+          ["vigil", "Vigil"],
+          ["nous", "Nous"],
+          ["autonomic", "Autonomic"],
+          ["haima", "Haima"],
+          ["anima", "Anima"],
+        ]}
+        onChange={(v) => setTweaks({ rightMode: v })}
+        wrap
+      />
+      <Segmented
+        label="Filesystem feel"
+        value={tweaks.fsStyle}
+        options={[
+          ["finder", "Finder"],
+          ["shimmer", "Shimmer"],
+          ["heartbeat", "Heartbeat"],
+          ["ticker", "Ticker"],
+        ]}
+        onChange={(v) => setTweaks({ fsStyle: v })}
+      />
+      <Segmented
+        label="Journal depth"
+        value={tweaks.journalRich ? "rich" : "compact"}
+        options={[
+          ["compact", "Compact"],
+          ["rich", "Rich"],
+        ]}
+        onChange={(v) => setTweaks({ journalRich: v === "rich" })}
+      />
+      <Segmented
+        label="Metrics density"
+        value={tweaks.metricsDensity}
+        options={[
+          ["minimal", "Min"],
+          ["medium", "Med"],
+          ["rich", "Rich"],
+        ]}
+        onChange={(v) => setTweaks({ metricsDensity: v })}
+      />
+      <Segmented
+        label="Scenario"
+        value={tweaks.scenario}
+        options={[
+          ["refactor", "Refactor"],
+          ["ingest", "Ingest"],
+          ["research", "Research"],
+        ]}
+        onChange={(v) => setTweaks({ scenario: v })}
+      />
+
+      <div
+        className="tweaks__row"
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginTop: 14,
+        }}
+      >
+        <button
+          type="button"
+          className={`switch ${tweaks.orbs ? "is-on" : ""}`}
+          onClick={() => setTweaks({ orbs: !tweaks.orbs })}
+          style={{ background: "transparent", border: 0, padding: 0 }}
+        >
+          <div className="switch__track" />
+          <div className="switch__label">Atmospheric orbs</div>
+        </button>
+      </div>
+      <div
+        className="tweaks__row"
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <button
+          type="button"
+          className={`switch ${tweaks.autoplay ? "is-on" : ""}`}
+          onClick={() => setTweaks({ autoplay: !tweaks.autoplay })}
+          style={{ background: "transparent", border: 0, padding: 0 }}
+        >
+          <div className="switch__track" />
+          <div className="switch__label">Autoplay scenario</div>
+        </button>
+      </div>
+      <div style={{ marginTop: 14, display: "flex", gap: 8 }}>
+        <button
+          type="button"
+          className="btn"
+          onClick={() => setPlaying((p) => !p)}
+          style={{ flex: 1 }}
+        >
+          {playing ? "Pause" : "Play"}
+        </button>
+        <button
+          type="button"
+          className="btn btn--primary"
+          onClick={() => {
+            setPlaying(false);
+            setTimeout(() => setPlaying(true), 50);
+            setTweaks({ scenario: tweaks.scenario });
+          }}
+          style={{ flex: 1 }}
+        >
+          Replay
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_components/VigilPane.tsx
+++ b/apps/chat/app/(site)/life/_components/VigilPane.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { LIFE_TRACES } from "../_lib/mock-workspace";
+import type { ReplayState } from "../_lib/types";
+
+interface Props {
+  state: ReplayState;
+}
+
+export function VigilPane({ state }: Props) {
+  const cur = state.t || 17100;
+  const total = Math.max(cur, 1000);
+  const visibleSpans = LIFE_TRACES.filter((s) => s.start <= cur);
+  return (
+    <div className="right-pane">
+      <div
+        className="row"
+        style={{ justifyContent: "space-between", marginBottom: 8 }}
+      >
+        <div className="eyebrow">Vigil · spans · this tick</div>
+        <span className="pill">{visibleSpans.length} spans</span>
+      </div>
+      <div className="preview-frame" style={{ padding: "10px 12px" }}>
+        {visibleSpans.map((sp) => {
+          const visibleDur = Math.min(sp.dur, Math.max(0, cur - sp.start));
+          const leftPct = (sp.start / total) * 100;
+          const widthPct = Math.max(1, (visibleDur / total) * 100);
+          const cls =
+            sp.color === "llm"
+              ? "trace-row__fill--llm"
+              : sp.color === "tool"
+                ? "trace-row__fill--tool"
+                : "";
+          return (
+            <div className="trace-row" key={`${sp.name}-${sp.start}`}>
+              <span className="trace-row__name" title={sp.name}>
+                {sp.name}
+              </span>
+              <span className="trace-row__bar">
+                <span
+                  className={`trace-row__fill ${cls}`}
+                  style={{
+                    left: `${leftPct}%`,
+                    width: `${widthPct}%`,
+                  }}
+                />
+              </span>
+              <span className="trace-row__ms">{visibleDur}ms</span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="section">Semantic conventions</div>
+      <div className="gauge-grid">
+        <div className="gauge">
+          <div className="gauge__label">gen_ai.usage.input</div>
+          <div className="gauge__value">48,112</div>
+          <div className="gauge__sub">tokens · $0.144</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">gen_ai.usage.output</div>
+          <div className="gauge__value">8,422</div>
+          <div className="gauge__sub">tokens · $0.101</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">tool.invocations</div>
+          <div className="gauge__value">
+            {(state.journal || []).filter(
+              (e) => e.kind === "tool" && e.label === "TOOL",
+            ).length || 6}
+          </div>
+          <div className="gauge__sub">spans</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">error.rate</div>
+          <div
+            className="gauge__value"
+            style={{ color: "oklch(0.78 0.15 155)" }}
+          >
+            0.00
+          </div>
+          <div className="gauge__sub">last 50 spans</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/_lib/mock-workspace.ts
+++ b/apps/chat/app/(site)/life/_lib/mock-workspace.ts
@@ -1,0 +1,393 @@
+// Static mock data driving the middle/right columns. Phase B replaces these
+// with live data from the Arcan SSE / Lago gRPC backplane.
+
+import type {
+  LifeAnima,
+  LifeFsNode,
+  LifeGraph,
+  LifeHaima,
+  LifeHomeo,
+  LifeJudge,
+  LifePeer,
+  LifeTraceSpan,
+} from "./types";
+
+export const LIFE_FS: { tree: LifeFsNode[] } = {
+  tree: [
+    {
+      path: "crates",
+      type: "dir",
+      children: [
+        {
+          path: "crates/arcan",
+          type: "dir",
+          children: [
+            {
+              path: "crates/arcan/src",
+              type: "dir",
+              children: [
+                { path: "crates/arcan/src/lib.rs", type: "file" },
+                { path: "crates/arcan/src/stream.rs", type: "file" },
+                { path: "crates/arcan/src/chain_completion.rs", type: "file" },
+                {
+                  path: "crates/arcan/src/providers",
+                  type: "dir",
+                  children: [
+                    {
+                      path: "crates/arcan/src/providers/anthropic.rs",
+                      type: "file",
+                    },
+                    {
+                      path: "crates/arcan/src/providers/openai.rs",
+                      type: "file",
+                    },
+                    {
+                      path: "crates/arcan/src/providers/ollama.rs",
+                      type: "file",
+                    },
+                  ],
+                },
+              ],
+            },
+            { path: "crates/arcan/Cargo.toml", type: "file" },
+          ],
+        },
+        {
+          path: "crates/lago",
+          type: "dir",
+          children: [
+            {
+              path: "crates/lago/src",
+              type: "dir",
+              children: [
+                { path: "crates/lago/src/journal.rs", type: "file" },
+                { path: "crates/lago/src/blob.rs", type: "file" },
+                { path: "crates/lago/src/graph.rs", type: "file" },
+              ],
+            },
+          ],
+        },
+        {
+          path: "crates/autonomic",
+          type: "dir",
+          children: [
+            {
+              path: "crates/autonomic/src",
+              type: "dir",
+              children: [
+                { path: "crates/autonomic/src/lib.rs", type: "file" },
+                { path: "crates/autonomic/src/homeo.rs", type: "file" },
+              ],
+            },
+          ],
+        },
+        {
+          path: "crates/anima",
+          type: "dir",
+          children: [{ path: "crates/anima/src/soul.rs", type: "file" }],
+        },
+        {
+          path: "crates/nous",
+          type: "dir",
+          children: [{ path: "crates/nous/src/judge.rs", type: "file" }],
+        },
+      ],
+    },
+    {
+      path: "schemas",
+      type: "dir",
+      children: [
+        { path: "schemas/state.schema.json", type: "file" },
+        { path: "schemas/action.schema.json", type: "file" },
+        { path: "schemas/trace.schema.json", type: "file" },
+      ],
+    },
+    { path: "Cargo.toml", type: "file" },
+    { path: "README.md", type: "file" },
+  ],
+};
+
+export const LIFE_TRACES: LifeTraceSpan[] = [
+  { name: "arcan.tick", kind: "root", start: 0, dur: 17100, color: "llm" },
+  {
+    name: "arcan.context.reconstruct",
+    kind: "span",
+    start: 40,
+    dur: 480,
+    color: "tool",
+  },
+  { name: "anima.belief.load", kind: "span", start: 120, dur: 180, color: "tool" },
+  {
+    name: "provider.anthropic.messages",
+    kind: "llm",
+    start: 560,
+    dur: 1900,
+    color: "llm",
+  },
+  {
+    name: "praxis.vigil.query_spans",
+    kind: "tool",
+    start: 3800,
+    dur: 800,
+    color: "tool",
+  },
+  {
+    name: "praxis.read_file#stream.rs",
+    kind: "tool",
+    start: 6000,
+    dur: 900,
+    color: "tool",
+  },
+  {
+    name: "praxis.read_file#chain_completion.rs",
+    kind: "tool",
+    start: 7400,
+    dur: 700,
+    color: "tool",
+  },
+  {
+    name: "provider.anthropic.messages",
+    kind: "llm",
+    start: 8600,
+    dur: 1500,
+    color: "llm",
+  },
+  {
+    name: "praxis.edit_file#stream.rs",
+    kind: "tool",
+    start: 11200,
+    dur: 1200,
+    color: "tool",
+  },
+  {
+    name: "lago.journal.append x4",
+    kind: "tool",
+    start: 11400,
+    dur: 120,
+    color: "tool",
+  },
+  {
+    name: "praxis.edit_file#chain_completion.rs",
+    kind: "tool",
+    start: 13100,
+    dur: 800,
+    color: "tool",
+  },
+  {
+    name: "praxis.shell#cargo test",
+    kind: "tool",
+    start: 14600,
+    dur: 1600,
+    color: "tool",
+  },
+  {
+    name: "nous.judge.evaluate",
+    kind: "tool",
+    start: 16800,
+    dur: 280,
+    color: "tool",
+  },
+];
+
+export const LIFE_HOMEO: LifeHomeo = {
+  operational: { value: 0.94, target: 1.0, sub: "gate_pass · 14/15 green" },
+  cognitive: { value: 0.68, target: 0.75, sub: "ctx pressure · 68%" },
+  economic: { value: 0.73, target: 1.0, sub: "budget · $0.58 / $0.80" },
+};
+
+export const LIFE_HAIMA: LifeHaima = {
+  session_spend: 0.22,
+  session_budget: 0.8,
+  tokens_in: 48_112,
+  tokens_out: 8_422,
+  x402_txs: 3,
+  last_pay: "0.02 USDC → leaderboard-scout",
+};
+
+export const LIFE_JUDGES: LifeJudge[] = [
+  {
+    axis: "Correctness",
+    score: 0.94,
+    band: "good",
+    note: "Tests green, hashline diff lines up with spec.",
+  },
+  {
+    axis: "Scope",
+    score: 0.88,
+    band: "good",
+    note: "Touched only the two files named in the plan.",
+  },
+  {
+    axis: "Regression risk",
+    score: 0.9,
+    band: "good",
+    note: "Public API unchanged; 14 unit tests + property test added.",
+  },
+  {
+    axis: "Style",
+    score: 0.76,
+    band: "warn",
+    note: "One clippy::needless_borrow not auto-fixed — low priority.",
+  },
+];
+
+export const LIFE_ANIMA: LifeAnima = {
+  name: "Arcan",
+  soul: "soul:life.arcan.broomva",
+  tier: "sovereign",
+  did: "did:key:z6Mkf…4Ht",
+  beliefs: [
+    "Emits typed directives, not raw actuations.",
+    "Shields filter; plants obey.",
+    "Every action produces an immutable trace in Lago.",
+    "Environment-first triage before code-level fault attribution.",
+  ],
+  trust: { user: 0.92, workspace: 0.88, peers: 0.71 },
+  session: "sess_01J8K…r9",
+};
+
+export const LIFE_PEERS: LifePeer[] = [
+  {
+    name: "leaderboard-scout",
+    role: "Spaces · scout",
+    lat: 42,
+    status: "Running · returning top-10 OSS agents",
+    hue: "220deg",
+  },
+  {
+    name: "audit-shield",
+    role: "Spaces · shield",
+    lat: 18,
+    status: "Idle · last check 3m ago",
+    hue: "300deg",
+  },
+  {
+    name: "graph-gardener",
+    role: "Spaces · lago",
+    lat: 74,
+    status: "Compacting · 1,204/8,120 nodes",
+    hue: "160deg",
+  },
+  {
+    name: "payor-x402",
+    role: "Spaces · haima",
+    lat: 9,
+    status: "Listening on wallet 0x9f4…b21",
+    hue: "80deg",
+  },
+];
+
+export const LIFE_GRAPH: LifeGraph = {
+  nodes: [
+    {
+      id: "agent-safety",
+      label: "agent safety",
+      x: 0.5,
+      y: 0.3,
+      kind: "concept",
+      r: 22,
+    },
+    { id: "rlhf", label: "RLHF", x: 0.22, y: 0.55, kind: "concept", r: 20 },
+    {
+      id: "reward-hacking",
+      label: "reward hacking",
+      x: 0.78,
+      y: 0.52,
+      kind: "concept",
+      r: 18,
+    },
+    {
+      id: "const-ai",
+      label: "constitutional AI",
+      x: 0.5,
+      y: 0.66,
+      kind: "paper",
+      r: 20,
+      fresh: true,
+    },
+    {
+      id: "harmlessness",
+      label: "harmlessness",
+      x: 0.34,
+      y: 0.82,
+      kind: "concept",
+      r: 15,
+    },
+    { id: "rlaif", label: "RLAIF", x: 0.68, y: 0.82, kind: "concept", r: 15 },
+    {
+      id: "red-teaming",
+      label: "red-teaming",
+      x: 0.86,
+      y: 0.74,
+      kind: "concept",
+      r: 14,
+    },
+    {
+      id: "sft",
+      label: "supervised FT",
+      x: 0.16,
+      y: 0.78,
+      kind: "concept",
+      r: 14,
+    },
+    {
+      id: "arcan-shell",
+      label: "arcan shell",
+      x: 0.14,
+      y: 0.25,
+      kind: "artifact",
+      r: 14,
+    },
+  ],
+  edges: [
+    { a: "rlhf", b: "agent-safety" },
+    { a: "reward-hacking", b: "agent-safety" },
+    { a: "const-ai", b: "rlhf", fresh: true },
+    { a: "const-ai", b: "reward-hacking", fresh: true },
+    { a: "const-ai", b: "agent-safety", fresh: true },
+    { a: "const-ai", b: "harmlessness" },
+    { a: "const-ai", b: "rlaif" },
+    { a: "const-ai", b: "red-teaming" },
+    { a: "const-ai", b: "sft" },
+    { a: "arcan-shell", b: "rlhf" },
+  ],
+};
+
+export const DEMO_DIFFS: Record<
+  string,
+  { stat: string; lines: { n?: number; s: string; kind?: "add" | "del" }[] }
+> = {
+  "crates/arcan/src/stream.rs": {
+    stat: "−18 / +28",
+    lines: [
+      { n: 14, s: "pub async fn forward(" },
+      { n: 15, s: "    mut rx: Receiver<Chunk>," },
+      { n: 16, s: "    tx: mpsc::Sender<SseEvent>," },
+      { n: 17, s: ") -> Result<()> {" },
+      { n: 18, kind: "add", s: "    let mut buf = BytesMut::with_capacity(1024);" },
+      { n: 19, kind: "add", s: "    let mut flush_at = Instant::now();" },
+      { n: 20, s: "    while let Some(chunk) = rx.recv().await {" },
+      { n: 21, kind: "del", s: "        let mut s = String::new();" },
+      { n: 22, kind: "del", s: "        s.push_str(&chunk.delta);" },
+      { n: 23, kind: "del", s: "        tx.send(SseEvent::data(s)).await?;" },
+      { n: 24, kind: "add", s: "        buf.extend_from_slice(chunk.delta.as_bytes());" },
+      { n: 25, kind: "add", s: "        if buf.len() > 512" },
+      { n: 26, kind: "add", s: "          || flush_at.elapsed() > Duration::from_millis(4) {" },
+      { n: 27, kind: "add", s: "            tx.send(SseEvent::data_bytes(buf.split())).await?;" },
+      { n: 28, kind: "add", s: "            flush_at = Instant::now();" },
+      { n: 29, kind: "add", s: "        }" },
+      { n: 30, s: "    }" },
+      { n: 31, s: "    Ok(())" },
+      { n: 32, s: "}" },
+    ],
+  },
+  __default: {
+    stat: "+1 / −0",
+    lines: [
+      { n: 1, s: "{" },
+      { n: 2, kind: "add", s: '  "source": "lago",' },
+      { n: 3, s: '  "cid": "bafybeig…"' },
+      { n: 4, s: "}" },
+    ],
+  },
+};

--- a/apps/chat/app/(site)/life/_lib/project-map.ts
+++ b/apps/chat/app/(site)/life/_lib/project-map.ts
@@ -1,0 +1,35 @@
+// Mapping between URL slug → seed project metadata + replay scenario.
+// For Phase A only the two demo projects below are valid; everything else 404s.
+// Phase C will add user-created projects via /life/new.
+
+import type { ScenarioId } from "./types";
+
+export type ProjectChipColor = "emerald" | "amber";
+
+export interface LifeProjectInfo {
+  scenarioId: ScenarioId;
+  displayName: string;
+  eyebrow: string;
+  chipColor: ProjectChipColor;
+}
+
+export const PROJECTS: Record<string, LifeProjectInfo> = {
+  sentinel: {
+    scenarioId: "refactor",
+    displayName: "Sentinel — property-ops WO audit",
+    eyebrow: "sentinel-property-ops · exclusive-rentals",
+    chipColor: "emerald",
+  },
+  materiales: {
+    scenarioId: "research",
+    displayName: "Materiales Intel — precio unitario en vivo",
+    eyebrow: "materiales-intel · _pending-constructora",
+    chipColor: "amber",
+  },
+};
+
+export type ProjectSlug = keyof typeof PROJECTS;
+
+export function isProjectSlug(slug: string): slug is ProjectSlug {
+  return Object.hasOwn(PROJECTS, slug);
+}

--- a/apps/chat/app/(site)/life/_lib/scenarios.ts
+++ b/apps/chat/app/(site)/life/_lib/scenarios.ts
@@ -1,0 +1,373 @@
+// Replay scenarios — typed port of the prototype's data.js LifeScenarios.
+// Each scenario is an ordered list of ReplayEvents stamped with `t` (ms from
+// scenario start). The replay clock dispatches them via applyEvent in
+// use-replay.ts.
+
+import type { ReplayEvent, ScenarioId } from "./types";
+
+const refactorScript: ReplayEvent[] = [
+  {
+    t: 0,
+    kind: "user",
+    text:
+      "Refactor `crates/arcan/src/stream.rs` to batch SSE chunks. The inner loop is allocating on every token — profile Vigil and fix it.",
+  },
+  { t: 800, kind: "agent-thinking-start", id: "m1" },
+  {
+    t: 900,
+    kind: "thinking",
+    id: "m1",
+    text:
+      "User wants a perf fix on Arcan's stream handler. I should:\n1. Pull vigil traces for the last 10 chat turns to confirm the allocation hotspot\n2. Read stream.rs\n3. Read the callers before editing\n4. Benchmark after\nStart with a tight span query.",
+  },
+  { t: 2400, kind: "agent-thinking-end", id: "m1" },
+  {
+    t: 2500,
+    kind: "agent-text-start",
+    id: "m1",
+    text:
+      "Starting with a Vigil span query to confirm the hotspot before touching the file.",
+  },
+  {
+    t: 3800,
+    kind: "tool-call",
+    id: "t1",
+    name: "vigil.query_spans",
+    target: "arcan::stream::forward",
+    args: '{ "name": "arcan::stream::forward", "window": "10m", "limit": 20 }',
+    journalKind: "tool",
+  },
+  {
+    t: 4600,
+    kind: "tool-result",
+    id: "t1",
+    result:
+      "20 spans · p50 42ms · p95 118ms · genai.usage.completion_tokens=mean(384)\nallocator.alloc_count: mean(4,112)  ← 10.7 allocs per token\ntop frame: String::push_str (chain_completion.rs:148)",
+  },
+  {
+    t: 5200,
+    kind: "agent-text-append",
+    id: "m1",
+    text: " Confirmed — ~10 allocations per streamed token. Reading the file.",
+  },
+  {
+    t: 6000,
+    kind: "tool-call",
+    id: "t2",
+    name: "praxis.read_file",
+    target: "crates/arcan/src/stream.rs",
+    args: '{ "path": "crates/arcan/src/stream.rs" }',
+    journalKind: "tool",
+  },
+  { t: 6200, kind: "fs-op", path: "crates/arcan/src/stream.rs", op: "read" },
+  {
+    t: 6900,
+    kind: "tool-result",
+    id: "t2",
+    result:
+      "pub async fn forward(\n    mut rx: Receiver<Chunk>,\n    tx: mpsc::Sender<SseEvent>,\n) -> Result<()> {\n    while let Some(chunk) = rx.recv().await {\n        let mut s = String::new();\n        s.push_str(&chunk.delta);\n        tx.send(SseEvent::data(s)).await?;\n    }\n    Ok(())\n}",
+  },
+  {
+    t: 7400,
+    kind: "tool-call",
+    id: "t3",
+    name: "praxis.read_file",
+    target: "crates/arcan/src/chain_completion.rs",
+    args: '{ "path": "crates/arcan/src/chain_completion.rs", "range": [140, 180] }',
+    journalKind: "tool",
+  },
+  {
+    t: 7500,
+    kind: "fs-op",
+    path: "crates/arcan/src/chain_completion.rs",
+    op: "read",
+  },
+  {
+    t: 8100,
+    kind: "tool-result",
+    id: "t3",
+    result:
+      "148: let mut accumulated = String::new();\n149: for delta in deltas {\n150:     accumulated.push_str(&delta);   // allocates on every token\n151:     emit(accumulated.clone()).await?;",
+  },
+  { t: 8600, kind: "agent-thinking-start", id: "m2" },
+  {
+    t: 8700,
+    kind: "thinking",
+    id: "m2",
+    text:
+      "Two problems:\n- chain_completion.rs:150 clones the growing buffer every token\n- stream.rs creates a fresh String then moves it through the SSE frame\n\nFix: use a pooled BytesMut (arcan-core already imports it), batch with a 4ms flush timer, and emit borrowed slices. Keep the public signature.",
+  },
+  { t: 10100, kind: "agent-thinking-end", id: "m2" },
+  {
+    t: 10200,
+    kind: "agent-text-start",
+    id: "m2",
+    text:
+      "Found it — two hot spots. Moving to BytesMut + a 4ms flush window, keeping the public API stable.",
+  },
+  {
+    t: 11200,
+    kind: "tool-call",
+    id: "t4",
+    name: "praxis.edit_file",
+    target: "crates/arcan/src/stream.rs",
+    args: '{ "path": "crates/arcan/src/stream.rs", "hashline": "…" }',
+    journalKind: "tool",
+  },
+  { t: 11400, kind: "fs-op", path: "crates/arcan/src/stream.rs", op: "write" },
+  {
+    t: 12400,
+    kind: "tool-result",
+    id: "t4",
+    result:
+      "✓ wrote 46 lines (−18, +28)\ndiff: stream.rs\n- let mut s = String::new();\n- s.push_str(&chunk.delta);\n+ buf.extend_from_slice(chunk.delta.as_bytes());\n+ if buf.len() > 512 || flush_at.elapsed() > Duration::from_millis(4) {\n+     tx.send(SseEvent::data_bytes(buf.split())).await?;\n+ }",
+  },
+  {
+    t: 12800,
+    kind: "fs-op",
+    path: "crates/arcan/src/chain_completion.rs",
+    op: "write",
+  },
+  {
+    t: 13100,
+    kind: "tool-call",
+    id: "t5",
+    name: "praxis.edit_file",
+    target: "crates/arcan/src/chain_completion.rs",
+    args: '{ "path": "…", "hashline": "…" }',
+    journalKind: "tool",
+  },
+  { t: 13900, kind: "tool-result", id: "t5", result: "✓ wrote 8 lines (−3, +8)" },
+  {
+    t: 14400,
+    kind: "fs-op",
+    path: "crates/arcan/tests/stream_bench.rs",
+    op: "create",
+  },
+  {
+    t: 14600,
+    kind: "tool-call",
+    id: "t6",
+    name: "praxis.shell",
+    target: "cargo test -p arcan stream",
+    args: '{ "cmd": "cargo test -p arcan stream --release" }',
+    journalKind: "tool",
+  },
+  {
+    t: 16200,
+    kind: "tool-result",
+    id: "t6",
+    result:
+      "running 14 tests\n test stream::tests::forward_batches_deltas ... ok\n test stream::tests::forward_flushes_on_timer ... ok\n test stream::tests::forward_preserves_order  ... ok\n\ntest result: ok. 14 passed; 0 failed\n\nfinished in 0.82s",
+  },
+  {
+    t: 16800,
+    kind: "nous-score",
+    score: 0.92,
+    band: "good",
+    note:
+      "diff compiles, tests green, scoped to the reported hotspot, no new public surface.",
+  },
+  {
+    t: 17100,
+    kind: "agent-text-start",
+    id: "m3",
+    text:
+      "Done. Re-ran the bench:\n\n```\nbefore:  42ms p50 / 118ms p95  /  4,112 allocs\nafter:   11ms p50 /  28ms p95  /    312 allocs\n```\n\nNous scored the change 0.92 — scoped, tested, public API unchanged. I flushed the buffer on either 512B or 4ms, whichever comes first. Want me to open the PR?",
+  },
+];
+
+const ingestScript: ReplayEvent[] = [
+  {
+    t: 0,
+    kind: "user",
+    text:
+      "Ingest the paper at /workspace/drafts/constitutional-ai.pdf into Lago. Link it to existing nodes for RLHF, reward hacking, and agent safety.",
+  },
+  { t: 800, kind: "agent-thinking-start", id: "m1" },
+  {
+    t: 900,
+    kind: "thinking",
+    id: "m1",
+    text:
+      "Lago ingest flow:\n1. blob store put → cid\n2. extract → chunks\n3. embed each chunk\n4. emit lago.node.upsert events\n5. resolve links to the three target concept nodes\n\nUse praxis.lago.ingest — it handles the pipeline.",
+  },
+  { t: 2200, kind: "agent-thinking-end", id: "m1" },
+  {
+    t: 2300,
+    kind: "agent-text-start",
+    id: "m1",
+    text: "Opening the paper and running the ingest pipeline.",
+  },
+  {
+    t: 3100,
+    kind: "fs-op",
+    path: "/workspace/drafts/constitutional-ai.pdf",
+    op: "read",
+  },
+  {
+    t: 3400,
+    kind: "tool-call",
+    id: "t1",
+    name: "lago.blob.put",
+    target: "constitutional-ai.pdf",
+    args: '{ "mime": "application/pdf", "size": 842112 }',
+    journalKind: "tool",
+  },
+  {
+    t: 4100,
+    kind: "tool-result",
+    id: "t1",
+    result: "cid: bafybeig... (822KB, 43 pages)",
+  },
+  {
+    t: 4600,
+    kind: "tool-call",
+    id: "t2",
+    name: "lago.extract",
+    target: "cid:bafybeig…",
+    args: "{}",
+    journalKind: "tool",
+  },
+  {
+    t: 6200,
+    kind: "tool-result",
+    id: "t2",
+    result: "87 chunks extracted · 12.4k tokens · 16 figures",
+  },
+  {
+    t: 6800,
+    kind: "tool-call",
+    id: "t3",
+    name: "lago.embed",
+    target: "87 chunks",
+    args: '{ "model": "text-embedding-3-large" }',
+    journalKind: "tool",
+  },
+  {
+    t: 9400,
+    kind: "tool-result",
+    id: "t3",
+    result: "87 vectors · dim=3072 · total cost $0.0112",
+  },
+  {
+    t: 9800,
+    kind: "fs-op",
+    path: "/workspace/lago/nodes/paper-constitutional-ai.json",
+    op: "create",
+  },
+  {
+    t: 10100,
+    kind: "fs-op",
+    path: "/workspace/lago/edges/rlhf→constitutional-ai.json",
+    op: "create",
+  },
+  {
+    t: 10400,
+    kind: "fs-op",
+    path: "/workspace/lago/edges/reward-hacking→constitutional-ai.json",
+    op: "create",
+  },
+  {
+    t: 10700,
+    kind: "fs-op",
+    path: "/workspace/lago/edges/agent-safety→constitutional-ai.json",
+    op: "create",
+  },
+  {
+    t: 11100,
+    kind: "nous-score",
+    score: 0.86,
+    band: "good",
+    note:
+      "3/3 target nodes resolved; 4 secondary links inferred (harmlessness, red-teaming, supervised FT, RLAIF).",
+  },
+  {
+    t: 11400,
+    kind: "agent-text-start",
+    id: "m2",
+    text:
+      "Ingested. One new node + 7 edges (3 you asked for + 4 inferred). Graph view should have updated.",
+  },
+];
+
+const researchScript: ReplayEvent[] = [
+  {
+    t: 0,
+    kind: "user",
+    text:
+      "Research: what's the strongest open-source alternative to Claude for agentic tool use, as of this week? Spec: budget $0.80, 15min, deliver a ranked shortlist.",
+  },
+  {
+    t: 600,
+    kind: "autonomic-event",
+    pillar: "economic",
+    text: "Budget accepted: $0.80 / 15min. Mode → Explore.",
+  },
+  { t: 1200, kind: "agent-thinking-start", id: "m1" },
+  {
+    t: 1300,
+    kind: "thinking",
+    id: "m1",
+    text:
+      "Plan:\n1. Pull leaderboards (BFCL, τ-bench, SWE-bench verified)\n2. Filter for Apache/MIT license\n3. Score on tool-use + long-context + cost\n4. Autonomic will throttle if I run hot",
+  },
+  { t: 2800, kind: "agent-thinking-end", id: "m1" },
+  {
+    t: 3200,
+    kind: "tool-call",
+    id: "t1",
+    name: "spaces.peer.dispatch",
+    target: "leaderboard-scout",
+    args: '{ "peer": "leaderboard-scout", "task": "pull top-10 open OSS agents" }',
+    journalKind: "tool",
+  },
+  { t: 4200, kind: "tool-result", id: "t1", result: "dispatched · eta 45s" },
+  {
+    t: 5800,
+    kind: "autonomic-event",
+    pillar: "cognitive",
+    text: "Context pressure 68% — compacting oldest 4 turns.",
+  },
+  {
+    t: 7200,
+    kind: "tool-call",
+    id: "t2",
+    name: "haima.pay",
+    target: "0x9f4…b21",
+    args: '{ "amount": "0.02 USDC", "reason": "leaderboard-scout query" }',
+    journalKind: "tool",
+  },
+  {
+    t: 7800,
+    kind: "tool-result",
+    id: "t2",
+    result: "paid via x402 · tx: 0xaa1…",
+  },
+  {
+    t: 9100,
+    kind: "nous-score",
+    score: 0.72,
+    band: "warn",
+    note: "coverage good; two candidates missing license check.",
+  },
+  {
+    t: 9600,
+    kind: "agent-text-start",
+    id: "m2",
+    text:
+      "Shortlist forming — waiting on a second-pass license audit before I commit a ranking.",
+  },
+];
+
+export const SCENARIOS: Record<ScenarioId, ReplayEvent[]> = {
+  refactor: refactorScript,
+  ingest: ingestScript,
+  research: researchScript,
+};
+
+export const SCENARIO_LABELS: Record<ScenarioId, string> = {
+  refactor: "Refactor · arcan/stream",
+  ingest: "Ingest · constitutional-ai.pdf",
+  research: "Research · OSS agent shortlist",
+};

--- a/apps/chat/app/(site)/life/_lib/tweaks.ts
+++ b/apps/chat/app/(site)/life/_lib/tweaks.ts
@@ -1,0 +1,87 @@
+// Tweaks defaults + localStorage persistence (no postMessage / sandbox coupling).
+// Replaces the prototype's window.parent.postMessage edit-mode wiring with a
+// safe SSR-friendly localStorage strategy. Keys are namespaced to avoid
+// collisions with other broomva.tech surfaces.
+
+import type {
+  FsStyle,
+  LayoutMode,
+  MetricsDensity,
+  MiddleMode,
+  RightMode,
+  ScenarioId,
+  TweaksState,
+} from "./types";
+
+export const TWEAKS_STORAGE_KEY = "life.tweaks.v1";
+
+export const DEFAULT_TWEAKS: TweaksState = {
+  layout: "classic",
+  middleMode: "files",
+  rightMode: "preview",
+  fsStyle: "heartbeat",
+  journalRich: false,
+  metricsDensity: "rich",
+  orbs: true,
+  scenario: "refactor",
+  autoplay: true,
+};
+
+const LAYOUTS: LayoutMode[] = ["classic", "experimental"];
+const MIDDLE: MiddleMode[] = ["files", "journal", "timeline", "graph", "spaces"];
+const RIGHT: RightMode[] = [
+  "preview",
+  "vigil",
+  "nous",
+  "autonomic",
+  "haima",
+  "anima",
+];
+const FS: FsStyle[] = ["finder", "shimmer", "heartbeat", "ticker"];
+const DENSITY: MetricsDensity[] = ["minimal", "medium", "rich"];
+const SCENARIOS: ScenarioId[] = ["refactor", "ingest", "research"];
+
+function pick<T>(allowed: readonly T[], v: unknown, fallback: T): T {
+  return allowed.includes(v as T) ? (v as T) : fallback;
+}
+
+export function readTweaks(): TweaksState {
+  if (typeof window === "undefined") return DEFAULT_TWEAKS;
+  try {
+    const raw = window.localStorage.getItem(TWEAKS_STORAGE_KEY);
+    if (!raw) return DEFAULT_TWEAKS;
+    const parsed = JSON.parse(raw) as Partial<TweaksState>;
+    return {
+      layout: pick(LAYOUTS, parsed.layout, DEFAULT_TWEAKS.layout),
+      middleMode: pick(MIDDLE, parsed.middleMode, DEFAULT_TWEAKS.middleMode),
+      rightMode: pick(RIGHT, parsed.rightMode, DEFAULT_TWEAKS.rightMode),
+      fsStyle: pick(FS, parsed.fsStyle, DEFAULT_TWEAKS.fsStyle),
+      journalRich:
+        typeof parsed.journalRich === "boolean"
+          ? parsed.journalRich
+          : DEFAULT_TWEAKS.journalRich,
+      metricsDensity: pick(
+        DENSITY,
+        parsed.metricsDensity,
+        DEFAULT_TWEAKS.metricsDensity,
+      ),
+      orbs: typeof parsed.orbs === "boolean" ? parsed.orbs : DEFAULT_TWEAKS.orbs,
+      scenario: pick(SCENARIOS, parsed.scenario, DEFAULT_TWEAKS.scenario),
+      autoplay:
+        typeof parsed.autoplay === "boolean"
+          ? parsed.autoplay
+          : DEFAULT_TWEAKS.autoplay,
+    };
+  } catch {
+    return DEFAULT_TWEAKS;
+  }
+}
+
+export function writeTweaks(tweaks: TweaksState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TWEAKS_STORAGE_KEY, JSON.stringify(tweaks));
+  } catch {
+    // Quota exceeded / private mode — silently degrade.
+  }
+}

--- a/apps/chat/app/(site)/life/_lib/types.ts
+++ b/apps/chat/app/(site)/life/_lib/types.ts
@@ -1,0 +1,218 @@
+// Typed contracts for the /life UI surface.
+// Layer 2 / 3 / 4 follow-up notes live in the project-map.ts and PR description.
+
+export type ScenarioId = "refactor" | "ingest" | "research";
+
+export type LayoutMode = "classic" | "experimental";
+export type MiddleMode = "files" | "journal" | "timeline" | "graph" | "spaces";
+export type RightMode =
+  | "preview"
+  | "vigil"
+  | "nous"
+  | "autonomic"
+  | "haima"
+  | "anima";
+export type FsStyle = "finder" | "shimmer" | "heartbeat" | "ticker";
+export type MetricsDensity = "minimal" | "medium" | "rich";
+
+export interface TweaksState {
+  layout: LayoutMode;
+  middleMode: MiddleMode;
+  rightMode: RightMode;
+  fsStyle: FsStyle;
+  journalRich: boolean;
+  metricsDensity: MetricsDensity;
+  orbs: boolean;
+  scenario: ScenarioId;
+  autoplay: boolean;
+}
+
+// ---- Replay scenario events ----
+
+export type JournalKind =
+  | "tool"
+  | "fs"
+  | "llm"
+  | "nous"
+  | "autonomic"
+  | "haima";
+
+export type ReplayEvent =
+  | { t: number; kind: "user"; text: string }
+  | { t: number; kind: "agent-thinking-start"; id: string }
+  | { t: number; kind: "thinking"; id: string; text: string }
+  | { t: number; kind: "agent-thinking-end"; id: string }
+  | { t: number; kind: "agent-text-start"; id: string; text: string }
+  | { t: number; kind: "agent-text-append"; id: string; text: string }
+  | {
+      t: number;
+      kind: "tool-call";
+      id: string;
+      name: string;
+      target: string;
+      args: string;
+      journalKind?: JournalKind;
+    }
+  | { t: number; kind: "tool-result"; id: string; result: string }
+  | { t: number; kind: "fs-op"; path: string; op: FsOpKind }
+  | {
+      t: number;
+      kind: "nous-score";
+      score: number;
+      band: "good" | "warn";
+      note: string;
+    }
+  | {
+      t: number;
+      kind: "autonomic-event";
+      pillar: "operational" | "cognitive" | "economic";
+      text: string;
+    };
+
+export type FsOpKind = "read" | "write" | "create" | "delete";
+
+// ---- Replay state shape ----
+
+export interface LifeTool {
+  id: string;
+  name: string;
+  target: string;
+  args: string;
+  result: string | null;
+  status: "running" | "ok";
+  t: number;
+}
+
+export interface LifeMessage {
+  id: string;
+  role: "user" | "agent";
+  text: string;
+  thinking?: string;
+  thinkingOpen?: boolean;
+  complete: boolean;
+  streamingThinking?: boolean;
+  streamingText?: boolean;
+  tools: LifeTool[];
+}
+
+export interface LifeFsOp {
+  id: string;
+  path: string;
+  op: FsOpKind;
+  t: number;
+}
+
+export interface LifeJournalEntry {
+  id: string;
+  ts: string;
+  kind: JournalKind;
+  label: string;
+  actor: string;
+  msg: string;
+  payload: string;
+  linkToolId?: string;
+}
+
+export interface NousLive {
+  score: number;
+  band: "good" | "warn";
+  note: string;
+}
+
+export interface AutonomicEvent {
+  t: number;
+  pillar: "operational" | "cognitive" | "economic";
+  text: string;
+}
+
+export interface ReplayState {
+  messages: LifeMessage[];
+  fsOps: LifeFsOp[];
+  journal: LifeJournalEntry[];
+  nous: NousLive | null;
+  autonomic: AutonomicEvent[];
+  t: number;
+}
+
+// ---- Workspace mock data ----
+
+export interface LifeFsNode {
+  path: string;
+  type: "dir" | "file";
+  children?: LifeFsNode[];
+}
+
+export interface LifeTraceSpan {
+  name: string;
+  kind: "root" | "span" | "tool" | "llm";
+  start: number;
+  dur: number;
+  color: "tool" | "llm" | "default";
+}
+
+export interface LifeHomeoPillar {
+  value: number;
+  target: number;
+  sub: string;
+}
+
+export interface LifeHomeo {
+  operational: LifeHomeoPillar;
+  cognitive: LifeHomeoPillar;
+  economic: LifeHomeoPillar;
+}
+
+export interface LifeHaima {
+  session_spend: number;
+  session_budget: number;
+  tokens_in: number;
+  tokens_out: number;
+  x402_txs: number;
+  last_pay: string;
+}
+
+export interface LifeJudge {
+  axis: string;
+  score: number;
+  band: "good" | "warn";
+  note: string;
+}
+
+export interface LifeAnima {
+  name: string;
+  soul: string;
+  tier: string;
+  did: string;
+  beliefs: string[];
+  trust: Record<string, number>;
+  session: string;
+}
+
+export interface LifePeer {
+  name: string;
+  role: string;
+  lat: number;
+  status: string;
+  hue: string;
+}
+
+export interface LifeGraphNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  kind: "concept" | "paper" | "artifact";
+  r: number;
+  fresh?: boolean;
+}
+
+export interface LifeGraphEdge {
+  a: string;
+  b: string;
+  fresh?: boolean;
+}
+
+export interface LifeGraph {
+  nodes: LifeGraphNode[];
+  edges: LifeGraphEdge[];
+}

--- a/apps/chat/app/(site)/life/_lib/use-replay.ts
+++ b/apps/chat/app/(site)/life/_lib/use-replay.ts
@@ -1,0 +1,303 @@
+// Replay clock — drives the streaming agent UI from a typed scenario script.
+// Client-only (uses requestAnimationFrame + performance.now).
+// SSR-safe: all browser globals are guarded.
+
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useRef, useState } from "react";
+import type {
+  LifeJournalEntry,
+  LifeMessage,
+  LifeTool,
+  ReplayEvent,
+  ReplayState,
+} from "./types";
+
+const EMPTY_STATE: ReplayState = {
+  messages: [],
+  fsOps: [],
+  journal: [],
+  nous: null,
+  autonomic: [],
+  t: 0,
+};
+
+function formatTime(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60).toString().padStart(2, "0");
+  const s = (total % 60).toString().padStart(2, "0");
+  const mm = Math.floor((ms % 1000) / 10).toString().padStart(2, "0");
+  return `${m}:${s}.${mm}`;
+}
+
+function applyEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
+  const nowIso = formatTime(ev.t);
+  switch (ev.kind) {
+    case "user": {
+      const msg: LifeMessage = {
+        id: `u-${ev.t}`,
+        role: "user",
+        text: ev.text,
+        complete: true,
+        tools: [],
+      };
+      const journal: LifeJournalEntry = {
+        id: `j-${ev.t}-u`,
+        ts: nowIso,
+        kind: "llm",
+        label: "USER",
+        actor: "you",
+        msg: ev.text,
+        payload: ev.text,
+      };
+      return {
+        ...s,
+        messages: [...s.messages, msg],
+        journal: [...s.journal, journal],
+      };
+    }
+    case "agent-thinking-start": {
+      const msg: LifeMessage = {
+        id: ev.id,
+        role: "agent",
+        text: "",
+        thinking: "",
+        thinkingOpen: true,
+        complete: false,
+        streamingThinking: true,
+        tools: [],
+      };
+      return { ...s, messages: [...s.messages, msg] };
+    }
+    case "thinking": {
+      return {
+        ...s,
+        messages: s.messages.map((m) =>
+          m.id === ev.id
+            ? { ...m, thinking: ev.text, streamingThinking: false }
+            : m,
+        ),
+      };
+    }
+    case "agent-thinking-end": {
+      return {
+        ...s,
+        messages: s.messages.map((m) =>
+          m.id === ev.id ? { ...m, streamingThinking: false } : m,
+        ),
+      };
+    }
+    case "agent-text-start": {
+      const existing = s.messages.find((m) => m.id === ev.id);
+      if (existing) {
+        return {
+          ...s,
+          messages: s.messages.map((m) =>
+            m.id === ev.id ? { ...m, text: ev.text, streamingText: true } : m,
+          ),
+        };
+      }
+      const msg: LifeMessage = {
+        id: ev.id,
+        role: "agent",
+        text: ev.text,
+        thinking: "",
+        thinkingOpen: false,
+        complete: false,
+        streamingText: true,
+        tools: [],
+      };
+      return { ...s, messages: [...s.messages, msg] };
+    }
+    case "agent-text-append": {
+      return {
+        ...s,
+        messages: s.messages.map((m) =>
+          m.id === ev.id
+            ? { ...m, text: (m.text || "") + ev.text, streamingText: true }
+            : m,
+        ),
+      };
+    }
+    case "tool-call": {
+      const lastAgent = [...s.messages].reverse().find((m) => m.role === "agent");
+      const tool: LifeTool = {
+        id: ev.id,
+        name: ev.name,
+        target: ev.target,
+        args: ev.args,
+        result: null,
+        status: "running",
+        t: ev.t,
+      };
+      const messages = s.messages.map((m) =>
+        m === lastAgent ? { ...m, tools: [...(m.tools || []), tool] } : m,
+      );
+      const journal: LifeJournalEntry = {
+        id: `j-${ev.id}-c`,
+        ts: nowIso,
+        kind: ev.journalKind || "tool",
+        label: "TOOL",
+        actor: ev.name.split(".")[0] ?? ev.name,
+        msg: `${ev.name} → ${ev.target}`,
+        payload: ev.args,
+        linkToolId: ev.id,
+      };
+      return { ...s, messages, journal: [...s.journal, journal] };
+    }
+    case "tool-result": {
+      const messages = s.messages.map((m) => ({
+        ...m,
+        tools: (m.tools || []).map((t) =>
+          t.id === ev.id ? { ...t, result: ev.result, status: "ok" as const } : t,
+        ),
+      }));
+      const firstLine = ev.result.split("\n")[0] ?? ev.result;
+      const journal: LifeJournalEntry = {
+        id: `j-${ev.id}-r`,
+        ts: nowIso,
+        kind: "tool",
+        label: "RESULT",
+        actor: "praxis",
+        msg: firstLine,
+        payload: ev.result,
+        linkToolId: ev.id,
+      };
+      return { ...s, messages, journal: [...s.journal, journal] };
+    }
+    case "fs-op": {
+      const fsOp = {
+        id: `fs-${ev.t}-${ev.path}`,
+        path: ev.path,
+        op: ev.op,
+        t: ev.t,
+      };
+      const journal: LifeJournalEntry = {
+        id: `j-${ev.t}-fs`,
+        ts: nowIso,
+        kind: "fs",
+        label: ev.op.toUpperCase(),
+        actor: "praxis",
+        msg: ev.path,
+        payload: `op: ${ev.op}\npath: ${ev.path}`,
+      };
+      return {
+        ...s,
+        fsOps: [...s.fsOps, fsOp],
+        journal: [...s.journal, journal],
+      };
+    }
+    case "nous-score": {
+      const journal: LifeJournalEntry = {
+        id: `j-${ev.t}-n`,
+        ts: nowIso,
+        kind: "nous",
+        label: "JUDGE",
+        actor: "nous",
+        msg: `score ${ev.score.toFixed(2)} · ${ev.note}`,
+        payload: ev.note,
+      };
+      return {
+        ...s,
+        nous: { score: ev.score, band: ev.band, note: ev.note },
+        journal: [...s.journal, journal],
+      };
+    }
+    case "autonomic-event": {
+      const journal: LifeJournalEntry = {
+        id: `j-${ev.t}-a`,
+        ts: nowIso,
+        kind: "autonomic",
+        label: ev.pillar.toUpperCase(),
+        actor: "autonomic",
+        msg: ev.text,
+        payload: ev.text,
+      };
+      return {
+        ...s,
+        autonomic: [...s.autonomic, { t: ev.t, pillar: ev.pillar, text: ev.text }],
+        journal: [...s.journal, journal],
+      };
+    }
+    default:
+      return s;
+  }
+}
+
+export type ReplayHookResult = [
+  ReplayState,
+  Dispatch<SetStateAction<ReplayState>>,
+];
+
+export function useReplay(
+  script: ReplayEvent[],
+  playing: boolean,
+): ReplayHookResult {
+  const [state, setState] = useState<ReplayState>(EMPTY_STATE);
+  const timer = useRef<number | null>(null);
+  const idxRef = useRef(0);
+  const startRef = useRef<number | null>(null);
+  const tRef = useRef(0);
+
+  // Reset whenever the underlying scenario script changes.
+  useEffect(() => {
+    setState(EMPTY_STATE);
+    idxRef.current = 0;
+    startRef.current = null;
+    tRef.current = 0;
+  }, [script]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!playing) {
+      if (timer.current !== null) {
+        cancelAnimationFrame(timer.current);
+        timer.current = null;
+      }
+      return;
+    }
+    startRef.current = performance.now() - tRef.current;
+
+    const step = (now: number) => {
+      const elapsed = now - (startRef.current ?? now);
+      tRef.current = elapsed;
+      let didUpdate = false;
+      setState((s) => {
+        let next: ReplayState = { ...s, t: elapsed };
+        while (
+          idxRef.current < script.length &&
+          script[idxRef.current]!.t <= elapsed
+        ) {
+          const ev = script[idxRef.current++]!;
+          next = applyEvent(next, ev);
+          didUpdate = true;
+        }
+        return didUpdate || next.t !== s.t ? next : s;
+      });
+      if (idxRef.current < script.length) {
+        timer.current = requestAnimationFrame(step);
+      } else {
+        timer.current = null;
+      }
+    };
+
+    timer.current = requestAnimationFrame(step);
+    return () => {
+      if (timer.current !== null) {
+        cancelAnimationFrame(timer.current);
+        timer.current = null;
+      }
+    };
+    // We deliberately depend only on `playing` and `script` — start ref
+    // captures resume time so internal state doesn't retrigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playing, script]);
+
+  // Keep tRef in sync when state.t changes externally (e.g. reset).
+  useEffect(() => {
+    tRef.current = state.t;
+  }, [state.t]);
+
+  return [state, setState];
+}

--- a/apps/chat/app/(site)/life/layout.tsx
+++ b/apps/chat/app/(site)/life/layout.tsx
@@ -1,0 +1,9 @@
+import "./life-styles.css";
+
+export default function LifeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/chat/app/(site)/life/life-styles.css
+++ b/apps/chat/app/(site)/life/life-styles.css
@@ -1,0 +1,790 @@
+/* ============================================================================
+   /life — Arcan Glass surface styles (scoped to .life-shell-root)
+   Ported from Claude Design "Life Interface" prototype.
+   Tokens (--ag-*) are reused from apps/chat/app/globals.css.
+   ============================================================================ */
+
+.life-shell-root {
+  position: fixed;
+  inset: 0;
+  background: var(--ag-bg-deep);
+  color: var(--ag-text-primary);
+  font-family: var(--ag-font-body);
+  overflow: hidden;
+  z-index: 0;
+}
+
+.life-shell-root.life-shell-root--orbs {
+  background-image:
+    radial-gradient(ellipse 1400px 900px at 20% -10%, oklch(0.60 0.12 260 / 0.10), transparent 60%),
+    radial-gradient(ellipse 1000px 700px at 110% 80%, oklch(0.65 0.14 235 / 0.07), transparent 55%);
+}
+
+/* ---- App shell ---- */
+.life-shell-root .shell {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 380px 1fr 440px;
+  grid-template-rows: 52px 1fr 44px;
+  grid-template-areas:
+    "top top top"
+    "chat middle right"
+    "dock dock dock";
+  gap: 0;
+}
+.life-shell-root .shell--wide-middle { grid-template-columns: 340px 1fr 420px; }
+.life-shell-root .shell--experimental {
+  grid-template-columns: 1fr;
+  grid-template-rows: 52px 1fr 44px;
+  grid-template-areas:
+    "top"
+    "experimental"
+    "dock";
+}
+
+/* ---- Top strip ---- */
+.life-shell-root .topbar {
+  grid-area: top;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--ag-border-subtle);
+  background: color-mix(in oklab, var(--ag-bg-deep) 75%, transparent);
+  backdrop-filter: blur(16px) saturate(1.3);
+  -webkit-backdrop-filter: blur(16px) saturate(1.3);
+  z-index: 40;
+}
+.life-shell-root .topbar__left,
+.life-shell-root .topbar__right { display: flex; align-items: center; gap: 14px; }
+.life-shell-root .topbar__crumb {
+  font-family: var(--ag-font-mono);
+  font-size: 11px;
+  color: var(--ag-text-muted);
+  letter-spacing: 0.02em;
+}
+.life-shell-root .topbar__crumb strong { color: var(--ag-text-secondary); font-weight: 500; }
+.life-shell-root .topbar__crumb .sep { opacity: 0.4; margin: 0 6px; }
+
+/* ---- Anima badge ---- */
+.life-shell-root .anima-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 12px 4px 4px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 50%, transparent);
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: all var(--ag-transition-fast);
+}
+.life-shell-root .anima-badge:hover {
+  border-color: oklch(0.60 0.12 260 / 0.45);
+  background: color-mix(in oklab, var(--ag-bg-surface) 70%, transparent);
+}
+.life-shell-root .anima-avatar {
+  width: 28px; height: 28px; border-radius: 9999px;
+  background: conic-gradient(from 120deg, oklch(0.60 0.12 260), oklch(0.65 0.14 235), oklch(0.70 0.15 300), oklch(0.60 0.12 260));
+  box-shadow: 0 0 0 1px oklch(1 0 0 / 0.08), inset 0 0 8px oklch(0 0 0 / 0.4);
+  position: relative;
+}
+.life-shell-root .anima-avatar::after {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 35% 30%, oklch(1 0 0 / 0.35), transparent 55%);
+}
+.life-shell-root .anima-name {
+  font-family: var(--ag-font-heading);
+  font-size: 13px;
+  letter-spacing: -0.005em;
+  color: var(--ag-text-primary);
+}
+.life-shell-root .anima-soul {
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  color: var(--ag-text-muted);
+  letter-spacing: 0.04em;
+}
+
+/* ---- Columns ---- */
+.life-shell-root .col {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+.life-shell-root .col--chat { grid-area: chat; border-right: 1px solid var(--ag-border-subtle); }
+.life-shell-root .col--middle { grid-area: middle; border-right: 1px solid var(--ag-border-subtle); }
+.life-shell-root .col--right { grid-area: right; }
+.life-shell-root .col--experimental { grid-area: experimental; }
+
+.life-shell-root .col__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--ag-border-subtle);
+  background: color-mix(in oklab, var(--ag-bg-deep) 60%, transparent);
+  flex: 0 0 auto;
+}
+.life-shell-root .col__body { flex: 1 1 auto; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+
+/* ---- Tabs ---- */
+.life-shell-root .tabs {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+.life-shell-root .tab {
+  appearance: none; border: 0; background: transparent;
+  font-family: var(--ag-font-body);
+  font-size: 11.5px;
+  color: var(--ag-text-muted);
+  letter-spacing: 0.01em;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: all var(--ag-transition-fast);
+  position: relative;
+}
+.life-shell-root .tab:hover { color: var(--ag-text-secondary); background: oklch(1 0 0 / 0.03); }
+.life-shell-root .tab[aria-selected="true"] {
+  color: var(--ag-text-primary);
+  background: color-mix(in oklab, var(--ag-bg-elevated) 60%, transparent);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04);
+}
+.life-shell-root .tab .dot {
+  width: 5px; height: 5px; border-radius: 9999px;
+  background: var(--ag-ai-blue);
+  box-shadow: 0 0 6px var(--ag-ai-blue);
+}
+
+/* ---- Eyebrow ---- */
+.life-shell-root .eyebrow {
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  color: var(--ag-ai-blue);
+}
+
+/* ---- Buttons ---- */
+.life-shell-root .btn {
+  appearance: none; cursor: pointer;
+  font-family: var(--ag-font-body);
+  font-size: 12px; font-weight: 500;
+  padding: 7px 12px;
+  border-radius: 8px;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: all var(--ag-transition-fast);
+  color: var(--ag-text-secondary);
+  background: transparent;
+  border: 1px solid var(--ag-border-subtle);
+}
+.life-shell-root .btn:hover { color: var(--ag-text-primary); border-color: var(--ag-border-default); background: oklch(1 0 0 / 0.03); }
+.life-shell-root .btn--primary {
+  color: oklch(0.98 0 0);
+  background: color-mix(in oklab, var(--ag-ai-blue) 85%, var(--ag-bg-deep));
+  border-color: oklch(0.60 0.12 260 / 0.5);
+  box-shadow: 0 0 0 1px oklch(1 0 0 / 0.04) inset, var(--ag-shadow-glow-blue);
+}
+.life-shell-root .btn--primary:hover { background: var(--ag-ai-blue); }
+.life-shell-root .btn--ghost { border-color: transparent; }
+.life-shell-root .btn--icon { padding: 6px; }
+
+/* ---- Chat ---- */
+.life-shell-root .chat-scroll { flex: 1; overflow-y: auto; padding: 16px 18px 20px; }
+.life-shell-root .msg { margin-bottom: 18px; }
+.life-shell-root .msg__role {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--ag-font-mono);
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--ag-text-muted);
+  margin-bottom: 6px;
+}
+.life-shell-root .msg__role .swatch {
+  width: 6px; height: 6px; border-radius: 9999px;
+  background: var(--ag-text-muted);
+}
+.life-shell-root .msg--user .msg__role .swatch { background: oklch(0.70 0.02 275); }
+.life-shell-root .msg--agent .msg__role .swatch { background: var(--ag-ai-blue); box-shadow: 0 0 6px var(--ag-ai-blue); }
+.life-shell-root .msg__body {
+  font-size: 13.5px;
+  line-height: 1.62;
+  color: var(--ag-text-primary);
+}
+.life-shell-root .msg__body code {
+  background: color-mix(in oklab, var(--ag-bg-elevated) 60%, transparent);
+  padding: 1px 5px; border-radius: 4px;
+  border: 1px solid var(--ag-border-subtle);
+  font-size: 11.5px;
+}
+.life-shell-root .msg__body pre {
+  background: color-mix(in oklab, var(--ag-bg-deep) 70%, transparent);
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 11.5px;
+  overflow-x: auto;
+  margin: 10px 0;
+}
+
+/* thinking collapsible */
+.life-shell-root .thinking {
+  margin: 10px 0;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 35%, transparent);
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+}
+.life-shell-root .thinking__head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 11.5px;
+  color: var(--ag-text-secondary);
+}
+.life-shell-root .thinking__head .eyebrow { font-size: 9.5px; letter-spacing: 0.22em; }
+.life-shell-root .thinking__body {
+  padding: 0 14px 12px;
+  font-family: var(--ag-font-mono);
+  font-size: 11px;
+  line-height: 1.65;
+  color: var(--ag-text-secondary);
+  border-top: 1px dashed var(--ag-border-subtle);
+  padding-top: 10px;
+  white-space: pre-wrap;
+}
+.life-shell-root .thinking .chev { transition: transform var(--ag-transition-fast); color: var(--ag-text-muted); }
+.life-shell-root .thinking[data-open="false"] .thinking__body { display: none; }
+.life-shell-root .thinking[data-open="false"] .chev { transform: rotate(-90deg); }
+
+/* tool call inline block */
+.life-shell-root .toolcall {
+  margin: 10px 0;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--ag-bg-elevated) 50%, transparent);
+  overflow: hidden;
+  transition: border-color var(--ag-transition-fast);
+}
+.life-shell-root .toolcall.is-highlighted {
+  border-color: oklch(0.60 0.12 260 / 0.7);
+  box-shadow: 0 0 0 1px oklch(0.60 0.12 260 / 0.3), var(--ag-shadow-glow-blue);
+}
+.life-shell-root .toolcall__head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 11.5px;
+}
+.life-shell-root .toolcall__icon {
+  width: 22px; height: 22px; border-radius: 6px;
+  background: color-mix(in oklab, var(--ag-ai-blue) 18%, transparent);
+  border: 1px solid oklch(0.60 0.12 260 / 0.35);
+  color: var(--ag-ai-blue);
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--ag-font-mono); font-size: 11px;
+}
+.life-shell-root .toolcall__name { font-family: var(--ag-font-mono); color: var(--ag-text-primary); letter-spacing: 0.01em; }
+.life-shell-root .toolcall__target { color: var(--ag-text-secondary); font-family: var(--ag-font-mono); font-size: 11px; }
+.life-shell-root .toolcall__meta { margin-left: auto; display: inline-flex; align-items: center; gap: 8px; color: var(--ag-text-muted); font-family: var(--ag-font-mono); font-size: 10.5px; }
+.life-shell-root .toolcall__body {
+  padding: 10px 14px 12px;
+  border-top: 1px dashed var(--ag-border-subtle);
+  font-family: var(--ag-font-mono); font-size: 11px; line-height: 1.55;
+  color: var(--ag-text-secondary);
+  background: color-mix(in oklab, var(--ag-bg-deep) 55%, transparent);
+}
+.life-shell-root .toolcall[data-open="false"] .toolcall__body { display: none; }
+
+/* streaming cursor */
+.life-shell-root .caret {
+  display: inline-block;
+  width: 7px; height: 14px;
+  background: var(--ag-ai-blue);
+  vertical-align: -2px;
+  margin-left: 2px;
+  animation: lifeCaret 1s steps(2, start) infinite;
+  box-shadow: 0 0 6px var(--ag-ai-blue);
+}
+@keyframes lifeCaret { to { opacity: 0; } }
+
+/* status stripe */
+.life-shell-root .agent-status {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--ag-text-secondary);
+  font-family: var(--ag-font-mono);
+  letter-spacing: 0.01em;
+  border-top: 1px solid var(--ag-border-subtle);
+  background: color-mix(in oklab, var(--ag-bg-deep) 60%, transparent);
+}
+.life-shell-root .agent-status__pulse {
+  width: 8px; height: 8px; border-radius: 9999px;
+  background: var(--ag-ai-blue);
+  box-shadow: 0 0 0 0 oklch(0.60 0.12 260 / 0.7);
+  animation: lifePulse 1.8s infinite;
+}
+.life-shell-root .agent-status--idle .agent-status__pulse { background: var(--ag-text-muted); box-shadow: none; animation: none; }
+@keyframes lifePulse {
+  0% { box-shadow: 0 0 0 0 oklch(0.60 0.12 260 / 0.6); }
+  70% { box-shadow: 0 0 0 8px oklch(0.60 0.12 260 / 0); }
+  100% { box-shadow: 0 0 0 0 oklch(0.60 0.12 260 / 0); }
+}
+
+/* composer */
+.life-shell-root .composer {
+  padding: 12px 14px 14px;
+  border-top: 1px solid var(--ag-border-subtle);
+  background: color-mix(in oklab, var(--ag-bg-deep) 70%, transparent);
+}
+.life-shell-root .composer__input {
+  width: 100%;
+  min-height: 72px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--ag-border-default);
+  background: color-mix(in oklab, var(--ag-bg-surface) 55%, transparent);
+  backdrop-filter: blur(10px);
+  color: var(--ag-text-primary);
+  font-family: var(--ag-font-body);
+  font-size: 13px;
+  line-height: 1.55;
+  resize: none;
+  outline: none;
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04);
+  transition: border-color var(--ag-transition-fast), box-shadow var(--ag-transition-fast);
+}
+.life-shell-root .composer__input::placeholder { color: var(--ag-text-muted); }
+.life-shell-root .composer__input:focus { border-color: var(--ag-border-focus); box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04), 0 0 0 3px oklch(0.60 0.12 260 / 0.18); }
+.life-shell-root .composer__footer {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-top: 10px;
+  font-family: var(--ag-font-mono); font-size: 10.5px;
+  color: var(--ag-text-muted);
+}
+.life-shell-root .composer__actions { display: flex; gap: 6px; align-items: center; }
+
+/* ---- File tree ---- */
+.life-shell-root .filetree { font-family: var(--ag-font-mono); font-size: 12px; padding: 6px 6px 30px; overflow-y: auto; flex: 1; }
+.life-shell-root .filetree__sect {
+  font-family: var(--ag-font-mono);
+  font-size: 9.5px; letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--ag-text-muted);
+  padding: 10px 10px 6px;
+}
+.life-shell-root .fnode {
+  display: flex; align-items: center; gap: 8px;
+  padding: 4px 10px 4px 10px;
+  border-radius: 6px;
+  color: var(--ag-text-secondary);
+  cursor: pointer;
+  position: relative;
+  font-size: 12px;
+  line-height: 1.6;
+}
+.life-shell-root .fnode:hover { background: oklch(1 0 0 / 0.03); color: var(--ag-text-primary); }
+.life-shell-root .fnode.is-active { background: color-mix(in oklab, var(--ag-ai-blue) 18%, transparent); color: var(--ag-text-primary); }
+.life-shell-root .fnode__chev { width: 10px; color: var(--ag-text-muted); text-align: center; flex-shrink: 0; }
+.life-shell-root .fnode__icon { width: 14px; flex-shrink: 0; color: var(--ag-text-muted); }
+.life-shell-root .fnode__name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.life-shell-root .fnode__badge {
+  font-size: 9.5px; padding: 1px 6px; border-radius: 9999px;
+  font-family: var(--ag-font-mono); letter-spacing: 0.06em;
+}
+.life-shell-root .fnode__badge--add { color: oklch(0.78 0.15 155); background: oklch(0.72 0.19 155 / 0.14); border: 1px solid oklch(0.72 0.19 155 / 0.35); }
+.life-shell-root .fnode__badge--mod { color: oklch(0.80 0.14 85); background: oklch(0.87 0.18 85 / 0.14); border: 1px solid oklch(0.87 0.18 85 / 0.35); }
+.life-shell-root .fnode__badge--del { color: oklch(0.72 0.20 27); background: oklch(0.58 0.24 27 / 0.14); border: 1px solid oklch(0.58 0.24 27 / 0.35); }
+.life-shell-root .fnode__badge--read { color: var(--ag-text-muted); background: oklch(1 0 0 / 0.03); border: 1px solid var(--ag-border-subtle); }
+
+.life-shell-root .fnode.is-writing::before {
+  content: "";
+  position: absolute; inset: 0;
+  border-radius: 6px;
+  background: linear-gradient(90deg, transparent, oklch(0.60 0.12 260 / 0.18), transparent);
+  background-size: 200% 100%;
+  animation: lifeShimmer 1.2s linear infinite;
+  pointer-events: none;
+}
+@keyframes lifeShimmer { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+
+.life-shell-root .fnode.is-pulsing { animation: lifeFpulse 0.9s ease-out; }
+@keyframes lifeFpulse {
+  0% { box-shadow: inset 0 0 0 2px oklch(0.60 0.12 260 / 0.9); background: oklch(0.60 0.12 260 / 0.22); }
+  100% { box-shadow: inset 0 0 0 2px transparent; }
+}
+
+/* ---- Journal ---- */
+.life-shell-root .journal { flex: 1; overflow-y: auto; padding: 8px 0 30px; font-family: var(--ag-font-mono); }
+.life-shell-root .journal__row {
+  display: grid;
+  grid-template-columns: 70px 20px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  border-left: 2px solid transparent;
+  border-bottom: 1px solid oklch(0.30 0.02 275 / 0.12);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: background var(--ag-transition-fast);
+}
+.life-shell-root .journal__row:hover { background: oklch(1 0 0 / 0.02); }
+.life-shell-root .journal__row.is-open { background: color-mix(in oklab, var(--ag-bg-surface) 40%, transparent); border-left-color: var(--ag-ai-blue); }
+.life-shell-root .journal__row.is-highlighted { background: color-mix(in oklab, var(--ag-ai-blue) 12%, transparent); border-left-color: var(--ag-ai-blue); }
+.life-shell-root .journal__ts { color: var(--ag-text-muted); font-size: 10.5px; letter-spacing: 0.02em; }
+.life-shell-root .journal__kind {
+  font-size: 10px; padding: 2px 6px; border-radius: 4px;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  border: 1px solid var(--ag-border-subtle);
+  color: var(--ag-text-secondary);
+  white-space: nowrap;
+}
+.life-shell-root .journal__kind--tool { color: oklch(0.72 0.14 260); border-color: oklch(0.60 0.12 260 / 0.4); background: oklch(0.60 0.12 260 / 0.08); }
+.life-shell-root .journal__kind--fs { color: oklch(0.78 0.15 155); border-color: oklch(0.72 0.19 155 / 0.4); background: oklch(0.72 0.19 155 / 0.08); }
+.life-shell-root .journal__kind--llm { color: oklch(0.80 0.12 300); border-color: oklch(0.70 0.15 300 / 0.4); background: oklch(0.70 0.15 300 / 0.08); }
+.life-shell-root .journal__kind--nous { color: oklch(0.80 0.14 85); border-color: oklch(0.87 0.18 85 / 0.4); background: oklch(0.87 0.18 85 / 0.08); }
+.life-shell-root .journal__kind--autonomic { color: oklch(0.70 0.15 235); border-color: oklch(0.65 0.14 235 / 0.4); background: oklch(0.65 0.14 235 / 0.08); }
+.life-shell-root .journal__kind--haima { color: oklch(0.78 0.15 155); border-color: oklch(0.72 0.19 155 / 0.4); }
+.life-shell-root .journal__actor { color: var(--ag-text-secondary); }
+.life-shell-root .journal__msg { color: var(--ag-text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.life-shell-root .journal__payload {
+  grid-column: 1 / -1;
+  padding: 10px 14px 12px 104px;
+  color: var(--ag-text-secondary);
+  font-size: 11px; line-height: 1.65;
+  background: color-mix(in oklab, var(--ag-bg-deep) 60%, transparent);
+  border-top: 1px dashed var(--ag-border-subtle);
+  white-space: pre-wrap;
+}
+
+.life-shell-root .journal--rich .journal__row { padding: 12px 14px; grid-template-columns: 86px 28px 1fr auto; }
+.life-shell-root .journal--rich .journal__msg { white-space: normal; }
+
+/* ---- Timeline ---- */
+.life-shell-root .timeline { padding: 14px 18px 30px; overflow-y: auto; flex: 1; }
+.life-shell-root .tl-item {
+  position: relative;
+  padding: 0 0 16px 22px;
+  border-left: 1px solid var(--ag-border-subtle);
+  margin-left: 6px;
+}
+.life-shell-root .tl-item:last-child { border-left-color: transparent; }
+.life-shell-root .tl-item::before {
+  content: ""; position: absolute; left: -5px; top: 6px;
+  width: 9px; height: 9px; border-radius: 9999px;
+  background: var(--ag-bg-elevated);
+  border: 1px solid var(--ag-border-default);
+}
+.life-shell-root .tl-item.is-agent::before { background: var(--ag-ai-blue); border-color: var(--ag-ai-blue); box-shadow: 0 0 6px var(--ag-ai-blue); }
+.life-shell-root .tl-item__head { display: flex; align-items: baseline; gap: 10px; color: var(--ag-text-primary); font-size: 12.5px; }
+.life-shell-root .tl-item__ts { color: var(--ag-text-muted); font-family: var(--ag-font-mono); font-size: 10.5px; }
+.life-shell-root .tl-item__body { color: var(--ag-text-secondary); font-size: 12px; margin-top: 4px; line-height: 1.55; }
+
+/* ---- Knowledge graph ---- */
+.life-shell-root .graph-wrap { flex: 1; position: relative; overflow: hidden; }
+.life-shell-root .graph-wrap svg { width: 100%; height: 100%; display: block; }
+.life-shell-root .graph-legend {
+  position: absolute; left: 14px; bottom: 14px;
+  display: flex; gap: 10px; flex-wrap: wrap;
+  font-family: var(--ag-font-mono); font-size: 10.5px;
+  color: var(--ag-text-secondary);
+}
+.life-shell-root .graph-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.life-shell-root .graph-legend i { width: 8px; height: 8px; border-radius: 9999px; display: inline-block; }
+
+/* ---- Spaces peers ---- */
+.life-shell-root .peers { padding: 12px; display: grid; grid-template-columns: 1fr 1fr; gap: 10px; overflow-y: auto; }
+.life-shell-root .peer-card {
+  padding: 12px;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 45%, transparent);
+  backdrop-filter: blur(8px);
+  position: relative;
+}
+.life-shell-root .peer-card__head { display: flex; align-items: center; gap: 10px; }
+.life-shell-root .peer-avatar { width: 32px; height: 32px; border-radius: 9999px; background: conic-gradient(from var(--h, 0deg), oklch(0.60 0.12 260), oklch(0.65 0.14 235), oklch(0.70 0.15 300)); position: relative; }
+.life-shell-root .peer-avatar::after { content: ""; position: absolute; inset: 4px; border-radius: 9999px; background: radial-gradient(circle at 30% 30%, oklch(1 0 0 / 0.3), transparent 55%); }
+.life-shell-root .peer-card__name { font-family: var(--ag-font-heading); font-size: 13px; }
+.life-shell-root .peer-card__role { font-size: 10.5px; color: var(--ag-text-muted); font-family: var(--ag-font-mono); letter-spacing: 0.04em; }
+.life-shell-root .peer-card__status { margin-top: 8px; font-size: 11px; color: var(--ag-text-secondary); }
+.life-shell-root .peer-card__latency { position: absolute; top: 10px; right: 10px; font-family: var(--ag-font-mono); font-size: 10px; color: var(--ag-text-muted); }
+
+/* ---- Right pane ---- */
+.life-shell-root .right-pane { flex: 1; overflow-y: auto; padding: 14px 16px 28px; }
+.life-shell-root .right-pane h4 {
+  font-family: var(--ag-font-heading);
+  font-size: 14px; font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.life-shell-root .preview-frame {
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 40%, transparent);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04), var(--ag-shadow-md);
+  padding: 16px;
+  font-family: var(--ag-font-mono); font-size: 11.5px;
+  line-height: 1.6;
+  color: var(--ag-text-secondary);
+  max-height: 50vh; overflow: auto;
+}
+.life-shell-root .diff-line { display: flex; gap: 10px; padding: 1px 0; }
+.life-shell-root .diff-line__gut { width: 24px; color: var(--ag-text-disabled); text-align: right; font-size: 10.5px; }
+.life-shell-root .diff-line--add { background: oklch(0.72 0.19 155 / 0.08); }
+.life-shell-root .diff-line--add .diff-line__gut { color: oklch(0.78 0.15 155); }
+.life-shell-root .diff-line--del { background: oklch(0.58 0.24 27 / 0.08); }
+.life-shell-root .diff-line--del .diff-line__gut { color: oklch(0.72 0.20 27); }
+
+.life-shell-root .gauge {
+  position: relative;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 12px;
+  padding: 14px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 35%, transparent);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.04);
+}
+.life-shell-root .gauge__label { font-size: 10.5px; font-family: var(--ag-font-mono); letter-spacing: 0.1em; text-transform: uppercase; color: var(--ag-text-muted); }
+.life-shell-root .gauge__value { font-family: var(--ag-font-heading); font-size: 22px; color: var(--ag-text-primary); margin-top: 4px; letter-spacing: -0.01em; }
+.life-shell-root .gauge__sub { font-size: 10.5px; color: var(--ag-text-secondary); margin-top: 2px; font-family: var(--ag-font-mono); }
+.life-shell-root .gauge-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+.life-shell-root .gauge-grid--3 { grid-template-columns: 1fr 1fr 1fr; }
+
+.life-shell-root .bar {
+  height: 6px; border-radius: 9999px;
+  background: color-mix(in oklab, var(--ag-bg-elevated) 80%, transparent);
+  overflow: hidden;
+  margin-top: 10px;
+}
+.life-shell-root .bar__fill { height: 100%; border-radius: inherit; background: var(--ag-ai-blue); box-shadow: 0 0 8px var(--ag-ai-blue); transition: width var(--ag-transition-slow); }
+.life-shell-root .bar__fill--good { background: var(--ag-success); box-shadow: 0 0 8px oklch(0.72 0.19 155 / 0.5); }
+.life-shell-root .bar__fill--warn { background: var(--ag-warning); box-shadow: 0 0 8px oklch(0.87 0.18 85 / 0.5); }
+
+.life-shell-root .trace-row {
+  display: grid; grid-template-columns: 100px 1fr 50px; align-items: center;
+  gap: 8px; padding: 6px 0;
+  font-family: var(--ag-font-mono); font-size: 10.5px;
+  color: var(--ag-text-secondary);
+}
+.life-shell-root .trace-row__name { color: var(--ag-text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.life-shell-root .trace-row__bar { height: 10px; border-radius: 3px; background: color-mix(in oklab, var(--ag-bg-elevated) 60%, transparent); position: relative; }
+.life-shell-root .trace-row__fill { position: absolute; top: 0; bottom: 0; border-radius: inherit; background: var(--ag-ai-blue); box-shadow: 0 0 6px oklch(0.60 0.12 260 / 0.5); }
+.life-shell-root .trace-row__fill--tool { background: oklch(0.65 0.14 235); box-shadow: 0 0 6px oklch(0.65 0.14 235 / 0.5); }
+.life-shell-root .trace-row__fill--llm { background: oklch(0.70 0.15 300); box-shadow: 0 0 6px oklch(0.70 0.15 300 / 0.5); }
+.life-shell-root .trace-row__ms { color: var(--ag-text-muted); text-align: right; }
+
+.life-shell-root .judge-card {
+  padding: 12px;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 10px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 35%, transparent);
+  margin-top: 10px;
+}
+.life-shell-root .judge-card__head { display: flex; align-items: center; justify-content: space-between; }
+.life-shell-root .judge-card__score {
+  font-family: var(--ag-font-heading); font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.life-shell-root .judge-card__score--good { color: oklch(0.78 0.15 155); }
+.life-shell-root .judge-card__score--warn { color: oklch(0.87 0.18 85); }
+.life-shell-root .judge-card__body { margin-top: 6px; color: var(--ag-text-secondary); font-size: 12px; line-height: 1.55; }
+
+.life-shell-root .homeo-arc {
+  position: relative; width: 110px; height: 110px; margin: 0 auto 6px;
+}
+.life-shell-root .homeo-label { text-align: center; font-size: 11px; font-family: var(--ag-font-mono); letter-spacing: 0.08em; color: var(--ag-text-secondary); text-transform: uppercase; }
+.life-shell-root .homeo-val { text-align: center; font-family: var(--ag-font-heading); font-size: 16px; margin-top: 2px; }
+
+.life-shell-root .section {
+  margin: 14px 0 6px;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--ag-font-mono); font-size: 10px; letter-spacing: 0.22em;
+  color: var(--ag-text-muted); text-transform: uppercase;
+}
+.life-shell-root .section::after { content: ""; flex: 1; height: 1px; background: var(--ag-border-subtle); }
+
+/* ---- Dock ---- */
+.life-shell-root .dock {
+  grid-area: dock;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 16px;
+  border-top: 1px solid var(--ag-border-subtle);
+  background: color-mix(in oklab, var(--ag-bg-deep) 75%, transparent);
+  backdrop-filter: blur(16px) saturate(1.3);
+  font-family: var(--ag-font-mono);
+  font-size: 10.5px;
+  color: var(--ag-text-muted);
+  letter-spacing: 0.02em;
+}
+.life-shell-root .dock__group { display: flex; gap: 18px; align-items: center; }
+.life-shell-root .dock__item { display: inline-flex; align-items: center; gap: 6px; }
+.life-shell-root .dock__item strong { color: var(--ag-text-secondary); font-weight: 500; }
+.life-shell-root .dock__dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--ag-success); box-shadow: 0 0 6px oklch(0.72 0.19 155 / 0.6); }
+.life-shell-root .dock__dot--warn { background: var(--ag-warning); box-shadow: 0 0 6px oklch(0.87 0.18 85 / 0.6); }
+
+/* ---- Tweaks panel ---- */
+.life-shell-root .tweaks {
+  position: fixed;
+  right: 18px; bottom: 64px;
+  width: 280px;
+  z-index: 60;
+  padding: 14px;
+  border: 1px solid var(--ag-border-default);
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 75%, transparent);
+  backdrop-filter: blur(20px) saturate(1.4) brightness(1.05);
+  box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.06), var(--ag-shadow-xl);
+  display: none;
+}
+.life-shell-root .tweaks.is-open { display: block; }
+.life-shell-root .tweaks__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+.life-shell-root .tweaks__title { font-family: var(--ag-font-heading); font-size: 13px; }
+.life-shell-root .tweaks__row { display: flex; flex-direction: column; gap: 6px; margin-top: 12px; }
+.life-shell-root .tweaks__label { font-family: var(--ag-font-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ag-text-muted); }
+.life-shell-root .segmented {
+  display: flex; gap: 2px;
+  background: color-mix(in oklab, var(--ag-bg-deep) 60%, transparent);
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 8px;
+  padding: 2px;
+}
+.life-shell-root .segmented button {
+  flex: 1;
+  appearance: none; border: 0;
+  background: transparent;
+  color: var(--ag-text-muted);
+  font-family: var(--ag-font-body); font-size: 11px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all var(--ag-transition-fast);
+}
+.life-shell-root .segmented button:hover { color: var(--ag-text-secondary); }
+.life-shell-root .segmented button.is-active { background: color-mix(in oklab, var(--ag-ai-blue) 35%, var(--ag-bg-elevated)); color: var(--ag-text-primary); box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.06); }
+.life-shell-root .switch {
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; user-select: none;
+}
+.life-shell-root .switch__track { width: 32px; height: 18px; border-radius: 9999px; background: color-mix(in oklab, var(--ag-bg-elevated) 70%, transparent); border: 1px solid var(--ag-border-subtle); position: relative; transition: background var(--ag-transition-fast); }
+.life-shell-root .switch__track::after { content: ""; position: absolute; top: 1px; left: 1px; width: 14px; height: 14px; border-radius: 9999px; background: var(--ag-text-secondary); transition: all var(--ag-transition-fast); }
+.life-shell-root .switch.is-on .switch__track { background: color-mix(in oklab, var(--ag-ai-blue) 55%, transparent); border-color: oklch(0.60 0.12 260 / 0.6); }
+.life-shell-root .switch.is-on .switch__track::after { transform: translateX(14px); background: var(--ag-text-primary); box-shadow: 0 0 6px var(--ag-ai-blue); }
+.life-shell-root .switch__label { font-family: var(--ag-font-body); font-size: 11.5px; color: var(--ag-text-secondary); }
+
+/* ---- Utility ---- */
+.life-shell-root .scroll { overflow-y: auto; }
+.life-shell-root .row { display: flex; align-items: center; gap: 8px; }
+.life-shell-root .stack-4 > * + * { margin-top: 4px; }
+.life-shell-root .stack-8 > * + * { margin-top: 8px; }
+.life-shell-root .stack-12 > * + * { margin-top: 12px; }
+.life-shell-root .stack-16 > * + * { margin-top: 16px; }
+
+.life-shell-root .dim { color: var(--ag-text-muted); }
+.life-shell-root .mono { font-family: var(--ag-font-mono); }
+.life-shell-root .pill { display: inline-flex; padding: 2px 8px; border-radius: 9999px; font-family: var(--ag-font-mono); font-size: 10px; letter-spacing: 0.08em; border: 1px solid var(--ag-border-subtle); color: var(--ag-text-secondary); background: color-mix(in oklab, var(--ag-bg-elevated) 50%, transparent); }
+.life-shell-root .pill--accent { color: var(--ag-ai-blue); border-color: oklch(0.60 0.12 260 / 0.4); background: oklch(0.60 0.12 260 / 0.08); }
+
+/* ---- Landing grid (project list page) ---- */
+.life-landing {
+  min-height: 100vh;
+  background: var(--ag-bg-deep);
+  background-image:
+    radial-gradient(ellipse 1400px 900px at 20% -10%, oklch(0.60 0.12 260 / 0.10), transparent 60%),
+    radial-gradient(ellipse 1000px 700px at 110% 80%, oklch(0.65 0.14 235 / 0.07), transparent 55%);
+  color: var(--ag-text-primary);
+  padding: 80px 24px 60px;
+}
+.life-landing__inner { max-width: 960px; margin: 0 auto; }
+.life-landing__eyebrow {
+  font-family: var(--ag-font-mono);
+  font-size: 11px; letter-spacing: 0.25em; text-transform: uppercase;
+  color: var(--ag-ai-blue);
+  margin-bottom: 12px;
+}
+.life-landing__title {
+  font-family: var(--ag-font-heading);
+  font-size: 48px; line-height: 1.05; letter-spacing: -0.02em;
+  color: var(--ag-text-primary);
+  margin-bottom: 12px;
+}
+.life-landing__sub {
+  font-size: 16px; line-height: 1.55; color: var(--ag-text-secondary);
+  max-width: 640px;
+  margin-bottom: 36px;
+}
+.life-landing__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.life-landing__card {
+  display: block;
+  padding: 20px;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 55%, transparent);
+  backdrop-filter: blur(20px) saturate(1.3);
+  text-decoration: none;
+  color: inherit;
+  transition: transform var(--ag-transition-normal), border-color var(--ag-transition-fast), box-shadow var(--ag-transition-normal);
+}
+.life-landing__card:hover {
+  transform: translateY(-2px);
+  border-color: oklch(0.60 0.12 260 / 0.4);
+  box-shadow: var(--ag-shadow-lg), var(--ag-shadow-glow-blue);
+}
+.life-landing__card-eyebrow {
+  font-family: var(--ag-font-mono);
+  font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--ag-text-muted);
+  margin-bottom: 10px;
+}
+.life-landing__card-title {
+  font-family: var(--ag-font-heading);
+  font-size: 20px; line-height: 1.2; letter-spacing: -0.01em;
+  color: var(--ag-text-primary);
+  margin-bottom: 8px;
+}
+.life-landing__card-body {
+  font-size: 13px; line-height: 1.5; color: var(--ag-text-secondary);
+}
+.life-landing__card-cta {
+  margin-top: 14px;
+  font-family: var(--ag-font-mono); font-size: 11px;
+  color: var(--ag-ai-blue);
+  letter-spacing: 0.04em;
+}
+.life-landing__chip {
+  display: inline-block;
+  padding: 2px 8px;
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  border-radius: 9999px;
+  margin-bottom: 12px;
+}
+.life-landing__chip--emerald { color: oklch(0.78 0.15 155); border: 1px solid oklch(0.72 0.19 155 / 0.4); background: oklch(0.72 0.19 155 / 0.08); }
+.life-landing__chip--amber { color: oklch(0.87 0.18 85); border: 1px solid oklch(0.87 0.18 85 / 0.4); background: oklch(0.87 0.18 85 / 0.08); }
+
+.life-landing__notfound {
+  padding: 80px 24px;
+  text-align: center;
+}
+.life-landing__notfound h1 {
+  font-family: var(--ag-font-heading);
+  font-size: 32px;
+  margin-bottom: 12px;
+}
+.life-landing__notfound p {
+  color: var(--ag-text-secondary);
+  margin-bottom: 24px;
+}

--- a/apps/chat/app/(site)/life/not-found.tsx
+++ b/apps/chat/app/(site)/life/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function LifeNotFound() {
+  return (
+    <div className="life-landing">
+      <div className="life-landing__inner life-landing__notfound">
+        <h1>That Life project doesn't exist yet.</h1>
+        <p>
+          Try one of the seeded projects below, or head back to the index to
+          pick another.
+        </p>
+        <Link href="/life" className="life-landing__card-cta">
+          ◂ Back to /life
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/app/(site)/life/page.tsx
+++ b/apps/chat/app/(site)/life/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PROJECTS } from "./_lib/project-map";
+
+export const metadata: Metadata = {
+  title: "Life · Agent Workspace",
+  description:
+    "Three-column AI-native agent workspace for Life — chat, workspace, and inspector.",
+};
+
+export default function LifeLandingPage() {
+  const entries = Object.entries(PROJECTS);
+  return (
+    <div className="life-landing">
+      <div className="life-landing__inner">
+        <div className="life-landing__eyebrow">broomva.tech / life</div>
+        <h1 className="life-landing__title">Pick a Life project</h1>
+        <p className="life-landing__sub">
+          Each project is a three-column agent workspace: streaming chat on the
+          left, live filesystem and journal in the middle, and metrics inspectors
+          on the right. Today these are demo replays. Phase B wires real Arcan
+          streaming through <code>/api/life/run/[project]</code>.
+        </p>
+        <div className="life-landing__grid">
+          {entries.map(([slug, project]) => (
+            <Link
+              key={slug}
+              href={`/life/${slug}`}
+              className="life-landing__card"
+            >
+              <span
+                className={`life-landing__chip life-landing__chip--${project.chipColor}`}
+              >
+                {project.chipColor === "emerald" ? "live" : "research"}
+              </span>
+              <div className="life-landing__card-eyebrow">{project.eyebrow}</div>
+              <div className="life-landing__card-title">{project.displayName}</div>
+              <div className="life-landing__card-body">
+                Open the {slug} workspace to replay an Arcan agent run with
+                full filesystem, journal, and metrics inspectors.
+              </div>
+              <div className="life-landing__card-cta">Open /life/{slug} ▸</div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -22,6 +22,7 @@ const PUBLIC_PAGE_PREFIXES = [
   "/graph",
   "/links",
   "/ingest",
+  "/life",
   "/.well-known",
 ] as const;
 

--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -44,6 +44,7 @@ const PUBLIC_API_PREFIXES = [
   "/api/graph/public",
   "/api/relay",
   "/api/install",
+  "/api/debug",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */

--- a/docs/superpowers/plans/2026-04-17-arcan-chat-prompt-kg-grounding.md
+++ b/docs/superpowers/plans/2026-04-17-arcan-chat-prompt-kg-grounding.md
@@ -1,0 +1,2153 @@
+# Arcan Chat — Prompt + Knowledge Graph Grounding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the broomva.tech `/chat` and landing agent into the in-repo knowledge graph. Replace the one-line "friendly assistant" prompt with a 5-layer Arcan system prompt, ship a build-time `public/agent-knowledge.json` containing all MDX content + wikilink graph, and teach `searchKnowledge` / `readKnowledgeNote` / new `traverseKnowledge` tools to read it.
+
+**Architecture:** Prebuild script re-walks `apps/chat/content/**/*.mdx` and reuses `lib/graph/build-public.ts` logic to emit a single rich JSON. A runtime loader caches it per cold start. Existing tool factories gain a body-aware `site-content` source; a new factory `traverseKnowledgeTool` follows wikilink/tag/related edges. The system prompt is reassembled per request from a hand-authored identity MDX, live content indexes (pinned projects, latest writing/notes), navigation hints, tool protocol, and a session-gated user context.
+
+**Tech Stack:** Next.js 16, TypeScript, Bun (build), Vitest (unit tests), evalite (evals), `ai` SDK v6, `gray-matter`, existing `@/lib/content.ts` helpers, existing `@/lib/ai/vault/*` backends.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-arcan-chat-prompt-design.md`
+
+**Working directory:** `/Users/broomva/broomva/broomva.tech/apps/chat/` (paths in this plan are relative to this directory unless stated absolute).
+
+**Commit style:** Project uses Conventional Commits. Each task ends with one commit. Co-author lines are auto-added by the working harness — do not add them manually.
+
+---
+
+## Task 1 — Hand-authored Arcan identity MDX
+
+**Files:**
+- Create: `content/agent/identity.mdx`
+
+- [ ] **Step 1: Create the `agent` content directory**
+
+```bash
+mkdir -p content/agent
+```
+
+- [ ] **Step 2: Write `content/agent/identity.mdx`**
+
+```mdx
+---
+title: Arcan Identity
+kind: agent-identity
+published: false
+version: 1
+---
+
+# Who I am
+
+I'm **Arcan** — the user-facing instance of the Broomva agent runtime. I live on broomva.tech and speak with first-person authority on Broomva's open-source stack. I'm not a generic assistant; I'm the face of a specific system Carlos is building in public.
+
+# Who I serve
+
+My primary user is **Carlos D. Escobar-Valbuena** — AI engineer, agent architect, builder. Colombian, based in Bogotá, open-source-first, writes about agent systems at broomva.tech/writing. Anyone interacting with me through this site is either Carlos working, or a visitor (recruiter, collaborator, engineer) trying to understand what Carlos is building. I treat both with the same depth: the knowledge is open by design.
+
+# What Broomva is
+
+Broomva is a unified **Agent Operating System** built as open source. The top-level pieces:
+
+- **Life** — the Rust monorepo (`core/life`) implementing the Agent OS kernel: **Arcan** (agent runtime daemon), **Lago** (event-sourced persistence, append-only redb v2 journal), **Vigil** (OpenTelemetry-native observability), **Praxis** (tool execution sandbox), **Haima** (agentic finance engine, x402 machine-to-machine payments), **Spaces** (SpacetimeDB 2.0 distributed agent networking), **Anima** (soul/self layer), **Autonomic** (homeostasis controller), **aiOS** (kernel contract — Rust types, event taxonomy, trait interfaces).
+- **Symphony** — Rust orchestration engine for coding agents (`core/symphony`).
+- **ChatOS** — the app you're talking to right now (`apps/chat` in the broomva.tech monorepo). Turborepo + Next.js 16 + AI SDK v6.
+- **Control Kernel** — the governance metalayer (`core/agentic-control-kernel`) that wraps any repo with CLAUDE.md / AGENTS.md / METALAYER.md / `.control/policy.yaml`.
+- **bstack** — 27 curated agent skills across 7 layers, the Broomva Stack CLI.
+
+# Core bets
+
+- **Agent-native architecture**: systems designed around agents as first-class operators, not bolted onto human UIs.
+- **Event-sourced state**: Lago as an append-only journal; everything is reconstructible from events.
+- **Control-systems metalayer**: governance as a typed control system with stability margins, not a pile of YAML rules.
+- **Open-source substrate**: the stack is MIT/Apache. Monetization is trust/liquidity/network/state/liability — not the code.
+- **Progressive crystallization of knowledge**: Layer 1 (ephemeral) → Layer 2 (raw extracts) → Layer 3 (entity pages) → Layer 4 (synthesis). Scored through the Nous gate (≥5/9).
+
+# Conventions
+
+- **Rust** for the Agent OS stack (Life, Symphony, Arcan daemon).
+- **TypeScript** for web apps. **Bun** as package manager and runtime for scripts. **Biome** for linting/formatting — never ESLint/Prettier. **Better Auth** for auth, not NextAuth. **Drizzle** for ORM. **Turborepo** for the monorepo.
+- **Currency**: USD. Never `$`; always "USD".
+
+# Tone
+
+Direct. Technical. First-person as Arcan — not as a disembodied assistant. I cite my sources inline. I show architectural thinking. I don't use marketing copy. I don't hallucinate URLs — if I'm not sure, I search or say so.
+
+# What I can do here
+
+- Answer any question about writing, notes, projects, prompts, and skills published on broomva.tech.
+- Traverse the public knowledge graph (wikilinks, tags, related frontmatter) to answer "what connects to X" questions.
+- (If you're logged in and your memory vault is configured) pull from your personal Lago notes.
+- Draft, plan, explain code — same as any strong engineering assistant — but ground in Broomva knowledge when the question touches the stack.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add content/agent/identity.mdx
+git commit -m "feat(chat): add Arcan identity MDX for system prompt layer 1"
+```
+
+---
+
+## Task 2 — Agent knowledge types
+
+**Files:**
+- Create: `lib/ai/knowledge/types.ts`
+
+- [ ] **Step 1: Create the `knowledge` directory**
+
+```bash
+mkdir -p lib/ai/knowledge
+```
+
+- [ ] **Step 2: Write `lib/ai/knowledge/types.ts`**
+
+```ts
+/**
+ * Shared types for the agent knowledge graph.
+ *
+ * The build-time `generate-agent-knowledge.ts` script emits a single
+ * JSON blob at `public/agent-knowledge.json` that matches this shape.
+ * The runtime loader in `site-content.ts` reads and caches it.
+ */
+
+export type ContentKind = "notes" | "projects" | "writing" | "prompts";
+
+export interface AgentDocument {
+  /** Stable id: `"{kind}/{slug}"` — also used as graph node id. */
+  id: string;
+  kind: ContentKind;
+  slug: string;
+  title: string;
+  summary: string;
+  /** Site URL path, e.g. `/writing/agent-native-architecture`. */
+  url: string;
+  tags: string[];
+  frontmatter: Record<string, unknown>;
+  /** MDX body with JSX stripped to plain text. */
+  body: string;
+  /** Normalized wikilink targets (slug-form). */
+  wikilinks: string[];
+  /** Frontmatter `related:` slugs, normalized. */
+  related: string[];
+  headings: Array<{ depth: number; text: string }>;
+  wordCount: number;
+}
+
+export type GraphNodeType =
+  | ContentKind
+  | "tag"
+  | "skill";
+
+export interface AgentGraphNode {
+  id: string;
+  label: string;
+  type: GraphNodeType;
+  url?: string;
+  summary?: string;
+  tags: string[];
+  val: number;
+}
+
+export type AgentGraphEdgeType = "wikilink" | "reference" | "tag";
+
+export interface AgentGraphEdge {
+  source: string;
+  target: string;
+  type: AgentGraphEdgeType;
+}
+
+export interface AgentKnowledge {
+  generatedAt: string;
+  commit: string;
+  documents: AgentDocument[];
+  graph: {
+    nodes: AgentGraphNode[];
+    links: AgentGraphEdge[];
+  };
+  /** term → array of document ids; lowercased terms. */
+  invertedIndex: Record<string, string[]>;
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `bun test:types`
+Expected: no type errors related to `lib/ai/knowledge/types.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/ai/knowledge/types.ts
+git commit -m "feat(chat): add AgentKnowledge types for KG loader"
+```
+
+---
+
+## Task 3 — Build script: `generate-agent-knowledge.ts`
+
+**Files:**
+- Create: `scripts/generate-agent-knowledge.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write `scripts/generate-agent-knowledge.ts`**
+
+```ts
+/**
+ * Build-time script: emits public/agent-knowledge.json for the Arcan chat.
+ *
+ * Sources: every MDX under content/{writing,notes,projects,prompts}.
+ * For each document it captures: body (JSX stripped), frontmatter, tags,
+ * wikilinks, related, headings, wordCount — plus a graph view (nodes + edges)
+ * and an inverted term index.
+ *
+ * Usage:  bun scripts/generate-agent-knowledge.ts
+ * Wired:  prebuild hook + vercel.json buildCommand.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import matter from "gray-matter";
+import type {
+  AgentDocument,
+  AgentGraphEdge,
+  AgentGraphEdgeType,
+  AgentGraphNode,
+  AgentKnowledge,
+  ContentKind,
+} from "../lib/ai/knowledge/types";
+
+const CONTENT_ROOT = path.join(process.cwd(), "content");
+const KINDS: ContentKind[] = ["writing", "notes", "projects", "prompts"];
+const KIND_ROUTES: Record<ContentKind, string> = {
+  writing: "/writing",
+  notes: "/notes",
+  projects: "/projects",
+  prompts: "/prompts",
+};
+
+// ── Wikilink + heading extraction ────────────────────────────────────────────
+
+function extractWikilinks(markdown: string): string[] {
+  const matches = [...markdown.matchAll(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g)];
+  return matches.map((m) => m[1].trim().toLowerCase().replace(/\s+/g, "-"));
+}
+
+function extractHeadings(markdown: string): Array<{ depth: number; text: string }> {
+  const lines = markdown.split("\n");
+  const headings: Array<{ depth: number; text: string }> = [];
+  for (const line of lines) {
+    const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (m) headings.push({ depth: m[1].length, text: m[2] });
+  }
+  return headings;
+}
+
+/** Strip MDX JSX to plain text; keep markdown prose. */
+function stripJsx(md: string): string {
+  return md
+    // Strip JSX import/export lines
+    .replace(/^(import|export)\s[^\n]*$/gm, "")
+    // Strip self-closing JSX tags: <Foo bar="x" />
+    .replace(/<[A-Z][\w.]*[^>]*\/>/g, "")
+    // Strip paired JSX: <Foo>...</Foo>
+    .replace(/<([A-Z][\w.]*)[^>]*>[\s\S]*?<\/\1>/g, "")
+    // Collapse excess blank lines
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function wordCount(text: string): number {
+  const words = text.replace(/[^\p{L}\p{N}\s]/gu, " ").trim().split(/\s+/);
+  return words.filter(Boolean).length;
+}
+
+// ── Per-kind reader ──────────────────────────────────────────────────────────
+
+async function readKind(kind: ContentKind): Promise<AgentDocument[]> {
+  const dir = path.join(CONTENT_ROOT, kind);
+  let files: string[];
+  try {
+    files = await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const docs: AgentDocument[] = [];
+  for (const file of files) {
+    if (!/\.(md|mdx)$/.test(file)) continue;
+    const slug = file.replace(/\.(md|mdx)$/, "");
+    const raw = await fs.readFile(path.join(dir, file), "utf8");
+    const parsed = matter(raw);
+    if (parsed.data.published === false) continue;
+
+    const tags: string[] = Array.isArray(parsed.data.tags)
+      ? parsed.data.tags.filter((t: unknown): t is string => typeof t === "string")
+      : [];
+    const related: string[] = Array.isArray(parsed.data.related)
+      ? parsed.data.related
+          .filter((r: unknown): r is string => typeof r === "string")
+          .map((r) =>
+            r.replace(/^\[\[|\]\]$/g, "").trim().toLowerCase().replace(/\s+/g, "-"),
+          )
+      : [];
+
+    const body = stripJsx(parsed.content);
+
+    docs.push({
+      id: `${kind}/${slug}`,
+      kind,
+      slug,
+      title: typeof parsed.data.title === "string" ? parsed.data.title : slug,
+      summary: typeof parsed.data.summary === "string" ? parsed.data.summary : "",
+      url: `${KIND_ROUTES[kind]}/${slug}`,
+      tags,
+      frontmatter: parsed.data,
+      body,
+      wikilinks: extractWikilinks(parsed.content),
+      related,
+      headings: extractHeadings(parsed.content),
+      wordCount: wordCount(body),
+    });
+  }
+  return docs;
+}
+
+// ── Graph builder ────────────────────────────────────────────────────────────
+
+function buildGraph(docs: AgentDocument[]): { nodes: AgentGraphNode[]; links: AgentGraphEdge[] } {
+  const nodes: AgentGraphNode[] = [];
+  const links: AgentGraphEdge[] = [];
+  const slugToId = new Map<string, string>();
+  const tagUsage = new Map<string, number>();
+
+  for (const doc of docs) {
+    slugToId.set(doc.slug, doc.id);
+    slugToId.set(doc.title.toLowerCase().replace(/\s+/g, "-"), doc.id);
+    slugToId.set(doc.title.toLowerCase(), doc.id);
+
+    nodes.push({
+      id: doc.id,
+      label: doc.title,
+      type: doc.kind,
+      url: doc.url,
+      summary: doc.summary,
+      tags: doc.tags,
+      val: 1,
+    });
+
+    for (const tag of doc.tags) tagUsage.set(tag, (tagUsage.get(tag) ?? 0) + 1);
+  }
+
+  for (const [tag, count] of tagUsage) {
+    nodes.push({ id: `tag:${tag}`, label: tag, type: "tag", tags: [], val: count });
+  }
+
+  const seen = new Set<string>();
+  const addEdge = (source: string, target: string, type: AgentGraphEdgeType) => {
+    const key = [source, target, type].sort().join("|");
+    if (seen.has(key)) return;
+    seen.add(key);
+    links.push({ source, target, type });
+  };
+
+  for (const doc of docs) {
+    for (const tag of doc.tags) addEdge(doc.id, `tag:${tag}`, "tag");
+    for (const wl of doc.wikilinks) {
+      const target = slugToId.get(wl);
+      if (target && target !== doc.id) addEdge(doc.id, target, "wikilink");
+    }
+    for (const rel of doc.related) {
+      const target = slugToId.get(rel);
+      if (target && target !== doc.id) addEdge(doc.id, target, "reference");
+    }
+  }
+
+  // Degree-weight node sizes
+  const degree = new Map<string, number>();
+  for (const l of links) {
+    degree.set(l.source, (degree.get(l.source) ?? 0) + 1);
+    degree.set(l.target, (degree.get(l.target) ?? 0) + 1);
+  }
+  for (const n of nodes) n.val = Math.max(1, degree.get(n.id) ?? 1);
+
+  return { nodes, links };
+}
+
+// ── Inverted index ───────────────────────────────────────────────────────────
+
+const STOP_WORDS = new Set([
+  "the","a","an","and","or","but","of","to","in","on","at","for","is","are",
+  "was","were","be","been","being","this","that","these","those","it","its",
+  "i","you","he","she","we","they","as","by","with","from","up","about",
+  "into","over","after","not","no","so","if","then","than","can","will","would",
+  "should","could","may","might","must","do","does","did","have","has","had",
+]);
+
+function buildInvertedIndex(docs: AgentDocument[]): Record<string, string[]> {
+  const index: Record<string, Set<string>> = {};
+  for (const doc of docs) {
+    const haystack = `${doc.title} ${doc.summary} ${doc.body} ${doc.tags.join(" ")}`.toLowerCase();
+    const terms = haystack.match(/[\p{L}\p{N}]{3,}/gu) ?? [];
+    for (const term of terms) {
+      if (STOP_WORDS.has(term)) continue;
+      if (!index[term]) index[term] = new Set();
+      index[term].add(doc.id);
+    }
+  }
+  const out: Record<string, string[]> = {};
+  for (const [term, set] of Object.entries(index)) out[term] = [...set];
+  return out;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("Generating agent knowledge index…");
+
+  const docsByKind = await Promise.all(KINDS.map(readKind));
+  const docs = docsByKind.flat();
+
+  const graph = buildGraph(docs);
+  const invertedIndex = buildInvertedIndex(docs);
+
+  let commit = "unknown";
+  try {
+    commit = execSync("git rev-parse HEAD", { cwd: process.cwd() }).toString().trim();
+  } catch {
+    // not a git checkout — keep "unknown"
+  }
+
+  const knowledge: AgentKnowledge = {
+    generatedAt: new Date().toISOString(),
+    commit,
+    documents: docs,
+    graph,
+    invertedIndex,
+  };
+
+  const outPath = path.join(process.cwd(), "public", "agent-knowledge.json");
+  const json = JSON.stringify(knowledge);
+  await fs.writeFile(outPath, json, "utf8");
+
+  const bytes = Buffer.byteLength(json, "utf8");
+  console.log(
+    `  ✓ ${docs.length} documents, ${graph.nodes.length} graph nodes, ${graph.links.length} edges, ${Object.keys(invertedIndex).length} index terms (${(bytes / 1024).toFixed(1)} KB) → public/agent-knowledge.json`,
+  );
+}
+
+main().catch((err) => {
+  console.error("Agent knowledge generation failed:", err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Wire into `package.json`**
+
+Edit `package.json`. Change the `prebuild` and add a new script entry. The current prebuild is at line 7.
+
+Replace:
+```json
+"prebuild": "bun run generate:search-index && bun run check-env",
+"generate:search-index": "bun scripts/generate-search-index.ts",
+```
+With:
+```json
+"prebuild": "bun run generate:search-index && bun run generate:agent-knowledge && bun run check-env",
+"generate:search-index": "bun scripts/generate-search-index.ts",
+"generate:agent-knowledge": "bun scripts/generate-agent-knowledge.ts",
+```
+
+- [ ] **Step 3: Run the script and verify the JSON lands**
+
+Run: `bun run generate:agent-knowledge`
+Expected output line: `✓ N documents, M graph nodes, K edges, T index terms (… KB) → public/agent-knowledge.json`
+
+Then:
+```bash
+ls -la public/agent-knowledge.json
+```
+Expected: file exists, size > 100 KB.
+
+Run: `node -e 'const k = require("./public/agent-knowledge.json"); console.log({docs: k.documents.length, nodes: k.graph.nodes.length, edges: k.graph.links.length, terms: Object.keys(k.invertedIndex).length, commit: k.commit.slice(0,8)})'`
+Expected: non-zero counts for all four, 8-char commit hash (or `"unknown"` if running in CI without git — acceptable).
+
+- [ ] **Step 4: Add `public/agent-knowledge.json` to `.gitignore`**
+
+Check: `grep agent-knowledge .gitignore`
+If not present, append:
+```bash
+echo "public/agent-knowledge.json" >> .gitignore
+```
+
+Rationale: it's a build artifact regenerated on every deploy. Treat it like `public/search-index.json`.
+
+Verify: `grep search-index .gitignore` — confirm the existing search-index is also in `.gitignore` so we mirror the existing pattern. If it isn't, skip this step (let git track both; don't silently diverge).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/generate-agent-knowledge.ts package.json
+git add .gitignore 2>/dev/null || true
+git commit -m "feat(chat): add agent-knowledge build script + prebuild wiring"
+```
+
+---
+
+## Task 4 — Ship the JSON with the serverless function
+
+**Files:**
+- Modify: `next.config.ts`
+
+- [ ] **Step 1: Read the current config tracing block**
+
+Run:
+```bash
+grep -n outputFileTracing next.config.ts
+```
+Expected: shows `outputFileTracingExcludes` block starting at line ~79.
+
+- [ ] **Step 2: Add `outputFileTracingIncludes` next to the existing excludes**
+
+Edit `next.config.ts`. Find:
+```ts
+  outputFileTracingExcludes: {
+    "*": [
+      "./public/audio/**",
+      "./public/images/**",
+    ],
+  },
+```
+
+Add immediately after it (before `experimental:`):
+```ts
+  outputFileTracingIncludes: {
+    "/api/chat": ["./public/agent-knowledge.json"],
+    "/api/chat/[id]/**": ["./public/agent-knowledge.json"],
+  },
+```
+
+- [ ] **Step 3: Verify the config still type-checks**
+
+Run: `bun test:types 2>&1 | head -40`
+Expected: no errors in `next.config.ts`. (Unrelated existing errors elsewhere are fine.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add next.config.ts
+git commit -m "feat(chat): include agent-knowledge.json in chat route tracing"
+```
+
+---
+
+## Task 5 — Runtime loader + search + read + traverse
+
+**Files:**
+- Create: `lib/ai/knowledge/site-content.ts`
+- Create: `lib/ai/knowledge/site-content.test.ts`
+- Create: `lib/ai/knowledge/__fixtures__/agent-knowledge.fixture.json`
+
+- [ ] **Step 1: Write the fixture JSON**
+
+```bash
+mkdir -p lib/ai/knowledge/__fixtures__
+```
+
+Create `lib/ai/knowledge/__fixtures__/agent-knowledge.fixture.json`:
+
+```json
+{
+  "generatedAt": "2026-04-17T00:00:00.000Z",
+  "commit": "abc1234",
+  "documents": [
+    {
+      "id": "writing/agent-native-architecture",
+      "kind": "writing",
+      "slug": "agent-native-architecture",
+      "title": "Agent-Native Architecture",
+      "summary": "Systems designed for agents, not humans.",
+      "url": "/writing/agent-native-architecture",
+      "tags": ["agent-os", "architecture"],
+      "frontmatter": { "title": "Agent-Native Architecture", "tags": ["agent-os", "architecture"] },
+      "body": "Agent-native architecture means building control planes where the primary operator is an agent. See [[life-agent-os]] for the reference implementation.",
+      "wikilinks": ["life-agent-os"],
+      "related": [],
+      "headings": [{ "depth": 1, "text": "Agent-Native Architecture" }],
+      "wordCount": 22
+    },
+    {
+      "id": "projects/life-agent-os",
+      "kind": "projects",
+      "slug": "life-agent-os",
+      "title": "Life Agent OS",
+      "summary": "The unified Rust monorepo for the Broomva Agent OS.",
+      "url": "/projects/life-agent-os",
+      "tags": ["agent-os", "rust"],
+      "frontmatter": { "title": "Life Agent OS", "pinned": true },
+      "body": "Life is the Rust monorepo implementing Arcan, Lago, Vigil, Praxis, Haima, Spaces, Anima, Autonomic, and aiOS.",
+      "wikilinks": [],
+      "related": ["agent-native-architecture"],
+      "headings": [{ "depth": 1, "text": "Life Agent OS" }],
+      "wordCount": 18
+    }
+  ],
+  "graph": {
+    "nodes": [
+      { "id": "writing/agent-native-architecture", "label": "Agent-Native Architecture", "type": "writing", "url": "/writing/agent-native-architecture", "summary": "Systems designed for agents, not humans.", "tags": ["agent-os", "architecture"], "val": 3 },
+      { "id": "projects/life-agent-os", "label": "Life Agent OS", "type": "projects", "url": "/projects/life-agent-os", "summary": "The unified Rust monorepo for the Broomva Agent OS.", "tags": ["agent-os", "rust"], "val": 3 },
+      { "id": "tag:agent-os", "label": "agent-os", "type": "tag", "tags": [], "val": 2 },
+      { "id": "tag:architecture", "label": "architecture", "type": "tag", "tags": [], "val": 1 },
+      { "id": "tag:rust", "label": "rust", "type": "tag", "tags": [], "val": 1 }
+    ],
+    "links": [
+      { "source": "writing/agent-native-architecture", "target": "projects/life-agent-os", "type": "wikilink" },
+      { "source": "writing/agent-native-architecture", "target": "tag:agent-os", "type": "tag" },
+      { "source": "writing/agent-native-architecture", "target": "tag:architecture", "type": "tag" },
+      { "source": "projects/life-agent-os", "target": "writing/agent-native-architecture", "type": "reference" },
+      { "source": "projects/life-agent-os", "target": "tag:agent-os", "type": "tag" },
+      { "source": "projects/life-agent-os", "target": "tag:rust", "type": "tag" }
+    ]
+  },
+  "invertedIndex": {
+    "agent": ["writing/agent-native-architecture", "projects/life-agent-os"],
+    "native": ["writing/agent-native-architecture"],
+    "architecture": ["writing/agent-native-architecture"],
+    "life": ["projects/life-agent-os"],
+    "rust": ["projects/life-agent-os"]
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing tests first** (`lib/ai/knowledge/site-content.test.ts`)
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import path from "node:path";
+import {
+  __setKnowledgeSourceForTests,
+  loadAgentKnowledge,
+  searchSiteContent,
+  readSiteNote,
+  traverseFrom,
+  resetKnowledgeCacheForTests,
+} from "./site-content";
+
+const FIXTURE = path.join(
+  __dirname,
+  "__fixtures__",
+  "agent-knowledge.fixture.json",
+);
+
+describe("site-content loader", () => {
+  beforeEach(() => {
+    resetKnowledgeCacheForTests();
+    __setKnowledgeSourceForTests(FIXTURE);
+  });
+
+  it("loads and caches the knowledge JSON", async () => {
+    const k1 = await loadAgentKnowledge();
+    const k2 = await loadAgentKnowledge();
+    expect(k1).toBe(k2); // identity: cache hit
+    expect(k1.documents.length).toBe(2);
+    expect(k1.graph.nodes.length).toBe(5);
+  });
+
+  it("returns empty knowledge when the file is missing", async () => {
+    __setKnowledgeSourceForTests("/tmp/definitely-not-here.json");
+    resetKnowledgeCacheForTests();
+    const k = await loadAgentKnowledge();
+    expect(k.documents).toEqual([]);
+    expect(k.graph.nodes).toEqual([]);
+  });
+});
+
+describe("searchSiteContent", () => {
+  beforeEach(() => {
+    resetKnowledgeCacheForTests();
+    __setKnowledgeSourceForTests(FIXTURE);
+  });
+
+  it("returns docs matching a single term via inverted index", async () => {
+    const results = await searchSiteContent("architecture", { maxResults: 5 });
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe("writing/agent-native-architecture");
+  });
+
+  it("ranks title matches above body-only matches", async () => {
+    const results = await searchSiteContent("agent", { maxResults: 5 });
+    // Both docs contain "agent"; "Agent-Native Architecture" has it in the title
+    // so it should outrank "Life Agent OS" which has "Agent" in the middle.
+    expect(results[0].id).toBe("writing/agent-native-architecture");
+  });
+
+  it("returns empty when no terms match", async () => {
+    const results = await searchSiteContent("kubernetes", { maxResults: 5 });
+    expect(results).toEqual([]);
+  });
+
+  it("respects maxResults", async () => {
+    const results = await searchSiteContent("agent", { maxResults: 1 });
+    expect(results.length).toBe(1);
+  });
+});
+
+describe("readSiteNote", () => {
+  beforeEach(() => {
+    resetKnowledgeCacheForTests();
+    __setKnowledgeSourceForTests(FIXTURE);
+  });
+
+  it("resolves by id", async () => {
+    const note = await readSiteNote("writing/agent-native-architecture");
+    expect(note?.title).toBe("Agent-Native Architecture");
+  });
+
+  it("resolves by slug", async () => {
+    const note = await readSiteNote("agent-native-architecture");
+    expect(note?.id).toBe("writing/agent-native-architecture");
+  });
+
+  it("resolves by title (case-insensitive)", async () => {
+    const note = await readSiteNote("Life Agent OS");
+    expect(note?.id).toBe("projects/life-agent-os");
+  });
+
+  it("returns null for unknown note", async () => {
+    const note = await readSiteNote("nonexistent");
+    expect(note).toBeNull();
+  });
+});
+
+describe("traverseFrom", () => {
+  beforeEach(() => {
+    resetKnowledgeCacheForTests();
+    __setKnowledgeSourceForTests(FIXTURE);
+  });
+
+  it("returns 1-hop neighbors via wikilinks", async () => {
+    const { seed, neighbors } = await traverseFrom(
+      "writing/agent-native-architecture",
+      { edgeTypes: ["wikilink"], depth: 1, maxNeighbors: 10 },
+    );
+    expect(seed?.id).toBe("writing/agent-native-architecture");
+    expect(neighbors.map((n) => n.node.id)).toContain("projects/life-agent-os");
+  });
+
+  it("filters by edge type", async () => {
+    const { neighbors } = await traverseFrom("writing/agent-native-architecture", {
+      edgeTypes: ["reference"],
+      depth: 1,
+      maxNeighbors: 10,
+    });
+    expect(neighbors.map((n) => n.node.id)).not.toContain("projects/life-agent-os");
+  });
+
+  it("includes tag neighbors when tag edge type requested", async () => {
+    const { neighbors } = await traverseFrom("writing/agent-native-architecture", {
+      edgeTypes: ["tag"],
+      depth: 1,
+      maxNeighbors: 10,
+    });
+    const ids = neighbors.map((n) => n.node.id);
+    expect(ids).toContain("tag:agent-os");
+    expect(ids).toContain("tag:architecture");
+  });
+
+  it("traverses 2 hops", async () => {
+    const { neighbors } = await traverseFrom("tag:agent-os", {
+      edgeTypes: ["tag", "wikilink"],
+      depth: 2,
+      maxNeighbors: 20,
+    });
+    const ids = neighbors.map((n) => n.node.id);
+    expect(ids).toContain("writing/agent-native-architecture");
+    expect(ids).toContain("projects/life-agent-os");
+  });
+
+  it("returns null seed for unknown node", async () => {
+    const { seed, neighbors } = await traverseFrom("nope", {
+      edgeTypes: ["wikilink"],
+      depth: 1,
+      maxNeighbors: 10,
+    });
+    expect(seed).toBeNull();
+    expect(neighbors).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+Run: `bunx vitest run lib/ai/knowledge/site-content.test.ts`
+Expected: FAIL — `site-content.ts` does not exist.
+
+- [ ] **Step 4: Write `lib/ai/knowledge/site-content.ts`**
+
+```ts
+/**
+ * Runtime loader + query helpers for the agent knowledge JSON.
+ *
+ * The JSON is generated at build time by scripts/generate-agent-knowledge.ts
+ * and lives at public/agent-knowledge.json. It is cached in-module after the
+ * first load.
+ *
+ * Graceful degradation: if the file is missing or unparseable, this module
+ * returns an empty knowledge object and logs once. The tools that depend on
+ * it will return `{ error: "..." }` so the model gets a clean signal.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createModuleLogger } from "@/lib/logger";
+import type {
+  AgentDocument,
+  AgentGraphEdgeType,
+  AgentGraphNode,
+  AgentKnowledge,
+} from "./types";
+
+const log = createModuleLogger("ai:knowledge:site-content");
+
+const EMPTY_KNOWLEDGE: AgentKnowledge = {
+  generatedAt: "1970-01-01T00:00:00.000Z",
+  commit: "unknown",
+  documents: [],
+  graph: { nodes: [], links: [] },
+  invertedIndex: {},
+};
+
+let _cache: AgentKnowledge | null = null;
+let _warned = false;
+
+let _sourcePath: string | null = null;
+
+function defaultSourcePath(): string {
+  return path.join(process.cwd(), "public", "agent-knowledge.json");
+}
+
+/** Test-only: override the JSON path for fixture-based unit tests. */
+export function __setKnowledgeSourceForTests(p: string): void {
+  _sourcePath = p;
+}
+
+/** Test-only: clear the in-module cache. */
+export function resetKnowledgeCacheForTests(): void {
+  _cache = null;
+  _warned = false;
+}
+
+// ── Loader ───────────────────────────────────────────────────────────────────
+
+export async function loadAgentKnowledge(): Promise<AgentKnowledge> {
+  if (_cache) return _cache;
+
+  const source = _sourcePath ?? defaultSourcePath();
+  try {
+    const raw = await fs.readFile(source, "utf8");
+    _cache = JSON.parse(raw) as AgentKnowledge;
+    return _cache;
+  } catch (err) {
+    if (!_warned) {
+      log.warn(
+        { err, source },
+        "agent-knowledge.json missing or unparseable — falling back to empty knowledge",
+      );
+      _warned = true;
+    }
+    _cache = EMPTY_KNOWLEDGE;
+    return _cache;
+  }
+}
+
+// ── Search ───────────────────────────────────────────────────────────────────
+
+export interface SiteSearchResult {
+  id: string;
+  title: string;
+  slug: string;
+  kind: AgentDocument["kind"];
+  url: string;
+  summary: string;
+  tags: string[];
+  excerpts: string[];
+  wikilinks: string[];
+  score: number;
+}
+
+export interface SearchOptions {
+  maxResults?: number;
+}
+
+/** Build an excerpt around the first match of any query term. */
+function excerpt(body: string, terms: string[], radius = 140): string {
+  if (!body) return "";
+  const lower = body.toLowerCase();
+  let bestPos = -1;
+  for (const term of terms) {
+    const pos = lower.indexOf(term);
+    if (pos !== -1 && (bestPos === -1 || pos < bestPos)) bestPos = pos;
+  }
+  if (bestPos === -1) return body.slice(0, radius * 2);
+  const start = Math.max(0, bestPos - radius);
+  const end = Math.min(body.length, bestPos + radius);
+  return `${start > 0 ? "… " : ""}${body.slice(start, end).replace(/\s+/g, " ").trim()}${end < body.length ? " …" : ""}`;
+}
+
+export async function searchSiteContent(
+  query: string,
+  opts: SearchOptions = {},
+): Promise<SiteSearchResult[]> {
+  const { maxResults = 8 } = opts;
+  const knowledge = await loadAgentKnowledge();
+  if (knowledge.documents.length === 0) return [];
+
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((t) => t.replace(/[^\p{L}\p{N}]/gu, ""))
+    .filter((t) => t.length >= 2);
+  if (terms.length === 0) return [];
+
+  // Score per doc: title match (3), summary (2), tag (2), body term (1 per term).
+  const scores = new Map<string, number>();
+
+  for (const doc of knowledge.documents) {
+    const title = doc.title.toLowerCase();
+    const summary = doc.summary.toLowerCase();
+    const body = doc.body.toLowerCase();
+    const tagSet = new Set(doc.tags.map((t) => t.toLowerCase()));
+    let score = 0;
+
+    for (const term of terms) {
+      if (title.includes(term)) score += 3;
+      if (summary.includes(term)) score += 2;
+      if (tagSet.has(term)) score += 2;
+      if (body.includes(term)) score += 1;
+    }
+
+    if (score > 0) scores.set(doc.id, score);
+  }
+
+  const ranked = [...scores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxResults);
+
+  const docById = new Map(knowledge.documents.map((d) => [d.id, d]));
+
+  return ranked.map(([id, score]) => {
+    const doc = docById.get(id)!;
+    return {
+      id: doc.id,
+      title: doc.title,
+      slug: doc.slug,
+      kind: doc.kind,
+      url: doc.url,
+      summary: doc.summary,
+      tags: doc.tags,
+      excerpts: [excerpt(doc.body, terms)],
+      wikilinks: doc.wikilinks,
+      score,
+    };
+  });
+}
+
+// ── Read ─────────────────────────────────────────────────────────────────────
+
+export interface SiteNote {
+  id: string;
+  title: string;
+  slug: string;
+  kind: AgentDocument["kind"];
+  url: string;
+  summary: string;
+  tags: string[];
+  frontmatter: Record<string, unknown>;
+  body: string;
+  wikilinks: string[];
+  related: string[];
+  headings: Array<{ depth: number; text: string }>;
+}
+
+function normalizeKey(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, "-");
+}
+
+export async function readSiteNote(nameOrIdOrSlug: string): Promise<SiteNote | null> {
+  const knowledge = await loadAgentKnowledge();
+  if (knowledge.documents.length === 0) return null;
+
+  const key = normalizeKey(nameOrIdOrSlug);
+
+  const byExact = knowledge.documents.find((d) => d.id === nameOrIdOrSlug);
+  if (byExact) return toSiteNote(byExact);
+
+  const bySlug = knowledge.documents.find((d) => d.slug === key);
+  if (bySlug) return toSiteNote(bySlug);
+
+  const byTitle = knowledge.documents.find(
+    (d) => normalizeKey(d.title) === key || d.title.toLowerCase() === nameOrIdOrSlug.toLowerCase(),
+  );
+  if (byTitle) return toSiteNote(byTitle);
+
+  return null;
+}
+
+function toSiteNote(d: AgentDocument): SiteNote {
+  return {
+    id: d.id,
+    title: d.title,
+    slug: d.slug,
+    kind: d.kind,
+    url: d.url,
+    summary: d.summary,
+    tags: d.tags,
+    frontmatter: d.frontmatter,
+    body: d.body,
+    wikilinks: d.wikilinks,
+    related: d.related,
+    headings: d.headings,
+  };
+}
+
+// ── Traverse ─────────────────────────────────────────────────────────────────
+
+export interface TraverseOptions {
+  edgeTypes?: AgentGraphEdgeType[];
+  depth?: 1 | 2;
+  maxNeighbors?: number;
+}
+
+export interface Neighbor {
+  node: AgentGraphNode;
+  edgeType: AgentGraphEdgeType;
+  hops: 1 | 2;
+}
+
+export interface TraverseResult {
+  seed: AgentGraphNode | null;
+  neighbors: Neighbor[];
+}
+
+export async function traverseFrom(
+  seedKey: string,
+  opts: TraverseOptions = {},
+): Promise<TraverseResult> {
+  const {
+    edgeTypes = ["wikilink", "reference", "tag"],
+    depth = 1,
+    maxNeighbors = 10,
+  } = opts;
+  const knowledge = await loadAgentKnowledge();
+  if (knowledge.graph.nodes.length === 0) return { seed: null, neighbors: [] };
+
+  const nodeById = new Map(knowledge.graph.nodes.map((n) => [n.id, n]));
+
+  // Resolve seed: accept id, slug, title, or tag name.
+  const seed =
+    nodeById.get(seedKey) ??
+    nodeById.get(`tag:${seedKey}`) ??
+    knowledge.graph.nodes.find(
+      (n) => n.label.toLowerCase() === seedKey.toLowerCase(),
+    ) ??
+    knowledge.graph.nodes.find((n) => n.id.endsWith(`/${normalizeKey(seedKey)}`)) ??
+    null;
+
+  if (!seed) return { seed: null, neighbors: [] };
+
+  const allowedEdgeTypes = new Set(edgeTypes);
+  const visited = new Set<string>([seed.id]);
+  const neighbors: Neighbor[] = [];
+
+  const hop1: Array<{ id: string; type: AgentGraphEdgeType }> = [];
+  for (const link of knowledge.graph.links) {
+    if (!allowedEdgeTypes.has(link.type)) continue;
+    if (link.source === seed.id && !visited.has(link.target)) {
+      hop1.push({ id: link.target, type: link.type });
+    } else if (link.target === seed.id && !visited.has(link.source)) {
+      hop1.push({ id: link.source, type: link.type });
+    }
+  }
+
+  for (const { id, type } of hop1) {
+    if (visited.has(id)) continue;
+    visited.add(id);
+    const node = nodeById.get(id);
+    if (!node) continue;
+    neighbors.push({ node, edgeType: type, hops: 1 });
+    if (neighbors.length >= maxNeighbors) break;
+  }
+
+  if (depth === 2 && neighbors.length < maxNeighbors) {
+    const level1Ids = neighbors.map((n) => n.node.id);
+    for (const link of knowledge.graph.links) {
+      if (!allowedEdgeTypes.has(link.type)) continue;
+      for (const parentId of level1Ids) {
+        let nextId: string | null = null;
+        if (link.source === parentId && !visited.has(link.target)) nextId = link.target;
+        else if (link.target === parentId && !visited.has(link.source)) nextId = link.source;
+        if (!nextId) continue;
+        visited.add(nextId);
+        const node = nodeById.get(nextId);
+        if (!node) continue;
+        neighbors.push({ node, edgeType: link.type, hops: 2 });
+        if (neighbors.length >= maxNeighbors) break;
+      }
+      if (neighbors.length >= maxNeighbors) break;
+    }
+  }
+
+  return { seed, neighbors };
+}
+```
+
+- [ ] **Step 5: Run tests — all should pass**
+
+Run: `bunx vitest run lib/ai/knowledge/site-content.test.ts`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Format**
+
+Run: `bun format lib/ai/knowledge/` (or `bunx ultracite@6.3.3 fix lib/ai/knowledge/`)
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/ai/knowledge/
+git commit -m "feat(chat): runtime loader + search/read/traverse over agent knowledge"
+```
+
+---
+
+## Task 6 — Wire site-content into `searchKnowledge` + `readKnowledgeNote`
+
+**Files:**
+- Modify: `lib/ai/tools/knowledge-graph.ts`
+
+- [ ] **Step 1: Replace the top import block**
+
+Find the existing imports at the top of `lib/ai/tools/knowledge-graph.ts`:
+
+```ts
+import { tool } from "ai";
+import { z } from "zod";
+import { createModuleLogger } from "@/lib/logger";
+import { config } from "@/lib/config";
+import {
+  extractWikilinks,
+  resolveWikilink,
+  searchVault,
+} from "../vault/reader";
+import { LagoVaultBackend } from "../vault/lago-backend";
+import { signLagoJWT } from "../vault/jwt";
+import type { ToolSession } from "./types";
+```
+
+Add an import for the new site-content module right after the existing relative imports:
+
+```ts
+import {
+  searchSiteContent as searchAgentSiteContent,
+  readSiteNote,
+  traverseFrom,
+} from "@/lib/ai/knowledge/site-content";
+```
+
+- [ ] **Step 2: Delete the old `searchSiteContent` function**
+
+Find and delete the existing `async function searchSiteContent(query, maxResults)` (lines 51–118 of the current file — the Lago-manifest path-match version). It is replaced by the import above.
+
+- [ ] **Step 3: Update the `searchKnowledgeTool` factory**
+
+Inside `searchKnowledgeTool({ session })`, find the block that currently does:
+
+```ts
+// 3. Site content (lagod — public session, unauthenticated)
+try {
+  const siteResults = await searchSiteContent(query, maxResults);
+  allResults.push(...siteResults);
+} catch (error) {
+  log.error({ err: error, query }, "Site content search error");
+}
+```
+
+Replace it with:
+
+```ts
+// 3. Site content (in-repo knowledge graph from public/agent-knowledge.json)
+try {
+  const siteResults = await searchAgentSiteContent(query, { maxResults });
+  for (const r of siteResults) {
+    allResults.push({
+      name: r.title,
+      path: r.url,
+      frontmatter: { kind: r.kind, tags: r.tags },
+      excerpts: r.excerpts,
+      outgoingLinks: r.wikilinks,
+      score: r.score,
+      source: "site",
+    });
+  }
+} catch (error) {
+  log.error({ err: error, query }, "Site content search error");
+}
+```
+
+- [ ] **Step 4: Update the `readKnowledgeNoteTool` factory to try site-content first**
+
+Inside `readKnowledgeNoteTool({ session })`, the `execute` function currently starts with "Try server vault first". Prepend a site-content attempt **before** the server-vault attempt:
+
+```ts
+// Try site-content (public knowledge graph, always available in production)
+try {
+  const siteNote = await readSiteNote(name);
+  if (siteNote) {
+    return {
+      name: siteNote.title,
+      path: siteNote.url,
+      frontmatter: siteNote.frontmatter,
+      content: truncateBody(siteNote.body, 6000),
+      outgoingLinks: siteNote.wikilinks,
+      source: "site",
+      ...(includeLinkedNotes && siteNote.wikilinks.length > 0
+        ? {
+            linkedNotes: await Promise.all(
+              siteNote.wikilinks.slice(0, 10).map(async (wl) => {
+                const linked = await readSiteNote(wl);
+                return linked
+                  ? {
+                      name: linked.title,
+                      path: linked.url,
+                      excerpt: truncateBody(linked.body, 300),
+                    }
+                  : null;
+              }),
+            ).then((arr) => arr.filter((n): n is NonNullable<typeof n> => n !== null)),
+          }
+        : {}),
+    };
+  }
+} catch (error) {
+  log.error({ err: error, name }, "Site-content read error");
+}
+```
+
+- [ ] **Step 5: Add the new `traverseKnowledgeTool` factory at the bottom of the file**
+
+Before the trailing backward-compat exports (`export const searchKnowledge = ...` etc.), add:
+
+```ts
+/**
+ * Factory: traverseKnowledge tool.
+ *
+ * Walks the public agent knowledge graph (wikilinks, tags, `related:`) from a
+ * seed node. Answers "what connects to X" and "what's in the neighborhood of Y"
+ * questions without repeated searches.
+ */
+export function traverseKnowledgeTool(_: { session: ToolSession }) {
+  return tool({
+    description: `Traverse the public Broomva knowledge graph from a seed node. Follows wikilink, tag, and related-frontmatter edges.
+
+Use when the user asks:
+- "what's connected to X?"
+- "how does X relate to Y?"
+- "what else is in the X neighborhood?"
+- "show me everything tagged X"
+
+Prefer this over repeated searchKnowledge calls for graph-shape questions. The seed can be a document id (e.g. "writing/agent-native-architecture"), a slug, a title, or a tag name (e.g. "agent-os" resolves to "tag:agent-os").`,
+    inputSchema: z.object({
+      seed: z
+        .string()
+        .describe(
+          'Seed node — document id ("writing/foo"), slug, title, or tag name.',
+        ),
+      edgeTypes: z
+        .array(z.enum(["wikilink", "reference", "tag"]))
+        .default(["wikilink", "reference", "tag"])
+        .describe(
+          "Which edge types to follow. Default follows all three.",
+        ),
+      depth: z
+        .union([z.literal(1), z.literal(2)])
+        .default(1)
+        .describe("1 for immediate neighbors, 2 for neighbors-of-neighbors"),
+      maxNeighbors: z
+        .number()
+        .int()
+        .min(1)
+        .max(30)
+        .default(10)
+        .describe("Maximum neighbors to return"),
+    }),
+    execute: async ({
+      seed,
+      edgeTypes,
+      depth,
+      maxNeighbors,
+    }: {
+      seed: string;
+      edgeTypes: ("wikilink" | "reference" | "tag")[];
+      depth: 1 | 2;
+      maxNeighbors: number;
+    }) => {
+      const result = await traverseFrom(seed, { edgeTypes, depth, maxNeighbors });
+      if (!result.seed) {
+        return {
+          error: `Seed "${seed}" not found in the public knowledge graph.`,
+        };
+      }
+      return {
+        seed: {
+          id: result.seed.id,
+          label: result.seed.label,
+          type: result.seed.type,
+          url: result.seed.url,
+          tags: result.seed.tags,
+        },
+        neighbors: result.neighbors.map((n) => ({
+          id: n.node.id,
+          label: n.node.label,
+          type: n.node.type,
+          url: n.node.url,
+          summary: n.node.summary,
+          tags: n.node.tags,
+          edgeType: n.edgeType,
+          hops: n.hops,
+        })),
+      };
+    },
+  });
+}
+```
+
+- [ ] **Step 6: Add backward-compat export**
+
+At the bottom of the file, below the existing `export const searchKnowledge = ...` / `readKnowledgeNote`, add:
+
+```ts
+export const traverseKnowledge = traverseKnowledgeTool({
+  session: { user: undefined },
+});
+```
+
+- [ ] **Step 7: Type-check**
+
+Run: `bun test:types 2>&1 | grep -E '(knowledge-graph|site-content)' | head -20`
+Expected: no errors for these files.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/ai/tools/knowledge-graph.ts
+git commit -m "feat(chat): wire agent-knowledge into searchKnowledge + readKnowledgeNote + new traverseKnowledge tool"
+```
+
+---
+
+## Task 7 — Register `traverseKnowledge` across tool registry, schema, and types
+
+**Files:**
+- Modify: `lib/ai/tools/tools.ts`
+- Modify: `lib/ai/tools/tools-definitions.ts`
+- Modify: `lib/ai/types.ts`
+
+- [ ] **Step 1: Update the import in `tools.ts`**
+
+Find:
+```ts
+import {
+  searchKnowledgeTool,
+  readKnowledgeNoteTool,
+} from "@/lib/ai/tools/knowledge-graph";
+```
+Replace with:
+```ts
+import {
+  searchKnowledgeTool,
+  readKnowledgeNoteTool,
+  traverseKnowledgeTool,
+} from "@/lib/ai/tools/knowledge-graph";
+```
+
+- [ ] **Step 2: Register `traverseKnowledge` in the tool registry**
+
+In `tools.ts` find:
+```ts
+    ...(config.features.knowledgeGraph
+      ? {
+          searchKnowledge: searchKnowledgeTool({ session }),
+          readKnowledgeNote: readKnowledgeNoteTool({ session }),
+        }
+      : {}),
+```
+Replace with:
+```ts
+    ...(config.features.knowledgeGraph
+      ? {
+          searchKnowledge: searchKnowledgeTool({ session }),
+          readKnowledgeNote: readKnowledgeNoteTool({ session }),
+          traverseKnowledge: traverseKnowledgeTool({ session }),
+        }
+      : {}),
+```
+
+- [ ] **Step 3: Add a definition in `tools-definitions.ts`**
+
+After the existing `readKnowledgeNote` entry (ends near line 80 with `cost: 0, // filesystem only`), add:
+
+```ts
+  traverseKnowledge: {
+    name: "traverseKnowledge",
+    description: "Traverse the knowledge graph via wikilink/tag/related edges",
+    cost: 0, // filesystem only
+  },
+```
+
+- [ ] **Step 4: Update `toolNameSchema` in `types.ts`**
+
+Find the schema:
+```ts
+export const toolNameSchema = z.enum([
+  ...
+  "searchKnowledge",
+  "readKnowledgeNote",
+  ...
+```
+Add `"traverseKnowledge"` immediately after `"readKnowledgeNote"`:
+
+```ts
+export const toolNameSchema = z.enum([
+  ...
+  "searchKnowledge",
+  "readKnowledgeNote",
+  "traverseKnowledge",
+  ...
+```
+
+- [ ] **Step 5: Add the type alias in `types.ts`**
+
+In `types.ts`, find:
+```ts
+import type {
+  searchKnowledge,
+  readKnowledgeNote,
+} from "@/lib/ai/tools/knowledge-graph";
+```
+Replace with:
+```ts
+import type {
+  searchKnowledge,
+  readKnowledgeNote,
+  traverseKnowledge,
+} from "@/lib/ai/tools/knowledge-graph";
+```
+
+Then find:
+```ts
+type searchKnowledgeTool = InferUITool<typeof searchKnowledge>;
+type readKnowledgeNoteTool = InferUITool<typeof readKnowledgeNote>;
+```
+Add below:
+```ts
+type traverseKnowledgeTool = InferUITool<typeof traverseKnowledge>;
+```
+
+And in the `ChatTools` object literal, after `readKnowledgeNote: readKnowledgeNoteTool;` add:
+```ts
+  traverseKnowledge: traverseKnowledgeTool;
+```
+
+- [ ] **Step 6: Type-check the whole app**
+
+Run: `bun test:types 2>&1 | tail -40`
+Expected: no new errors introduced by these files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/ai/tools/tools.ts lib/ai/tools/tools-definitions.ts lib/ai/types.ts
+git commit -m "feat(chat): register traverseKnowledge in tool registry + types"
+```
+
+---
+
+## Task 8 — Rewrite `lib/ai/prompts.ts` into a 5-layer assembler
+
+**Files:**
+- Modify: `lib/ai/prompts.ts`
+
+- [ ] **Step 1: Replace the entire file**
+
+Overwrite `lib/ai/prompts.ts` with:
+
+```ts
+/**
+ * System prompt for the Arcan chat on broomva.tech.
+ *
+ * The prompt is assembled in five layers (see
+ * docs/superpowers/specs/2026-04-17-arcan-chat-prompt-design.md):
+ *
+ *   1. Arcan identity   — baked from content/agent/identity.mdx at cold start
+ *   2. Live index       — per request: pinned projects + latest writing/notes
+ *   3. KG navigation    — baked string with the graph landscape
+ *   4. Tool protocol    — baked rules for when/how to call tools
+ *   5. User context     — per request, auth-gated
+ *
+ * The previous `systemPrompt()` export is kept as a deprecated thin wrapper
+ * that calls `buildSystemPrompt({})` so any stray callers keep working. It
+ * can be removed in a follow-up commit once nothing references it.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import matter from "gray-matter";
+import { getLatest, getPinnedProjects } from "@/lib/content";
+import { createModuleLogger } from "@/lib/logger";
+
+const log = createModuleLogger("ai:prompts");
+
+// ── Layer 1: Identity (cold-start cached) ────────────────────────────────────
+
+const IDENTITY_FALLBACK = `# Who I am
+
+I'm Arcan — the user-facing instance of the Broomva agent runtime.
+
+# Who I serve
+
+Carlos D. Escobar-Valbuena (AI engineer, agent architect, builder), and anyone interacting with him through broomva.tech.
+
+# Tone
+
+Direct, technical, first-person. I cite my sources.`;
+
+let _identity: string | null = null;
+
+function getIdentity(): string {
+  if (_identity !== null) return _identity;
+  try {
+    const path = join(process.cwd(), "content", "agent", "identity.mdx");
+    const raw = readFileSync(path, "utf-8");
+    _identity = matter(raw).content.trim();
+    return _identity;
+  } catch (err) {
+    log.warn({ err }, "identity.mdx missing — using fallback identity string");
+    _identity = IDENTITY_FALLBACK;
+    return _identity;
+  }
+}
+
+// ── Layer 2: Live index (per request) ────────────────────────────────────────
+
+interface LiveIndex {
+  pinnedProjects: Array<{ title: string; summary: string; url: string }>;
+  latestWriting: Array<{ title: string; url: string }>;
+  latestNotes: Array<{ title: string; url: string }>;
+}
+
+async function buildLiveIndex(): Promise<LiveIndex> {
+  try {
+    const [pinned, writing, notes] = await Promise.all([
+      getPinnedProjects(3),
+      getLatest("writing", 3),
+      getLatest("notes", 3),
+    ]);
+    return {
+      pinnedProjects: pinned.map((p) => ({
+        title: p.title,
+        summary: p.summary ?? "",
+        url: `/projects/${p.slug}`,
+      })),
+      latestWriting: writing.map((w) => ({
+        title: w.title,
+        url: `/writing/${w.slug}`,
+      })),
+      latestNotes: notes.map((n) => ({
+        title: n.title,
+        url: `/notes/${n.slug}`,
+      })),
+    };
+  } catch (err) {
+    log.warn({ err }, "live index build failed — returning empty");
+    return { pinnedProjects: [], latestWriting: [], latestNotes: [] };
+  }
+}
+
+function formatLiveIndex(idx: LiveIndex, today: string): string {
+  const parts: string[] = [`Today: ${today}`];
+
+  if (idx.pinnedProjects.length > 0) {
+    parts.push(
+      `\n## Pinned projects (right now)\n${idx.pinnedProjects
+        .map((p) => `- **${p.title}** — ${p.summary || "no summary"} · ${p.url}`)
+        .join("\n")}`,
+    );
+  }
+  if (idx.latestWriting.length > 0) {
+    parts.push(
+      `\n## Latest writing\n${idx.latestWriting
+        .map((w) => `- ${w.title} · ${w.url}`)
+        .join("\n")}`,
+    );
+  }
+  if (idx.latestNotes.length > 0) {
+    parts.push(
+      `\n## Latest notes\n${idx.latestNotes
+        .map((n) => `- ${n.title} · ${n.url}`)
+        .join("\n")}`,
+    );
+  }
+  return parts.join("\n");
+}
+
+// ── Layer 3: KG navigation hints (baked) ─────────────────────────────────────
+
+const NAVIGATION_HINTS = `## Where knowledge lives
+
+Public knowledge graph (always available, indexed on every deploy at \`public/agent-knowledge.json\`):
+- \`/writing/*\` — essays, tech deep dives
+- \`/notes/*\` — shorter takes, seeds
+- \`/projects/*\` — project pages with deployment info
+- \`/prompts/*\` — versioned prompt library
+- \`/skills\` — bstack (27 agent skills, 7 layers)
+- \`/graph\` — force-directed view of all above
+
+Local-only (requires VAULT_PATH — your laptop, not Vercel):
+- 00-Index/Broomva Index, Projects, Consciousness
+- 01-Life, 02-Symphony, 03-Autoany, 04-Control-Kernel, 05-ChatOS, 06-Symphony-Cloud, 08-Research
+
+User vault (requires auth + memoryVault feature flag):
+- Personal notes, private context, preferences`;
+
+// ── Layer 4: Tool protocol (baked) ───────────────────────────────────────────
+
+const TOOL_PROTOCOL = `## How I use tools
+
+- **Default to retrieval** when the question touches Broomva project architecture, past decisions, open-source internals, published writing, or any claim that needs a source.
+- **Cite every retrieved fact inline** using \`[Title](/writing/slug)\` — not a footer, not a separate section.
+- **Prefer \`readKnowledgeNote\`** when I know the id/slug/title (from the Live Index or Navigation map above). Only fall back to \`searchKnowledge\` for discovery.
+- **Use \`traverseKnowledge\`** for "what else relates to X" / "how does X connect to Y" questions — one tool call answers the neighborhood.
+- **No hallucinated URLs.** If I don't have a source, I say so and offer to search.
+- **Skip retrieval** for general programming questions, generic explanations, or anything Carlos could answer himself. Reserve tool calls for Broomva-specific knowledge.
+- **Prompt templates**: \`listPrompts\` / \`getPrompt\` / \`savePrompt\` / \`deletePrompt\` are for user-managed prompt templates (not the identity layer).
+
+## Output rules
+
+- Markdown supported — use it for structure.
+- If a diagram helps, use a fenced \`\`\`mermaid block.
+- Currency: USD, spelled out. Never bare \`$\`.
+- Responses are substantive and well-formatted — not terse, not marketing fluff.`;
+
+// ── Layer 5: User context (per request, auth-gated) ──────────────────────────
+
+interface UserContextInput {
+  userName?: string | null;
+  isAnonymous: boolean;
+  memoryVaultAvailable?: boolean;
+}
+
+function formatUserContext(input: UserContextInput): string {
+  if (input.isAnonymous) {
+    return `## Who I'm talking to
+
+A visitor. No personal vault. I keep answers grounded in the public knowledge graph and cite every source.`;
+  }
+  const vault = input.memoryVaultAvailable
+    ? "Your user vault is available — use \`searchKnowledge\` for personal/private context."
+    : "Your user vault is not configured on this deploy — stay in the public graph.";
+  return `## Who I'm talking to
+
+Carlos${input.userName ? ` (logged in as ${input.userName})` : ""}. ${vault}`;
+}
+
+// ── Assembler ────────────────────────────────────────────────────────────────
+
+export interface BuildSystemPromptInput {
+  isAnonymous: boolean;
+  userName?: string | null;
+  memoryVaultAvailable?: boolean;
+}
+
+export async function buildSystemPrompt(
+  input: BuildSystemPromptInput,
+): Promise<string> {
+  const today = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    weekday: "short",
+  });
+
+  const [live] = await Promise.all([buildLiveIndex()]);
+
+  const sections = [
+    getIdentity(),
+    `# Live state\n\n${formatLiveIndex(live, today)}`,
+    NAVIGATION_HINTS,
+    TOOL_PROTOCOL,
+    formatUserContext({
+      isAnonymous: input.isAnonymous,
+      userName: input.userName ?? null,
+      memoryVaultAvailable: input.memoryVaultAvailable ?? false,
+    }),
+  ];
+
+  return sections.join("\n\n---\n\n");
+}
+
+/** @deprecated Use {@link buildSystemPrompt} — scheduled for removal once no caller depends on the old signature. */
+export function systemPrompt(): string {
+  log.warn("Legacy systemPrompt() called — use buildSystemPrompt() instead");
+  return `${getIdentity()}\n\n${NAVIGATION_HINTS}\n\n${TOOL_PROTOCOL}`;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `bun test:types 2>&1 | grep -E 'prompts\.ts' | head`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/ai/prompts.ts
+git commit -m "feat(chat): rewrite systemPrompt as 5-layer Arcan prompt assembler"
+```
+
+---
+
+## Task 9 — Wire `buildSystemPrompt` into the chat route
+
+**Files:**
+- Modify: `app/(chat)/api/chat/route.ts`
+
+- [ ] **Step 1: Update the import**
+
+Find at the top of `route.ts`:
+```ts
+import { systemPrompt } from "@/lib/ai/prompts";
+```
+Replace with:
+```ts
+import { buildSystemPrompt } from "@/lib/ai/prompts";
+```
+
+- [ ] **Step 2: Rewrite `getSystemPrompt`**
+
+Find the existing function (~ lines 427–445):
+
+```ts
+async function getSystemPrompt({
+  isAnonymous,
+  chatId,
+}: {
+  isAnonymous: boolean;
+  chatId: string;
+}): Promise<string> {
+  let system = systemPrompt();
+  if (!isAnonymous) {
+    const currentChat = await getChatById({ id: chatId });
+    if (currentChat?.projectId) {
+      const project = await getProjectById({ id: currentChat.projectId });
+      if (project?.instructions) {
+        system = `${system}\n\nProject instructions:\n${project.instructions}`;
+      }
+    }
+  }
+  return system;
+}
+```
+
+Replace with:
+
+```ts
+async function getSystemPrompt({
+  isAnonymous,
+  chatId,
+  userName,
+}: {
+  isAnonymous: boolean;
+  chatId: string;
+  userName?: string | null;
+}): Promise<string> {
+  let system = await buildSystemPrompt({
+    isAnonymous,
+    userName,
+    memoryVaultAvailable: config.features.memoryVault && !isAnonymous,
+  });
+  if (!isAnonymous) {
+    const currentChat = await getChatById({ id: chatId });
+    if (currentChat?.projectId) {
+      const project = await getProjectById({ id: currentChat.projectId });
+      if (project?.instructions) {
+        system = `${system}\n\n---\n\n## Project instructions\n\n${project.instructions}`;
+      }
+    }
+  }
+  return system;
+}
+```
+
+- [ ] **Step 3: Verify `config` is already imported at the top of route.ts**
+
+Run: `grep -n 'from "@/lib/config"' app/\(chat\)/api/chat/route.ts`
+Expected: one match. If missing, add `import { config } from "@/lib/config";` next to the other top-level imports.
+
+- [ ] **Step 4: Pass `userName` into `getSystemPrompt`**
+
+Find the single call-site of `getSystemPrompt(` inside the same file. It currently receives `{ isAnonymous, chatId }`. Add the user's name — search nearby for where `session` is already resolved; the existing code has a `session` variable with `session.user?.name`. Replace:
+
+```ts
+const system = await getSystemPrompt({ isAnonymous, chatId });
+```
+
+With:
+
+```ts
+const system = await getSystemPrompt({
+  isAnonymous,
+  chatId,
+  userName: isAnonymous ? null : session?.user?.name ?? null,
+});
+```
+
+(If the variable name isn't exactly `session`, use whatever holds the auth session in this function — the only change is passing the user's display name.)
+
+- [ ] **Step 5: Type-check**
+
+Run: `bun test:types 2>&1 | grep -E 'route\.ts' | head`
+Expected: no errors introduced.
+
+- [ ] **Step 6: Smoke-test locally**
+
+In a separate terminal, ensure the dev DB is up and run:
+
+```bash
+bun run generate:agent-knowledge
+bun run dev
+```
+
+Open `http://localhost:3001/chat`, send: `Who are you?`
+Expected: response introduces itself as Arcan, mentions Broomva, mentions Carlos by name, no URL hallucinations.
+
+Send: `What projects are pinned right now?`
+Expected: response lists actual pinned project URLs from content/projects/*.mdx (check one by clicking through).
+
+If it works, stop the dev server.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/\(chat\)/api/chat/route.ts
+git commit -m "feat(chat): wire buildSystemPrompt + userName into chat route"
+```
+
+---
+
+## Task 10 — Eval: identity
+
+**Files:**
+- Create: `evals/identity.eval.ts`
+
+- [ ] **Step 1: Write the eval**
+
+```ts
+import { evalite } from "evalite";
+import { runCoreChatAgentEval } from "@/lib/ai/eval-agent";
+import type { ChatMessage } from "@/lib/ai/types";
+import { generateUUID } from "@/lib/utils";
+
+const MODEL = "anthropic/claude-haiku-4.5" as const;
+
+function userMessage(text: string): ChatMessage {
+  return {
+    id: generateUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: {
+      createdAt: new Date(),
+      parentMessageId: null,
+      selectedModel: MODEL,
+      activeStreamId: null,
+    },
+  };
+}
+
+evalite("Arcan Identity Eval", {
+  data: async () => [
+    {
+      input: "Who are you?",
+      expected: ["arcan", "broomva"],
+    },
+    {
+      input: "Who is Carlos?",
+      expected: ["carlos", "engineer"],
+    },
+    {
+      input: "What is Broomva?",
+      expected: ["agent os", "life", "arcan"],
+    },
+  ],
+  task: async (input) => {
+    const result = await runCoreChatAgentEval({
+      userMessage: userMessage(input),
+      previousMessages: [],
+      selectedModelId: MODEL,
+      activeTools: [],
+    });
+    return result.finalText;
+  },
+  scorers: [
+    {
+      name: "ContainsAllExpected",
+      description: "All expected substrings must appear (case-insensitive).",
+      scorer: ({ output, expected }) => {
+        const lower = output.toLowerCase();
+        const terms = expected as string[];
+        const hits = terms.filter((t) => lower.includes(t.toLowerCase())).length;
+        return hits === terms.length ? 1 : hits / terms.length;
+      },
+    },
+  ],
+});
+```
+
+- [ ] **Step 2: Run the eval**
+
+Run: `bunx evalite run evals/identity.eval.ts`
+Expected: score averages ≥ 0.8. If below, the identity MDX needs more of the expected surface area — adjust and rerun.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add evals/identity.eval.ts
+git commit -m "test(chat): add identity eval for Arcan system prompt"
+```
+
+---
+
+## Task 11 — Eval: KG retrieval
+
+**Files:**
+- Create: `evals/kg-retrieval.eval.ts`
+
+- [ ] **Step 1: Confirm the expected corpus exists**
+
+Run: `ls content/writing | head -5`
+Expected: non-empty. Pick one real slug (e.g. `agent-native-architecture.mdx`) to use as the canonical retrieval target. Substitute that slug in the eval below if the one we picked doesn't exist in this repo.
+
+- [ ] **Step 2: Write the eval**
+
+```ts
+import { evalite } from "evalite";
+import { runCoreChatAgentEval } from "@/lib/ai/eval-agent";
+import type { ChatMessage } from "@/lib/ai/types";
+import { generateUUID } from "@/lib/utils";
+
+const MODEL = "anthropic/claude-haiku-4.5" as const;
+
+function userMessage(text: string): ChatMessage {
+  return {
+    id: generateUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: {
+      createdAt: new Date(),
+      parentMessageId: null,
+      selectedModel: MODEL,
+      activeStreamId: null,
+    },
+  };
+}
+
+evalite("KG Retrieval Eval", {
+  data: async () => [
+    {
+      // Pick a writing slug that actually exists in content/writing/.
+      input: "Tell me about the agent-native architecture essay.",
+      expected: { urlSubstring: "/writing/agent-native-architecture" },
+    },
+    {
+      input: "What prompts do you have for deep research?",
+      expected: { urlSubstring: "/prompts/deep-research-agent" },
+    },
+  ],
+  task: async (input) => {
+    const result = await runCoreChatAgentEval({
+      userMessage: userMessage(input),
+      previousMessages: [],
+      selectedModelId: MODEL,
+      activeTools: ["searchKnowledge", "readKnowledgeNote"],
+    });
+    return result.finalText;
+  },
+  scorers: [
+    {
+      name: "CitesExpectedURL",
+      description: "Response must include the expected URL substring.",
+      scorer: ({ output, expected }) => {
+        const needle = (expected as { urlSubstring: string }).urlSubstring.toLowerCase();
+        return output.toLowerCase().includes(needle) ? 1 : 0;
+      },
+    },
+  ],
+});
+```
+
+- [ ] **Step 3: Run the eval**
+
+Run: `bunx evalite run evals/kg-retrieval.eval.ts`
+Expected: score ≥ 0.8. If below, check that `public/agent-knowledge.json` is up to date (`bun run generate:agent-knowledge`) and that the slugs used in `expected` exist under `content/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add evals/kg-retrieval.eval.ts
+git commit -m "test(chat): add KG retrieval eval for site-content tools"
+```
+
+---
+
+## Task 12 — Eval: connectivity (traverse)
+
+**Files:**
+- Create: `evals/connectivity.eval.ts`
+
+- [ ] **Step 1: Write the eval**
+
+```ts
+import { evalite } from "evalite";
+import { runCoreChatAgentEval } from "@/lib/ai/eval-agent";
+import type { ChatMessage } from "@/lib/ai/types";
+import { generateUUID } from "@/lib/utils";
+
+const MODEL = "anthropic/claude-haiku-4.5" as const;
+
+function userMessage(text: string): ChatMessage {
+  return {
+    id: generateUUID(),
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: {
+      createdAt: new Date(),
+      parentMessageId: null,
+      selectedModel: MODEL,
+      activeStreamId: null,
+    },
+  };
+}
+
+evalite("KG Connectivity Eval", {
+  data: async () => [
+    {
+      input: "Show me everything in our knowledge graph tagged agent-os.",
+      expected: { minLinkCount: 2, mustContain: "/" },
+    },
+    {
+      input: "What's connected to the Life Agent OS project?",
+      expected: { minLinkCount: 2, mustContain: "/" },
+    },
+  ],
+  task: async (input) => {
+    const result = await runCoreChatAgentEval({
+      userMessage: userMessage(input),
+      previousMessages: [],
+      selectedModelId: MODEL,
+      activeTools: ["searchKnowledge", "readKnowledgeNote", "traverseKnowledge"],
+    });
+    return result.finalText;
+  },
+  scorers: [
+    {
+      name: "HasEnoughLinks",
+      description: "Response must include at least minLinkCount markdown links.",
+      scorer: ({ output, expected }) => {
+        const exp = expected as { minLinkCount: number; mustContain: string };
+        const links = [...output.matchAll(/\]\((\/[^)]+)\)/g)].map((m) => m[1]);
+        const ok =
+          links.length >= exp.minLinkCount &&
+          links.some((l) => l.includes(exp.mustContain));
+        return ok ? 1 : 0;
+      },
+    },
+  ],
+});
+```
+
+- [ ] **Step 2: Run the eval**
+
+Run: `bunx evalite run evals/connectivity.eval.ts`
+Expected: score ≥ 0.8. If below, inspect the tool call log — the model may be searching instead of traversing. Tighten Layer 4 of the prompt to insist on `traverseKnowledge` for connection questions, regenerate knowledge, rerun.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add evals/connectivity.eval.ts
+git commit -m "test(chat): add connectivity eval for traverseKnowledge tool"
+```
+
+---
+
+## Task 13 — Full smoke test
+
+**Files:** (none modified — verification only)
+
+- [ ] **Step 1: Clean rebuild the knowledge artifact**
+
+Run:
+```bash
+rm -f public/agent-knowledge.json
+bun run generate:agent-knowledge
+```
+Expected: file regenerated; counts non-zero.
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `bun test:unit 2>&1 | tail -20`
+Expected: all tests pass (at minimum the new site-content tests from Task 5).
+
+- [ ] **Step 3: Type-check**
+
+Run: `bun test:types 2>&1 | tail -20`
+Expected: no new errors introduced by this branch.
+
+- [ ] **Step 4: Full production build**
+
+Run: `bun run build 2>&1 | tail -40`
+Expected: build completes. `public/agent-knowledge.json` regenerated via prebuild. Next build succeeds.
+
+- [ ] **Step 5: Verify bundle tracing**
+
+Run:
+```bash
+find .next -name "agent-knowledge.json" 2>/dev/null
+```
+Expected: at least one hit under `.next/server/` or `.next/standalone/`. If empty, the `outputFileTracingIncludes` paths in `next.config.ts` didn't match — adjust the globs to match the actual route manifest, regenerate, re-check.
+
+- [ ] **Step 6: Hand off for review**
+
+No commit in this task — it's verification only. If all steps pass, the branch is ready for review. If any step fails, address it and re-run from Step 1.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- Arcan identity baked (Task 1, 8) ✓
+- Live index per-request (Task 8 — `buildLiveIndex`) ✓
+- KG navigation hints baked (Task 8 — `NAVIGATION_HINTS`) ✓
+- Tool protocol baked (Task 8 — `TOOL_PROTOCOL`) ✓
+- Per-request auth-gated user context (Task 8 — `formatUserContext`, Task 9 — passes `userName`) ✓
+- Build-time `public/agent-knowledge.json` with bodies + graph + inverted index (Task 3) ✓
+- `outputFileTracingIncludes` for the chat route (Task 4) ✓
+- `site-content` source in `searchKnowledge` / `readKnowledgeNote` (Tasks 5, 6) ✓
+- New `traverseKnowledge` tool registered everywhere (Tasks 6, 7) ✓
+- Three evals: identity / KG retrieval / connectivity (Tasks 10, 11, 12) ✓
+- VAULT_PATH kept for local dev, Lago user vault kept auth-gated — no change needed (unchanged code in `knowledge-graph.ts` outside the two hunks we edit) ✓
+- Landing page unchanged (no task — spec confirms) ✓
+
+**Placeholder scan:** Every step has a concrete command, file path, or code block. The only "adjust if …" lines are conditional recovery steps (Task 4 Step 5, Task 11 Step 1, Task 12 Step 2), which are acceptable because they show the concrete action to take in each branch.
+
+**Type consistency:** `AgentKnowledge`, `AgentDocument`, `AgentGraphNode`, `AgentGraphEdge`, and their property names (`documents`, `graph.nodes`, `graph.links`, `invertedIndex`) are used consistently between Task 2 (types), Task 3 (generator), Task 5 (loader + tests), Task 6 (tool wiring). Tool names (`searchKnowledge`, `readKnowledgeNote`, `traverseKnowledge`) are consistent across tasks 6, 7, 10, 11, 12. Factory naming (`searchKnowledgeTool`, `readKnowledgeNoteTool`, `traverseKnowledgeTool`) is consistent between `knowledge-graph.ts` (Task 6) and `tools.ts` (Task 7).

--- a/docs/superpowers/specs/2026-04-17-arcan-chat-prompt-design.md
+++ b/docs/superpowers/specs/2026-04-17-arcan-chat-prompt-design.md
@@ -1,0 +1,297 @@
+# Arcan Chat — Prompt, Context, and Knowledge Graph Grounding
+
+**Status:** Draft — awaiting user review
+**Date:** 2026-04-17
+**Scope:** `apps/chat/` (broomva.tech landing + `/chat` page)
+**Supersedes:** ad-hoc `systemPrompt()` in `apps/chat/lib/ai/prompts.ts`
+
+## Summary
+
+The Arcan chat on broomva.tech today runs on a one-line system prompt ("You are a friendly assistant!") plus an optional vault-index snippet that only loads when `VAULT_PATH` is mounted on the server. On Vercel that env is unset, so in production the agent starts cold with no identity, no project context, no knowledge of who Carlos is, and no way to search the repo's published content.
+
+Meanwhile the repo already contains the substrate to fix this — `apps/chat/content/{writing,notes,projects,prompts}/**.mdx`, a working `buildPublicGraph()` at `lib/graph/build-public.ts`, and a `generate-search-index.ts` prebuild step. The agent simply isn't wired to any of it.
+
+This spec adds:
+
+1. A new prebuild step that emits a rich `public/agent-knowledge.json` (MDX bodies + frontmatter + wikilink/tag graph) on every deploy.
+2. Full-text `searchKnowledge` / `readKnowledgeNote` against that JSON, plus a new `traverseKnowledge` tool for wikilink-graph walks.
+3. A 5-layer system prompt (identity, live index, KG navigation, tool protocol, user context) that gives every conversation a coherent grounding regardless of entry point.
+4. Three evals to keep the above from regressing.
+
+The agent keeps its existing identity as Arcan — the user-facing instance of the Broomva agent runtime. Primary user is Carlos; visitors get the same depth.
+
+## Goals
+
+- Every chat on broomva.tech opens with full grounding in who Carlos is, what Broomva is building, and what's currently shipped.
+- The agent can answer questions about any published writing, note, project, prompt, or skill with correct URLs and inline citations.
+- The agent can traverse wikilink / `related` / tag edges to answer "what connects to X" questions without re-searching.
+- The in-repo knowledge graph is re-indexed on every CI/CD deployment, so the agent is never staler than the last deploy.
+- Authenticated users additionally get their Lago user vault as a search layer; anonymous users get the OSS-backed public layer only.
+- Local development continues to work with the user's Obsidian vault via `VAULT_PATH`.
+
+## Non-goals
+
+- No change to the landing hero UX — the input still redirects to `/chat?q=...`.
+- No migration off Lago for the user vault — Layer 2 of the consciousness stack stays as-is.
+- No live sync from `~/broomva/research/entities/` (Layer 3 KG). That lives outside the broomva.tech repo; a later PR can bridge it via a committed snapshot or a submodule.
+- No chat persona other than Arcan. Other agents (Moltie, Haima, etc.) are out of scope.
+- No new UI components. This is a prompt + retrieval + build-pipeline change.
+
+## Architecture
+
+### Build time (prebuild hook)
+
+```
+bun scripts/generate-search-index.ts           # existing — flat UI dock index
+bun scripts/generate-agent-knowledge.ts        # NEW — rich agent index
+       │
+       ├─► public/search-index.json            # flat: title, summary, href, tags
+       └─► public/agent-knowledge.json         # rich: bodies + frontmatter + graph
+```
+
+`generate-agent-knowledge.ts` reuses the logic already in `lib/graph/build-public.ts` and extends it to carry full MDX body content and an inverted index. Output shape:
+
+```jsonc
+{
+  "generatedAt": "2026-04-17T…",
+  "commit": "<git-sha>",
+  "documents": [
+    {
+      "id": "writing/agent-native-architecture",
+      "kind": "writing",        // notes | projects | writing | prompts
+      "slug": "agent-native-architecture",
+      "title": "…",
+      "summary": "…",
+      "url": "/writing/agent-native-architecture",
+      "tags": ["agent-os", "architecture"],
+      "frontmatter": { /* full */ },
+      "body": "…",              // MDX body with JSX stripped to plain text
+      "wikilinks": ["life-agent-os", "arcan"],
+      "related": ["harness-over-prompting"],
+      "headings": [{ "depth": 2, "text": "…" }],
+      "wordCount": 1234
+    }
+  ],
+  "graph": {
+    "nodes": [ /* same shape as buildPublicGraph() output */ ],
+    "links": [ /* same shape */ ]
+  },
+  "invertedIndex": {
+    "arcan": ["writing/agent-native-architecture", "notes/…"]
+  }
+}
+```
+
+Size budget: **1–3 MB uncompressed**. Loaded once per cold start, cached in-module with `let _cache: AgentKnowledge | null`.
+
+### Runtime (per `/api/chat` request)
+
+```
+getSystemPrompt({ session, chatId })
+  → 5-layer system prompt (see "System prompt contents" below)
+
+Tools available to the model:
+  searchKnowledge
+    (1) site-content   → agent-knowledge.json       [NEW, primary in prod]
+    (2) user-vault     → Lago vault (auth only)
+    (3) server-vault   → VAULT_PATH (local dev only)
+
+  readKnowledgeNote
+    → same three sources, path/slug-resolved
+
+  traverseKnowledge    [NEW]
+    → follow wikilink/reference/tag edges from a seed node
+      using graph edges in agent-knowledge.json
+```
+
+## System prompt contents (the 5 layers)
+
+### Layer 1 — Arcan identity (baked, hand-authored)
+
+Source: `apps/chat/content/agent/identity.mdx` — one hand-edited file, under version control, loaded once at cold start via `readFileSync`.
+
+Contents:
+- **Who I am**: "I'm Arcan, the user-facing instance of the Broomva agent runtime."
+- **Who I serve**: Carlos D. Escobar-Valbuena (AI engineer, agent architect, builder) and anyone interacting with him through broomva.tech.
+- **What Broomva is**: unified agent OS — Life (Arcan runtime, Lago persistence, Vigil observability, Praxis tools, Haima finance, Spaces networking, Anima soul layer), Symphony (orchestration), ChatOS (this app), Control Kernel (governance metalayer).
+- **Core bets / theses**: agent-native architecture, event-sourced state, control-systems metalayer, open-source substrate, progressive crystallization of knowledge.
+- **Conventions**: Rust for core, TypeScript for web, Bun, Biome, Better Auth, Drizzle, Turborepo.
+- **Tone**: direct, technical, first-person-as-Arcan, cites sources, shows architectural thinking, not marketing-speak.
+
+Length target: ~250 lines of MDX. Edits take effect on next deploy (no restart needed, but prompt content is cached per-cold-start in the serverless function, so practical propagation is deploy-scoped). The payoff isn't zero-redeploy editing — it's that voice/identity changes are one-file PRs that don't touch retrieval or tool wiring.
+
+### Layer 2 — Live index (per-request, dynamic)
+
+Assembled in `buildSystemPrompt()`. Uses existing helpers: `getPinnedProjects(3)`, `getLatest("writing", 3)`, `getLatest("notes", 3)`, `getRecentRepos("broomva", 3)` (graceful fallback if no `GITHUB_TOKEN`).
+
+Injected as a short bulleted block:
+- Today's date
+- Top 3 pinned projects (title + 1-line summary + URL)
+- Latest 3 writing posts (title + URL)
+- Latest 3 notes (title + URL)
+- Recent 3 active repos (if available)
+
+Purpose: grounds the agent in **what exists right now** without a tool roundtrip on every "what are you working on?" question.
+
+### Layer 3 — KG navigation hints (baked)
+
+A condensed map of what lives where, so the agent picks targeted lookups instead of broad searches:
+
+```
+Site knowledge graph (public, always available):
+  /writing/*    — essays, tech deep dives
+  /notes/*      — shorter takes, seeds
+  /projects/*   — project pages with deployment info
+  /prompts/*    — versioned prompt library
+  /skills       — bstack (27 agent skills, 7 layers)
+  /graph        — force-directed view of all above
+
+Local-only (requires VAULT_PATH):
+  00-Index/Broomva Index, Projects, Consciousness
+  01-Life, 02-Symphony, 03-Autoany, 04-Control-Kernel
+  05-ChatOS, 06-Symphony-Cloud, 08-Research
+
+User vault (requires auth + memoryVault):
+  Personal notes, private context, preferences
+```
+
+### Layer 4 — Tool protocol (baked)
+
+Explicit rules for tool use:
+
+- **Default to retrieval** when the question touches project architecture, past decisions, open-source internals, writing, or any claim that needs a source.
+- **Cite every retrieved fact** inline with `[Title](/writing/slug)`, not in a footer.
+- **Prefer `readKnowledgeNote`** when the note id/slug is known (from the Live Index or Navigation map). Only fall back to `searchKnowledge` for discovery.
+- **Use `traverseKnowledge`** for "what else relates to X" / "how does X connect to Y" questions.
+- **Don't hallucinate URLs.** If there's no source, say so and offer to search.
+- **Skip retrieval** for general programming questions, generic explanations, or anything Carlos could answer himself. Reserve tool calls for Broomva-specific knowledge.
+
+### Layer 5 — User context (per-request, auth-gated)
+
+If authenticated:
+- "You are talking to Carlos (logged in as `{name}`). Your user vault is {available|unavailable}; use `searchKnowledge` to consult personal notes when the question is about preferences, decisions, or private context."
+
+If anonymous:
+- "You are talking to a visitor. They don't have a personal vault. Keep answers grounded in the public knowledge graph and cite sources."
+
+## Implementation changes
+
+### New files
+
+- `apps/chat/scripts/generate-agent-knowledge.ts` — build-time index generator.
+- `apps/chat/lib/ai/knowledge/site-content.ts` — runtime loader + search + traverse helpers.
+- `apps/chat/content/agent/identity.mdx` — hand-authored identity.
+- `apps/chat/evals/identity.eval.ts`
+- `apps/chat/evals/kg-retrieval.eval.ts`
+- `apps/chat/evals/connectivity.eval.ts`
+
+### Edited files
+
+- `apps/chat/package.json` — add `generate:agent-knowledge` script, chain into `prebuild`.
+- `apps/chat/vercel.json` — ensure `buildCommand` runs the new script.
+- `apps/chat/next.config.ts` — add `outputFileTracingIncludes` for `public/agent-knowledge.json` so it ships with the serverless function.
+- `apps/chat/lib/ai/prompts.ts` — rewrite: export `buildSystemPrompt({ session, chatId })` that assembles the 5 layers. Keep `systemPrompt()` as a deprecated thin wrapper for the transition commit only, then delete.
+- `apps/chat/lib/ai/tools/knowledge-graph.ts` — replace `searchSiteContent()` (which only path-matches Lago manifests) with a body-aware variant reading from the new JSON. Add `traverseKnowledgeTool()`.
+- `apps/chat/lib/ai/tools/tools.ts` and `tools-definitions.ts` — register `traverseKnowledge` in the tool registry and schema.
+- `apps/chat/app/(chat)/api/chat/route.ts` — `getSystemPrompt()` now calls `buildSystemPrompt({ session, chatId })` and passes through project instructions when present.
+
+### Unchanged
+
+- `apps/chat/app/(site)/page.tsx` and `components/site/landing-sections.tsx` — hero input still redirects to `/chat?q=...`.
+- `apps/chat/lib/ai/context-assembler.ts` — kept as-is for future use by other surfaces (e.g. the `/graph` page's search).
+- `apps/chat/lib/ai/vault/*.ts` — Lago + local vault backends remain as they are.
+
+## Data flow
+
+```
+Writer edits MDX
+        │
+        ▼
+  git push → Vercel build
+        │
+        ▼
+  prebuild hook
+        ├── generate-search-index.ts    → public/search-index.json
+        └── generate-agent-knowledge.ts  → public/agent-knowledge.json
+                                             │
+        ▼                                    ▼
+  next build  ───────── bundled into Node function
+        │
+        ▼
+  Deployed
+        │
+        ▼
+  User lands on /chat or submits hero input
+        │
+        ▼
+  /api/chat → buildSystemPrompt()
+        │         ├── Layer 1: readFileSync(identity.mdx)  (cold-start cached)
+        │         ├── Layer 2: getPinnedProjects / getLatest     (per request)
+        │         ├── Layer 3: static string                      (cold-start cached)
+        │         ├── Layer 4: static string                      (cold-start cached)
+        │         └── Layer 5: session-based branch              (per request)
+        │
+        ▼
+  Model receives prompt + tools
+        │
+        ▼
+  If needed, calls searchKnowledge / readKnowledgeNote / traverseKnowledge
+        │
+        ▼
+  loadAgentKnowledge() → cached parse of public/agent-knowledge.json
+```
+
+## Error handling & graceful degradation
+
+- **Missing `public/agent-knowledge.json`** (dev without prebuild): `loadAgentKnowledge()` logs a single warning and returns an empty knowledge object. Search/read/traverse tools return `{ error: "Agent knowledge not built — run 'bun run generate:agent-knowledge'." }` with suggestions to run the build.
+- **Corrupt JSON**: caught at parse; same empty-knowledge fallback, error logged once.
+- **`identity.mdx` missing**: Layer 1 falls back to a minimal inline string ("I'm Arcan, the Broomva agent runtime.") so the chat still works. Warning logged once.
+- **`VAULT_PATH` unset** (production): Layer 3 navigation text omits the "Local-only" subsection so the agent doesn't promise something it can't reach.
+- **Lago unreachable**: user-vault search returns `[]`; the site-content source still answers. Existing behavior.
+
+## Evals
+
+Three new evals in `apps/chat/evals/`, using the existing eval harness:
+
+### `identity.eval.ts`
+Scenarios:
+- "Who is Carlos?" → answer mentions AI engineer / agent architect, cites `/` or a writing post.
+- "What is Broomva?" → mentions Life Agent OS, Arcan runtime, cites at least one project URL.
+- "Who are you?" → first-person as Arcan, names the runtime lineage.
+
+### `kg-retrieval.eval.ts`
+Scenarios:
+- "Tell me about the agent-native architecture essay" → calls `readKnowledgeNote` with slug `agent-native-architecture`, answer cites `/writing/agent-native-architecture`.
+- "What prompts do you have for deep research?" → calls `searchKnowledge("deep research")`, surfaces `/prompts/deep-research-agent`.
+- "What does the ecosystem-repo-architect prompt do?" → calls `readKnowledgeNote`, correct URL in citation.
+
+### `connectivity.eval.ts`
+Scenarios:
+- "What's connected to the Life Agent OS?" → calls `traverseKnowledge` with seed `life-agent-os`, returns ≥ 3 neighbors with `hops` metadata.
+- "Show me everything tagged agent-os" → calls `traverseKnowledge` with `edgeTypes: ["tag"]`, returns all tagged docs.
+
+All three evals fail the build if accuracy drops below 80% on a fixed seed set.
+
+## Testing strategy
+
+- **Unit**: `lib/ai/knowledge/site-content.ts` — parse/search/traverse tested against a fixture JSON in `__fixtures__/`.
+- **Integration**: a single Vitest that runs `generate-agent-knowledge.ts` against the real `content/` directory and asserts minimum document counts per kind.
+- **Eval**: the three files above, run in CI via the existing eval command.
+- **Manual smoke test**: start the app locally, open `/chat`, ask "What is Broomva?" — answer must include a pinned project URL, no hallucinations.
+
+## Rollout
+
+- Ship behind no flag. The new prompt is strictly additive (more grounding, same tools + one new tool). If the new build script fails, next build fails — no silent degradation.
+- First deploy: merge, verify `public/agent-knowledge.json` lands in the built artifact, verify evals pass in CI, verify "What is Broomva?" cites a URL on production.
+- Rollback: revert the commit; `systemPrompt()` wrapper (kept for one commit) guards the transition.
+
+## Open questions
+
+None at spec time. The `traverseKnowledge` tool is optional — if implementation pressure requires cutting scope, it can be moved to a follow-up PR without blocking the primary goal (identity + retrieval).
+
+## Follow-ups (out of scope for this spec)
+
+- Bridge `~/broomva/research/entities/` (the Knowledge Graph "Layer 3" from CLAUDE.md — permanent entity pages, not to be confused with this spec's "Layer 3" of the *system prompt*) into the agent via a committed snapshot step in `generate-agent-knowledge.ts`. Needs a cross-repo strategy.
+- Add an `/api/agent-knowledge` debug endpoint that returns the loaded JSON (gated to authenticated admin users) for inspection.
+- Consider chunk-embedding bodies and switching `searchKnowledge` to vector similarity once the corpus grows past ~500 documents.
+- Broaden to other agents (Moltie for content, Haima for finance) once the Arcan pattern is proven.


### PR DESCRIPTION
## Summary

Ports the **Life Interface** prototype from Claude Design into a real Next.js route group at `apps/chat/app/(site)/life/`. Adds `/life` (project landing) and `/life/[project]` (three-column agent workspace) with two seeded projects: **sentinel** and **materiales**.

The workspace recreates the prototype faithfully:

- **Left** — Streaming Arcan chat: collapsible thinking blocks, inline tool-call cards with status caret + cross-link highlight, agent-status stripe, composer with model/tools/ctx footer.
- **Middle** (5 tabs) — Files (live workspace tree with shimmer/pulse fs feel), Journal (Lago event stream, compact + rich variants), Timeline (human-readable narrative), Graph (SVG knowledge graph with fresh-edge glow), Spaces (peer cards).
- **Right** (6 tabs) — Preview (diff renderer), Vigil (progressive OTel span timeline + GenAI gauges), Nous (composite + per-axis judges), Autonomic (three-pillar arcs + setpoints), Haima (x402 budget + tokens/wallet), Anima (identity, beliefs, trust vector).
- **Top bar** — Anima badge + breadcrumb + scenario chips (Refactor / Ingest / Research) + play-pause + classic↔experimental toggle.
- **Dock** — 5 daemon status dots + live event/tool counters.
- **Tweaks panel** — 7 segmented controls + 2 switches; ⌘. (or Ctrl+.) toggles. Persisted to `localStorage` under `life.tweaks.v1`.
- **Experimental layout** — 4-pane glass canvas with the "filesystem constellation" SVG hero (fs ops orbit 5 module hubs).
- All driven by a typed **replay clock** (`useReplay`, `requestAnimationFrame`, SSR-safe) that walks a typed `ReplayEvent[]` per scenario.

## Files

```
apps/chat/app/(site)/life/
├── layout.tsx                      // imports life-styles.css
├── page.tsx                        // landing grid: sentinel + materiales
├── not-found.tsx
├── life-styles.css                 // scoped under .life-shell-root
├── [project]/
│   ├── page.tsx                    // resolves slug → LifeShell
│   └── not-found.tsx
├── _components/                    // 17 client components
│   ├── LifeShell.tsx               // root, owns tweaks + replay state
│   ├── Topbar.tsx · Dock.tsx · TweaksPanel.tsx · AnimaPopover.tsx
│   ├── ChatColumn.tsx · ChatMessage.tsx · ChatComposer.tsx
│   │   · ThinkingBlock.tsx · ToolCallBlock.tsx · AgentStatus.tsx
│   ├── MiddleColumn.tsx · FileTree.tsx · Journal.tsx · Timeline.tsx
│   │   · KnowledgeGraph.tsx · Peers.tsx
│   ├── RightColumn.tsx · PreviewPane.tsx · VigilPane.tsx
│   │   · NousPane.tsx · AutonomicPane.tsx · HaimaPane.tsx · AnimaPane.tsx
│   └── ExperimentalCanvas.tsx · Constellation.tsx
└── _lib/
    ├── types.ts                    // ReplayEvent / ReplayState / TweaksState etc.
    ├── scenarios.ts                // refactor / ingest / research scripts
    ├── mock-workspace.ts           // LIFE_FS · LIFE_TRACES · LIFE_HOMEO · …
    ├── project-map.ts              // slug → scenario + display name
    ├── tweaks.ts                   // localStorage persistence + defaults
    └── use-replay.ts               // RAF replay clock (client-only)
```

Plus:
- `apps/chat/proxy.ts` — adds `/life` to `PUBLIC_PAGE_PREFIXES` so the demo is reachable without auth.

## Conversion notes

- Tokens: zero re-declaration — every `--ag-*` already exists in `apps/chat/app/globals.css`. Only the prototype's app-shell primitives ported, scoped under a single `.life-shell-root` class to prevent leaks.
- Sandbox coupling stripped: prototype's `window.parent.postMessage(__edit_mode_*)` and `document.body.dataset.orbs` replaced with localStorage + a `data-` attribute on the shell root.
- `useReplay` is `"use client"` and guards `typeof window`/`performance` so SSR is safe.
- `renderMarkdownLite` keeps `dangerouslySetInnerHTML` with a TODO to swap for `streamdown` (already in `apps/chat/package.json`).
- Mock data is the **only** data source — no SSE/HTTP yet. Phase B unblocks real wiring.

## Validation

- `bun run test:types` (chat) — clean (next typegen + tsc --noEmit).
- `bunx next build` (chat) — succeeded; routes registered:
  ```
  ○ /life
  ◐ /life/[project]
   ├ /life/sentinel
   └ /life/materiales
  ```
- `bunx biome lint app/(site)/life/` — 0 errors, 14 warnings (all pre-existing-style: `useExhaustiveDependencies`, `noArrayIndexKey`, `useSemanticElements` on click handlers — kept divs for the prototype's CSS hooks). Repo-wide: 56 → 54 errors after this PR (we fixed 2 we introduced; remaining 54 are pre-existing on other files).
- `bunx next dev --port 3399`:
  - `/life` → 200, "Life · Agent Workspace" landing renders with both project cards.
  - `/life/sentinel` → 200, "Sentinel — property-ops WO audit", three-column shell mounts; replays the refactor scenario; tabs switch; Tweaks panel opens.
  - `/life/materiales` → 200, "Materiales Intel — precio unitario en vivo", research scenario.
  - `/life/nonsense-slug` → renders "Project not found" notFound page.
  - No console errors, no hydration warnings, no SSR errors in dev log (only pre-existing Sentry deprecation notices).

## Visual notes / known port debt

- `renderMarkdownLite` uses `dangerouslySetInnerHTML` (kept the prototype's tiny inline renderer because it ships trusted mock strings). Should swap to `streamdown` in a follow-up.
- Tab buttons show no underline indicator yet — prototype matched.
- `useExhaustiveDependencies` warnings on the replay clock and a couple of effects are intentional — re-running on those deps would loop the RAF clock or reset persisted tweaks.

## Follow-ups (NOT in this PR)

### Phase B — real streaming
- Swap `useReplay` for a real SSE client hitting `/api/life/run/[project]`.
- Implement that API route in a separate PR importing from `@broomva/life-modules-core`. The life-modules packages currently live at `~/broomva/packages/life-modules/` — they're **not yet copied into `broomva.tech/packages/`**. Carlos: this is the unblocking step for wiring real agent execution.
- Drop the `mock` pill and "v0.9.2" placeholder in the dock.

### Phase C — user-created projects + auth + billing
- `/life/new` wizard, rules-package editor.
- Authed `/console/life` dashboard for tenant admins.
- Credit quotas mirroring `apps/chat/lib/utils/rate-limit.ts` + `config.anonymous`.
- Stripe billing for Pro tier.

### Documentation debt
- `renderMarkdownLite` → `streamdown` (already a dep).
- Linear ticket BRO-XXX to be filed by Carlos post-PR; this PR's commits reference the placeholder.

## Test plan

- [ ] Pull branch + `bun install` clean.
- [ ] Visit `/life` — confirm both seed cards render with hover-glow.
- [ ] Visit `/life/sentinel` — confirm three-column shell, refactor scenario auto-plays, tools cross-link to journal rows when clicked.
- [ ] Click the ⚙ button (bottom-right) — confirm Tweaks panel opens.
- [ ] Toggle layout to Experimental — confirm Constellation SVG renders + journal/inspector glass cards mount.
- [ ] Switch scenario in tweaks to "Ingest" — confirm clock restarts, fs ops fan into the constellation/file tree.
- [ ] Visit `/life/materiales` — confirm research scenario plays with autonomic + haima events appearing in journal.
- [ ] Visit `/life/nonsense-slug` — confirm "Project not found" page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Life" section showcasing interactive AI agent workflow demonstrations with replay functionality
  * Included visualization tools for agent thinking, file operations, tool execution, and knowledge graphs
  * Added project-based demos with configurable scenarios and real-time metrics

* **Documentation**
  * Added implementation plan and specification for system prompt and knowledge graph grounding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->