### PR TITLE
feat(life): Phase 2 — DB schema + SSE runner + live streaming on /life/sentinel (BRO-846)

### DIFF
--- a/apps/chat/app/(site)/life/[project]/page.tsx
+++ b/apps/chat/app/(site)/life/[project]/page.tsx
@@ -36,6 +36,7 @@ export default async function LifeProjectPage({
       scenarioId={info.scenarioId}
       displayName={info.displayName}
       eyebrow={info.eyebrow}
+      liveStream={info.liveStream}
     />
   );
 }

--- a/apps/chat/app/(site)/life/_components/LifeShell.tsx
+++ b/apps/chat/app/(site)/life/_components/LifeShell.tsx
@@ -9,6 +9,7 @@ import {
 } from "../_lib/tweaks";
 import type { ScenarioId, TweaksState } from "../_lib/types";
 import { useReplay } from "../_lib/use-replay";
+import { useLiveRun } from "../_lib/use-live-run";
 import { AnimaPopover } from "./AnimaPopover";
 import { ChatColumn } from "./ChatColumn";
 import { Dock } from "./Dock";
@@ -23,6 +24,13 @@ interface Props {
   scenarioId: ScenarioId;
   displayName: string;
   eyebrow: string;
+  /**
+   * When true, the shell reads events from /api/life/run/<slug> over SSE
+   * instead of replaying the local scenario clock. Phase 2 enables it for
+   * Sentinel; Materiales stays on local replay until the live pipeline with
+   * web_search lands in a follow-up PR.
+   */
+  liveStream?: boolean;
 }
 
 function usePersistedTweaks(initialScenario: ScenarioId): {
@@ -61,6 +69,7 @@ export function LifeShell({
   scenarioId,
   displayName,
   eyebrow,
+  liveStream = false,
 }: Props) {
   const { tweaks, setTweaks } = usePersistedTweaks(scenarioId);
   const [tweaksOpen, setTweaksOpen] = useState(false);
@@ -77,7 +86,25 @@ export function LifeShell({
     setPlaying(tweaks.autoplay);
   }, [tweaks.scenario, tweaks.autoplay]);
 
-  const [state, setState] = useReplay(script, playing);
+  // Replay state (local scenario clock) — used when liveStream is false OR
+  // when the user has paused / switched scenarios in the Tweaks panel.
+  const [replayState, setReplayState] = useReplay(script, playing && !liveStream);
+
+  // Live SSE state — used only when the project is wired for live streaming
+  // AND the user hasn't overridden the scenario via Tweaks. If they do, we
+  // fall back to the local replay clock so the Tweaks panel keeps working.
+  const liveEnabled =
+    liveStream && playing && tweaks.scenario === scenarioId;
+  const [liveState, setLiveState, liveMeta] = useLiveRun({
+    projectSlug,
+    enabled: liveEnabled,
+  });
+
+  // The downstream UI is agnostic to which source drove state — it only
+  // reads { state, setState }.
+  const state = liveEnabled ? liveState : replayState;
+  const setState = liveEnabled ? setLiveState : setReplayState;
+  void liveMeta; // status surface wires into the agent-status stripe in a follow-up
 
   // Cross-link highlight between chat tool calls and journal rows.
   const [toolHighlight, setToolHighlight] = useState<string | null>(null);

--- a/apps/chat/app/(site)/life/_lib/project-map.ts
+++ b/apps/chat/app/(site)/life/_lib/project-map.ts
@@ -11,6 +11,13 @@ export interface LifeProjectInfo {
   displayName: string;
   eyebrow: string;
   chipColor: ProjectChipColor;
+  /**
+   * When true, the shell hits /api/life/run/<slug> over SSE instead of
+   * running the in-browser scenario replay clock. Phase 2 flips this on for
+   * Sentinel (mock-replay server-side — no Claude cost); Materiales stays
+   * client-replay until the OAuth shim migration lands in the next PR.
+   */
+  liveStream: boolean;
 }
 
 export const PROJECTS: Record<string, LifeProjectInfo> = {
@@ -19,12 +26,14 @@ export const PROJECTS: Record<string, LifeProjectInfo> = {
     displayName: "Sentinel — property-ops WO audit",
     eyebrow: "sentinel-property-ops · exclusive-rentals",
     chipColor: "emerald",
+    liveStream: true,
   },
   materiales: {
     scenarioId: "research",
     displayName: "Materiales Intel — precio unitario en vivo",
     eyebrow: "materiales-intel · _pending-constructora",
     chipColor: "amber",
+    liveStream: false,
   },
 };
 

--- a/apps/chat/app/(site)/life/_lib/use-live-run.ts
+++ b/apps/chat/app/(site)/life/_lib/use-live-run.ts
@@ -1,0 +1,242 @@
+// Live-run hook — drives the Life Interface UI from a real SSE stream
+// coming out of /api/life/run/[project]. Returns the same [state, setState]
+// tuple as useReplay, so LifeShell can swap between mock and live modes
+// with zero downstream component change.
+//
+// Protocol: each SSE message is { type, payload, at }. Mapped back to
+// ReplayEvent shape and folded via applyReplayEvent so the reducer logic
+// lives in exactly one place.
+
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { ReplayEvent, ReplayState } from "./types";
+import { EMPTY_REPLAY_STATE, applyReplayEvent } from "./use-replay";
+
+// ---------------------------------------------------------------------------
+// Wire-format event emitted by the server (runner-dispatch.ts)
+// ---------------------------------------------------------------------------
+
+interface ServerEvent {
+  type: string;
+  payload: Record<string, unknown>;
+  at: string;
+}
+
+/**
+ * Translate a server RunEvent to the client's ReplayEvent shape so
+ * applyReplayEvent can fold it into state. `t` is synthesized from the
+ * wall-clock stream time so the UI's timeline label stays monotonic.
+ */
+function toReplayEvent(server: ServerEvent, t: number): ReplayEvent | null {
+  const p = server.payload as Record<string, unknown>;
+  switch (server.type) {
+    case "thinking_start":
+      return { t, kind: "agent-thinking-start", id: String(p.id) };
+    case "thinking_delta":
+      return {
+        t,
+        kind: "thinking",
+        id: String(p.id),
+        text: String(p.text ?? ""),
+      };
+    case "thinking_end":
+      return { t, kind: "agent-thinking-end", id: String(p.id) };
+    case "text_start": {
+      const role = p.role === "user" ? "user" : "agent";
+      if (role === "user") {
+        return { t, kind: "user", text: String(p.text ?? "") };
+      }
+      return {
+        t,
+        kind: "agent-text-start",
+        id: String(p.id),
+        text: String(p.text ?? ""),
+      };
+    }
+    case "text_delta":
+      return {
+        t,
+        kind: "agent-text-append",
+        id: String(p.id),
+        text: String(p.text ?? ""),
+      };
+    case "tool_call":
+      return {
+        t,
+        kind: "tool-call",
+        id: String(p.id),
+        name: String(p.name ?? "unknown"),
+        target: String(p.target ?? ""),
+        args: String(p.args ?? ""),
+        journalKind: (p.journalKind as "tool" | "fs" | "llm" | "nous" | "autonomic" | "haima" | undefined) ?? "tool",
+      };
+    case "tool_result":
+      return {
+        t,
+        kind: "tool-result",
+        id: String(p.id),
+        result: String(p.result ?? ""),
+      };
+    case "fs_op":
+      return {
+        t,
+        kind: "fs-op",
+        path: String(p.path ?? ""),
+        op: (p.op as "read" | "write" | "create" | "delete") ?? "read",
+      };
+    case "nous_score":
+      return {
+        t,
+        kind: "nous-score",
+        score: Number(p.score ?? 0),
+        band: (p.band as "good" | "warn") ?? "good",
+        note: String(p.note ?? ""),
+      };
+    case "autonomic_event":
+      return {
+        t,
+        kind: "autonomic-event",
+        pillar: (p.pillar as "operational" | "cognitive" | "economic") ?? "operational",
+        text: String(p.text ?? ""),
+      };
+    // These are control events — they don't fold into state.
+    case "run_started":
+    case "run_metadata":
+    case "done":
+    case "error":
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export type LiveRunHookResult = [
+  ReplayState,
+  Dispatch<SetStateAction<ReplayState>>,
+  { status: "idle" | "streaming" | "succeeded" | "failed"; error?: string },
+];
+
+export interface UseLiveRunOptions {
+  /** URL slug of the project to run (matches LifeProject.slug). */
+  projectSlug: string;
+  /**
+   * Turn the live run on/off. On transition to false mid-stream, the hook
+   * cancels the reader so no further events apply.
+   */
+  enabled: boolean;
+  /** Optional input payload sent in the POST body. */
+  input?: unknown;
+}
+
+/**
+ * Reads Server-Sent Events from /api/life/run/[project] and folds them into
+ * a ReplayState. Drop-in replacement for useReplay in terms of state shape.
+ */
+export function useLiveRun({
+  projectSlug,
+  enabled,
+  input,
+}: UseLiveRunOptions): LiveRunHookResult {
+  const [state, setState] = useState<ReplayState>(EMPTY_REPLAY_STATE);
+  const [status, setStatus] = useState<"idle" | "streaming" | "succeeded" | "failed">(
+    "idle",
+  );
+  const [error, setError] = useState<string | undefined>(undefined);
+  const abortRef = useRef<AbortController | null>(null);
+  const startTsRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      return;
+    }
+    if (typeof window === "undefined") return;
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setState(EMPTY_REPLAY_STATE);
+    setStatus("streaming");
+    setError(undefined);
+    startTsRef.current = performance.now();
+
+    (async () => {
+      try {
+        const resp = await fetch(`/api/life/run/${projectSlug}`, {
+          method: "POST",
+          signal: controller.signal,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ input: input ?? null }),
+        });
+        if (!resp.ok || !resp.body) {
+          // 402 Payment Required from the server lands here for paid projects;
+          // surface the quote to callers via the error message for now.
+          const body = await resp.text().catch(() => "");
+          const msg = `HTTP ${resp.status}: ${body.slice(0, 200)}`;
+          setStatus("failed");
+          setError(msg);
+          return;
+        }
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          // SSE events are delimited by a blank line.
+          const frames = buf.split("\n\n");
+          buf = frames.pop() ?? "";
+          for (const frame of frames) {
+            const lines = frame.split("\n").filter(Boolean);
+            const dataLines = lines
+              .filter((l) => l.startsWith("data:"))
+              .map((l) => l.slice(5).trimStart());
+            if (dataLines.length === 0) continue;
+            const json = dataLines.join("");
+            let ev: ServerEvent;
+            try {
+              ev = JSON.parse(json) as ServerEvent;
+            } catch {
+              continue;
+            }
+            const elapsed = performance.now() - startTsRef.current;
+            const replayEv = toReplayEvent(ev, elapsed);
+            if (replayEv) {
+              setState((prev) => applyReplayEvent({ ...prev, t: elapsed }, replayEv));
+            } else if (ev.type === "done") {
+              setStatus("succeeded");
+            } else if (ev.type === "error") {
+              setStatus("failed");
+              setError(String(ev.payload?.message ?? "unknown error"));
+            } else {
+              // Non-folding control events (run_metadata, run_started) still
+              // update elapsed time so the timeline moves.
+              setState((prev) => ({ ...prev, t: elapsed }));
+            }
+          }
+        }
+
+        if (status === "streaming") setStatus("succeeded");
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        setStatus("failed");
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+
+    return () => controller.abort();
+    // `input` is deliberately excluded — changing inputs mid-stream is not a
+    // supported use case for the current UI (single run per project).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, projectSlug]);
+
+  return [state, setState, { status, error }];
+}

--- a/apps/chat/app/(site)/life/_lib/use-replay.ts
+++ b/apps/chat/app/(site)/life/_lib/use-replay.ts
@@ -14,7 +14,7 @@ import type {
   ReplayState,
 } from "./types";
 
-const EMPTY_STATE: ReplayState = {
+export const EMPTY_REPLAY_STATE: ReplayState = {
   messages: [],
   fsOps: [],
   journal: [],
@@ -22,6 +22,9 @@ const EMPTY_STATE: ReplayState = {
   autonomic: [],
   t: 0,
 };
+
+// Back-compat alias (keep EMPTY_STATE used by the hook body below).
+const EMPTY_STATE = EMPTY_REPLAY_STATE;
 
 function formatTime(ms: number): string {
   const total = Math.floor(ms / 1000);
@@ -31,7 +34,7 @@ function formatTime(ms: number): string {
   return `${m}:${s}.${mm}`;
 }
 
-function applyEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
+export function applyReplayEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
   const nowIso = formatTime(ev.t);
   switch (ev.kind) {
     case "user": {
@@ -270,7 +273,7 @@ export function useReplay(
           script[idxRef.current]!.t <= elapsed
         ) {
           const ev = script[idxRef.current++]!;
-          next = applyEvent(next, ev);
+          next = applyReplayEvent(next, ev);
           didUpdate = true;
         }
         return didUpdate || next.t !== s.t ? next : s;

--- a/apps/chat/app/api/life/run/[project]/route.ts
+++ b/apps/chat/app/api/life/run/[project]/route.ts
@@ -1,0 +1,269 @@
+/**
+ * POST /api/life/run/[project]
+ *
+ * Executes a Life project and streams the result as Server-Sent Events.
+ * Every event is persisted to LifeRunEvent so the run is replayable.
+ *
+ * Billing contract (BRO-846 / refined commercial model):
+ *   • Authed user        → credits debit via @/lib/db/credits (subscription)
+ *   • Anon on free pub   → free_tier (existing anon-session quota)
+ *   • Anon on paid pub   → 402 Payment Required with x402 quote in body
+ *   • Authed + BYOK      → byok mode, bypasses LLM cost (platform fee stays)
+ *   • Paid pub + authed  → haima_balance (settlement wiring lands in follow-up)
+ *
+ * Phase 2 scope (this PR):
+ *   • Full billing decision + LifeRun row + event persistence
+ *   • Scenario-replay runner (zero Claude cost)
+ *   • 402 Payment Required response for x402 callers (scaffold body)
+ * Phase 2.1 (next PR):
+ *   • Real Sentinel runner through @broomva/sentinel-property-ops
+ *   • Haima / x402 settlement wiring
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { headers } from "next/headers";
+
+import { getSafeSession } from "@/lib/auth";
+import { getAnonymousSession } from "@/lib/anonymous-session-server";
+import {
+  appendRunEvent,
+  bumpProjectStats,
+  createRun,
+  finishRun,
+  getCurrentRulesVersion,
+  getProjectBySlug,
+} from "@/lib/life-runtime/queries";
+import {
+  pickPaymentMode,
+  settleCreditsDebit,
+  userHasCreditsFor,
+} from "@/lib/life-runtime/billing";
+import { getRunner } from "@/lib/life-runtime/runner-dispatch";
+import { RunRequestSchema, type ConsumerIdentity } from "@/lib/life-runtime/types";
+
+// nextConfig.cacheComponents blocks the usual `export const runtime` pattern.
+// Dynamism comes from the POST handler + SSE body, which Next infers
+// automatically without explicit hints.
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonError(
+  status: number,
+  message: string,
+  extra: Record<string, unknown> = {},
+) {
+  return NextResponse.json({ error: message, ...extra }, { status });
+}
+
+function sseHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no", // hint to nginx / Vercel to NOT buffer
+  };
+}
+
+function sseFormat(event: { type: string; payload: unknown; at?: string }): string {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+/** Resolve who is calling this endpoint. */
+async function resolveConsumer(): Promise<ConsumerIdentity | null> {
+  const hdrs = await headers();
+
+  // Authed Neon/Better-Auth session → user identity + optional org.
+  const session = await getSafeSession({ fetchOptions: { headers: hdrs } });
+  if (session?.user?.id) {
+    return {
+      kind: "user",
+      id: session.user.id,
+      // Org context is discovered via the tenant package in a follow-up PR;
+      // keeping it undefined here routes authed users to credits-debit path.
+    };
+  }
+
+  // Anon session (cookie-based) — existing chat infra.
+  const anon = await getAnonymousSession();
+  if (anon) return { kind: "anon", id: anon.id };
+
+  // Presence of X-PAYMENT (x402) header → machine consumer.
+  if (hdrs.get("x-payment") || hdrs.get("authorization")?.startsWith("x402 ")) {
+    return { kind: "agent", id: hdrs.get("x-payment-sender") ?? "unknown-wallet" };
+  }
+
+  return null; // Fall through to anon-by-default below in the route.
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+const ParamsSchema = z.object({ project: z.string().min(1).max(128) });
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ project: string }> },
+) {
+  const resolvedParams = await params;
+  const parsedParams = ParamsSchema.safeParse(resolvedParams);
+  if (!parsedParams.success) {
+    return jsonError(400, "Invalid project slug.");
+  }
+  const { project: slug } = parsedParams.data;
+
+  // 1. Load project
+  const project = await getProjectBySlug(slug);
+  if (!project) return jsonError(404, "Project not found.");
+  if (project.status !== "active") {
+    return jsonError(403, `Project is ${project.status}.`);
+  }
+
+  // 2. Resolve consumer (fall back to anon-by-default for public projects)
+  let consumer = await resolveConsumer();
+  if (!consumer) {
+    // Read-only public access: treat as ephemeral agent-without-payment.
+    // The billing decision below will route to x402 for paid projects.
+    consumer = { kind: "agent", id: "anonymous" };
+  }
+
+  // 3. Parse body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const parsedBody = RunRequestSchema.safeParse(body);
+  if (!parsedBody.success) {
+    return jsonError(400, "Invalid body.", { issues: parsedBody.error.issues });
+  }
+  const { input = null, byokKeyId } = parsedBody.data;
+
+  // 4. Billing decision
+  const decision = pickPaymentMode({ project, consumer, byokKeyId });
+
+  // 402 fast-path for external callers on paid projects
+  if (decision.mode === "x402") {
+    return NextResponse.json(
+      {
+        error: "Payment Required",
+        quote: decision.paymentQuote,
+        retryWithHeader: "X-PAYMENT",
+        projectSlug: slug,
+      },
+      {
+        status: 402,
+        headers: { "WWW-Authenticate": `x402 nonce="${decision.paymentQuote?.nonce}"` },
+      },
+    );
+  }
+
+  // Credits pre-flight for authed users on their own projects
+  if (decision.mode === "credits" && consumer.kind === "user") {
+    const ok = await userHasCreditsFor(consumer.id, decision.quotedCents);
+    if (!ok) {
+      return jsonError(402, "Insufficient credits.", {
+        quotedCents: decision.quotedCents,
+        rationale: decision.rationale,
+      });
+    }
+  }
+
+  // 5. Create run row
+  const rulesVersion = await getCurrentRulesVersion(project);
+  const run = await createRun({
+    projectId: project.id,
+    rulesVersionId: rulesVersion?.id ?? null,
+    consumerKind: consumer.kind,
+    consumerId: consumer.id,
+    organizationId: consumer.organizationId,
+    input,
+    paymentMode: decision.mode,
+  });
+
+  // 6. Dispatch runner; stream over SSE.
+  const runner = getRunner(project.moduleTypeId);
+  let finalCostCents = 0;
+  let model: string | undefined;
+  let provider: string | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const enc = new TextEncoder();
+      let seq = 0;
+
+      const emit = async (event: { type: string; payload: unknown; at?: string }) => {
+        const at = event.at ?? new Date().toISOString();
+        const frame = sseFormat({ ...event, at });
+        controller.enqueue(enc.encode(frame));
+        await appendRunEvent(run.id, seq++, event.type, {
+          ...(event.payload as Record<string, unknown>),
+          at,
+        });
+      };
+
+      try {
+        // Emit run metadata up-front so the UI can render project chrome
+        // before the first agent event lands.
+        await emit({
+          type: "run_metadata",
+          payload: {
+            runId: run.id,
+            projectSlug: slug,
+            moduleTypeId: project.moduleTypeId,
+            paymentMode: decision.mode,
+            quotedCents: decision.quotedCents,
+            displayName: project.displayName,
+          },
+        });
+
+        for await (const ev of runner.run({
+          projectSlug: slug,
+          moduleTypeId: project.moduleTypeId,
+          input,
+          maxCostCents: decision.maxCostCents,
+          onFinish: (cost) => {
+            finalCostCents = cost.llmCents;
+            model = cost.model;
+            provider = cost.provider;
+          },
+        })) {
+          await emit(ev);
+        }
+
+        await finishRun({
+          runId: run.id,
+          status: "succeeded",
+          llmCostCents: finalCostCents,
+          consumerPaidCents: decision.quotedCents,
+          model,
+          provider,
+        });
+        if (decision.mode === "credits" && consumer.kind === "user") {
+          await settleCreditsDebit({
+            userId: consumer.id,
+            mode: decision.mode,
+            amountCents: decision.quotedCents,
+          });
+        }
+        await bumpProjectStats(project.id, finalCostCents);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        await emit({ type: "error", payload: { message: msg } });
+        await finishRun({
+          runId: run.id,
+          status: "failed",
+          errorReason: msg,
+        });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, { headers: sseHeaders() });
+}

--- a/apps/chat/lib/db/migrations/0059_quiet_lenny_balinger.sql
+++ b/apps/chat/lib/db/migrations/0059_quiet_lenny_balinger.sql
@@ -1,0 +1,118 @@
+CREATE TABLE "LifeByokKey" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"ownerKind" varchar(16) NOT NULL,
+	"ownerId" varchar(256) NOT NULL,
+	"provider" varchar(32) NOT NULL,
+	"label" varchar(128) NOT NULL,
+	"encryptedPayload" text NOT NULL,
+	"keyHint" varchar(16),
+	"scope" varchar(32) DEFAULT 'internal' NOT NULL,
+	"status" varchar(32) DEFAULT 'active' NOT NULL,
+	"lastUsedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "LifeModuleType" (
+	"id" varchar(128) PRIMARY KEY NOT NULL,
+	"version" varchar(32) NOT NULL,
+	"displayName" varchar(256) NOT NULL,
+	"description" text,
+	"runnerRef" varchar(128) NOT NULL,
+	"inputSchema" json NOT NULL,
+	"outputSchema" json NOT NULL,
+	"requiredTools" json DEFAULT '[]'::jsonb NOT NULL,
+	"defaultUi" varchar(128) DEFAULT 'life-interface-classic' NOT NULL,
+	"costEstimateCents" json DEFAULT '{"avg":10,"p95":30}'::jsonb NOT NULL,
+	"status" varchar(32) DEFAULT 'active' NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "LifeProject" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" varchar(128) NOT NULL,
+	"displayName" varchar(256) NOT NULL,
+	"description" text,
+	"ownerKind" varchar(16) NOT NULL,
+	"ownerId" varchar(256) NOT NULL,
+	"moduleTypeId" varchar(128) NOT NULL,
+	"currentRulesVersionId" uuid,
+	"visibility" varchar(32) DEFAULT 'private' NOT NULL,
+	"pricing" json,
+	"secretsMode" varchar(32) DEFAULT 'platform' NOT NULL,
+	"status" varchar(32) DEFAULT 'draft' NOT NULL,
+	"safetyFlags" json DEFAULT '{}'::jsonb NOT NULL,
+	"stats" json DEFAULT '{}'::jsonb NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "LifeProject_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "LifeReservedSlug" (
+	"slug" varchar(64) PRIMARY KEY NOT NULL,
+	"reason" varchar(128) DEFAULT 'platform-reserved' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "LifeRulesVersion" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"projectId" uuid NOT NULL,
+	"rulesJson" json NOT NULL,
+	"semver" varchar(32) NOT NULL,
+	"parentId" uuid,
+	"createdByUserId" text,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "LifeRun" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"projectId" uuid NOT NULL,
+	"rulesVersionId" uuid NOT NULL,
+	"consumerKind" varchar(16) NOT NULL,
+	"consumerId" varchar(256) NOT NULL,
+	"organizationId" uuid,
+	"input" json NOT NULL,
+	"output" json,
+	"status" varchar(32) DEFAULT 'queued' NOT NULL,
+	"errorReason" text,
+	"llmCostCents" integer DEFAULT 0 NOT NULL,
+	"platformFeeCents" integer DEFAULT 0 NOT NULL,
+	"creatorFeeCents" integer DEFAULT 0 NOT NULL,
+	"consumerPaidCents" integer DEFAULT 0 NOT NULL,
+	"paymentMode" varchar(32) DEFAULT 'credits' NOT NULL,
+	"paymentRail" varchar(32),
+	"paymentTxId" varchar(256),
+	"model" varchar(128),
+	"provider" varchar(32),
+	"byokKeyId" uuid,
+	"startedAt" timestamp,
+	"finishedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "LifeRunEvent" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "LifeRunEvent_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"runId" uuid NOT NULL,
+	"seq" integer NOT NULL,
+	"type" varchar(64) NOT NULL,
+	"payload" json DEFAULT '{}'::jsonb NOT NULL,
+	"at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "LifeProject" ADD CONSTRAINT "LifeProject_moduleTypeId_LifeModuleType_id_fk" FOREIGN KEY ("moduleTypeId") REFERENCES "public"."LifeModuleType"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRulesVersion" ADD CONSTRAINT "LifeRulesVersion_projectId_LifeProject_id_fk" FOREIGN KEY ("projectId") REFERENCES "public"."LifeProject"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRulesVersion" ADD CONSTRAINT "LifeRulesVersion_parentId_fk" FOREIGN KEY ("parentId") REFERENCES "public"."LifeRulesVersion"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRun" ADD CONSTRAINT "LifeRun_projectId_LifeProject_id_fk" FOREIGN KEY ("projectId") REFERENCES "public"."LifeProject"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRun" ADD CONSTRAINT "LifeRun_rulesVersionId_LifeRulesVersion_id_fk" FOREIGN KEY ("rulesVersionId") REFERENCES "public"."LifeRulesVersion"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRun" ADD CONSTRAINT "LifeRun_organizationId_Organization_id_fk" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRun" ADD CONSTRAINT "LifeRun_byokKeyId_LifeByokKey_id_fk" FOREIGN KEY ("byokKeyId") REFERENCES "public"."LifeByokKey"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "LifeRunEvent" ADD CONSTRAINT "LifeRunEvent_runId_LifeRun_id_fk" FOREIGN KEY ("runId") REFERENCES "public"."LifeRun"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "LifeByokKey_owner_idx" ON "LifeByokKey" USING btree ("ownerKind","ownerId","status");--> statement-breakpoint
+CREATE INDEX "LifeProject_owner_idx" ON "LifeProject" USING btree ("ownerKind","ownerId");--> statement-breakpoint
+CREATE INDEX "LifeProject_visibility_idx" ON "LifeProject" USING btree ("visibility","status");--> statement-breakpoint
+CREATE INDEX "LifeProject_module_idx" ON "LifeProject" USING btree ("moduleTypeId");--> statement-breakpoint
+CREATE INDEX "LifeRulesVersion_project_idx" ON "LifeRulesVersion" USING btree ("projectId","createdAt");--> statement-breakpoint
+CREATE INDEX "LifeRun_project_idx" ON "LifeRun" USING btree ("projectId","createdAt");--> statement-breakpoint
+CREATE INDEX "LifeRun_consumer_idx" ON "LifeRun" USING btree ("consumerKind","consumerId");--> statement-breakpoint
+CREATE INDEX "LifeRun_status_idx" ON "LifeRun" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "LifeRun_org_idx" ON "LifeRun" USING btree ("organizationId");--> statement-breakpoint
+CREATE UNIQUE INDEX "LifeRunEvent_run_seq_uq" ON "LifeRunEvent" USING btree ("runId","seq");

--- a/apps/chat/lib/db/migrations/0060_seed_life_runtime.sql
+++ b/apps/chat/lib/db/migrations/0060_seed_life_runtime.sql
@@ -1,0 +1,98 @@
+-- BRO-846: Seed the Life Runtime platform — reserved slugs, module types,
+-- and Broomva-owned Sentinel/Materiales projects at /life/sentinel + /life/materiales.
+
+-- ---------------------------------------------------------------------------
+-- Reserved slugs (platform routes that cannot be claimed as project slugs)
+-- ---------------------------------------------------------------------------
+INSERT INTO "LifeReservedSlug" ("slug", "reason") VALUES
+  ('new',       'wizard-route'),
+  ('templates', 'gallery-route'),
+  ('pricing',   'marketing'),
+  ('docs',      'docs-route'),
+  ('help',      'support'),
+  ('admin',     'platform'),
+  ('api',       'api'),
+  ('settings',  'account'),
+  ('account',   'account'),
+  ('login',     'auth'),
+  ('signup',    'auth'),
+  ('logout',    'auth'),
+  ('search',    'discovery'),
+  ('explore',   'discovery'),
+  ('featured',  'discovery')
+ON CONFLICT DO NOTHING;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Module types (runner registry)
+-- ---------------------------------------------------------------------------
+INSERT INTO "LifeModuleType"
+  ("id", "version", "displayName", "description", "runnerRef",
+   "inputSchema", "outputSchema", "requiredTools", "costEstimateCents")
+VALUES
+  (
+    'sentinel-property-ops',
+    '1.0.0',
+    'Sentinel — property-ops audit',
+    'Work-order audit agent: detects duplicates, weak closures, follow-up risk, missing evidence.',
+    '@broomva/sentinel-property-ops',
+    '{"type":"object","required":["workOrders"],"properties":{"workOrders":{"type":"array","items":{"type":"object"}}}}'::jsonb,
+    '{"type":"object","required":["alerts","summary"],"properties":{"alerts":{"type":"array"},"summary":{"type":"object"}}}'::jsonb,
+    '[]'::jsonb,
+    '{"avg":15,"p95":40}'::jsonb
+  ),
+  (
+    'materiales-intel',
+    '1.0.0',
+    'Materiales Intel — precio unitario',
+    'Live construction-material price research over Colombian supplier panel with Claude web_search.',
+    '@broomva/materiales-intel',
+    '{"type":"object","required":["family","item"],"properties":{"family":{"type":"string"},"item":{"type":"string"},"quantity":{"type":"number"},"unit":{"type":"string"},"region":{"type":"string"},"mode":{"type":"string","enum":["fast","standard","deep"]}}}'::jsonb,
+    '{"type":"object","required":["suppliers"],"properties":{"suppliers":{"type":"array"},"medianUnitPriceCop":{"type":"number"},"spread":{"type":"number"}}}'::jsonb,
+    '["web_search"]'::jsonb,
+    '{"avg":30,"p95":120}'::jsonb
+  ),
+  (
+    'generic-rules-runner',
+    '1.0.0',
+    'Generic rules runner',
+    'Executes any rules package against a structured input with Claude + declared tools.',
+    '@broomva/life-modules-core',
+    '{"type":"object"}'::jsonb,
+    '{"type":"object"}'::jsonb,
+    '[]'::jsonb,
+    '{"avg":20,"p95":80}'::jsonb
+  )
+ON CONFLICT ("id") DO NOTHING;
+--> statement-breakpoint
+
+-- ---------------------------------------------------------------------------
+-- Platform-owned Sentinel + Materiales projects
+-- ---------------------------------------------------------------------------
+INSERT INTO "LifeProject"
+  ("slug", "displayName", "description", "ownerKind", "ownerId",
+   "moduleTypeId", "visibility", "status", "stats")
+VALUES
+  (
+    'sentinel',
+    'Sentinel — property-ops WO audit',
+    'AI-native work-order audit for property managers. Flags duplicates, weak closures, follow-up risk, and missing evidence on closed WOs. Free during launch.',
+    'platform',
+    'platform',
+    'sentinel-property-ops',
+    'public',
+    'active',
+    '{"totalRuns":0}'::jsonb
+  ),
+  (
+    'materiales',
+    'Materiales Intel — precio unitario en vivo',
+    'Investigación de precios unitarios de materiales de construcción, en vivo, sobre el panel de proveedores colombianos. Gratuito durante el lanzamiento.',
+    'platform',
+    'platform',
+    'materiales-intel',
+    'public',
+    'active',
+    '{"totalRuns":0}'::jsonb
+  )
+ON CONFLICT ("slug") DO NOTHING;

--- a/apps/chat/lib/db/migrations/meta/0059_snapshot.json
+++ b/apps/chat/lib/db/migrations/meta/0059_snapshot.json
@@ -1,0 +1,5881 @@
+{
+  "id": "af89b5bb-d778-4a1c-8020-380fe07ad640",
+  "prevId": "14356661-7f99-4094-9c16-18a9b950e771",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentKeyId": {
+          "name": "agentKeyId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Agent_user_id_idx": {
+          "name": "Agent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_status_idx": {
+          "name": "Agent_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_agent_key_id_unique": {
+          "name": "Agent_agent_key_id_unique",
+          "columns": [
+            {
+              "expression": "agentKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_public_key_unique": {
+          "name": "Agent_public_key_unique",
+          "columns": [
+            {
+              "expression": "publicKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_userId_user_id_fk": {
+          "name": "Agent_userId_user_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentRegistration": {
+      "name": "AgentRegistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustLevel": {
+          "name": "trustLevel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unrated'"
+        },
+        "lastEvaluatedAt": {
+          "name": "lastEvaluatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentRegistration_org_id_idx": {
+          "name": "AgentRegistration_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_trust_level_idx": {
+          "name": "AgentRegistration_trust_level_idx",
+          "columns": [
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_status_idx": {
+          "name": "AgentRegistration_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentRegistration_organizationId_Organization_id_fk": {
+          "name": "AgentRegistration_organizationId_Organization_id_fk",
+          "tableFrom": "AgentRegistration",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentService": {
+      "name": "AgentService",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustMinimum": {
+          "name": "trustMinimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "callCount": {
+          "name": "callCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRevenue": {
+          "name": "totalRevenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentService_agent_id_idx": {
+          "name": "AgentService_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_user_id_idx": {
+          "name": "AgentService_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_category_idx": {
+          "name": "AgentService_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_status_idx": {
+          "name": "AgentService_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentService_userId_user_id_fk": {
+          "name": "AgentService_userId_user_id_fk",
+          "tableFrom": "AgentService",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AudioPlaybackState": {
+      "name": "AudioPlaybackState",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audioSrc": {
+          "name": "audioSrc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentTime": {
+          "name": "currentTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "AudioPlaybackState_userId_user_id_fk": {
+          "name": "AudioPlaybackState_userId_user_id_fk",
+          "tableFrom": "AudioPlaybackState",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_org_id_idx": {
+          "name": "AuditLog_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_actor_id_idx": {
+          "name": "AuditLog_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_created_at_idx": {
+          "name": "AuditLog_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_agent_id_idx": {
+          "name": "AuditLog_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AuditLog_organizationId_Organization_id_fk": {
+          "name": "AuditLog_organizationId_Organization_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "AuditLog_actorId_user_id_fk": {
+          "name": "AuditLog_actorId_user_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_user_id_fk": {
+          "name": "Chat_userId_user_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_projectId_Project_id_fk": {
+          "name": "Chat_projectId_Project_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeviceAuthCode": {
+      "name": "DeviceAuthCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pollingInterval": {
+          "name": "pollingInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeviceAuthCode_device_code_idx": {
+          "name": "DeviceAuthCode_device_code_idx",
+          "columns": [
+            {
+              "expression": "deviceCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeviceAuthCode_user_code_idx": {
+          "name": "DeviceAuthCode_user_code_idx",
+          "columns": [
+            {
+              "expression": "userCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeviceAuthCode_userId_user_id_fk": {
+          "name": "DeviceAuthCode_userId_user_id_fk",
+          "tableFrom": "DeviceAuthCode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeviceAuthCode_deviceCode_unique": {
+          "name": "DeviceAuthCode_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCode"
+          ]
+        },
+        "DeviceAuthCode_userCode_unique": {
+          "name": "DeviceAuthCode_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Document_message_id_idx": {
+          "name": "Document_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_user_id_fk": {
+          "name": "Document_userId_user_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_messageId_Message_id_fk": {
+          "name": "Document_messageId_Message_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EscrowTransaction": {
+      "name": "EscrowTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerOrgId": {
+          "name": "buyerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerOrgId": {
+          "name": "sellerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCredits": {
+          "name": "amountCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commissionCredits": {
+          "name": "commissionCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "heldAt": {
+          "name": "heldAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "releasedAt": {
+          "name": "releasedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputeReason": {
+          "name": "disputeReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EscrowTransaction_task_id_idx": {
+          "name": "EscrowTransaction_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_buyer_idx": {
+          "name": "EscrowTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_seller_idx": {
+          "name": "EscrowTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_status_idx": {
+          "name": "EscrowTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EscrowTransaction_taskId_MarketplaceTask_id_fk": {
+          "name": "EscrowTransaction_taskId_MarketplaceTask_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "MarketplaceTask",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_buyerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_buyerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "buyerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_sellerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_sellerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "sellerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeByokKey": {
+      "name": "LifeByokKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerKind": {
+          "name": "ownerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedPayload": {
+          "name": "encryptedPayload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHint": {
+          "name": "keyHint",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeByokKey_owner_idx": {
+          "name": "LifeByokKey_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeModuleType": {
+      "name": "LifeModuleType",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runnerRef": {
+          "name": "runnerRef",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputSchema": {
+          "name": "inputSchema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputSchema": {
+          "name": "outputSchema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requiredTools": {
+          "name": "requiredTools",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "defaultUi": {
+          "name": "defaultUi",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'life-interface-classic'"
+        },
+        "costEstimateCents": {
+          "name": "costEstimateCents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"avg\":10,\"p95\":30}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeProject": {
+      "name": "LifeProject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerKind": {
+          "name": "ownerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moduleTypeId": {
+          "name": "moduleTypeId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentRulesVersionId": {
+          "name": "currentRulesVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secretsMode": {
+          "name": "secretsMode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "safetyFlags": {
+          "name": "safetyFlags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeProject_owner_idx": {
+          "name": "LifeProject_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProject_visibility_idx": {
+          "name": "LifeProject_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProject_module_idx": {
+          "name": "LifeProject_module_idx",
+          "columns": [
+            {
+              "expression": "moduleTypeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeProject_moduleTypeId_LifeModuleType_id_fk": {
+          "name": "LifeProject_moduleTypeId_LifeModuleType_id_fk",
+          "tableFrom": "LifeProject",
+          "tableTo": "LifeModuleType",
+          "columnsFrom": [
+            "moduleTypeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "LifeProject_slug_unique": {
+          "name": "LifeProject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeReservedSlug": {
+      "name": "LifeReservedSlug",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform-reserved'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRulesVersion": {
+      "name": "LifeRulesVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rulesJson": {
+          "name": "rulesJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semver": {
+          "name": "semver",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRulesVersion_project_idx": {
+          "name": "LifeRulesVersion_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRulesVersion_projectId_LifeProject_id_fk": {
+          "name": "LifeRulesVersion_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeRulesVersion",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeRulesVersion_parentId_fk": {
+          "name": "LifeRulesVersion_parentId_fk",
+          "tableFrom": "LifeRulesVersion",
+          "tableTo": "LifeRulesVersion",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRun": {
+      "name": "LifeRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rulesVersionId": {
+          "name": "rulesVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerKind": {
+          "name": "consumerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerId": {
+          "name": "consumerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "errorReason": {
+          "name": "errorReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llmCostCents": {
+          "name": "llmCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platformFeeCents": {
+          "name": "platformFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creatorFeeCents": {
+          "name": "creatorFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consumerPaidCents": {
+          "name": "consumerPaidCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paymentMode": {
+          "name": "paymentMode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credits'"
+        },
+        "paymentRail": {
+          "name": "paymentRail",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentTxId": {
+          "name": "paymentTxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byokKeyId": {
+          "name": "byokKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRun_project_idx": {
+          "name": "LifeRun_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_consumer_idx": {
+          "name": "LifeRun_consumer_idx",
+          "columns": [
+            {
+              "expression": "consumerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_status_idx": {
+          "name": "LifeRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_org_idx": {
+          "name": "LifeRun_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRun_projectId_LifeProject_id_fk": {
+          "name": "LifeRun_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "LifeRun_rulesVersionId_LifeRulesVersion_id_fk": {
+          "name": "LifeRun_rulesVersionId_LifeRulesVersion_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeRulesVersion",
+          "columnsFrom": [
+            "rulesVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "LifeRun_organizationId_Organization_id_fk": {
+          "name": "LifeRun_organizationId_Organization_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "LifeRun_byokKeyId_LifeByokKey_id_fk": {
+          "name": "LifeRun_byokKeyId_LifeByokKey_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeByokKey",
+          "columnsFrom": [
+            "byokKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRunEvent": {
+      "name": "LifeRunEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "LifeRunEvent_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "runId": {
+          "name": "runId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRunEvent_run_seq_uq": {
+          "name": "LifeRunEvent_run_seq_uq",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRunEvent_runId_LifeRun_id_fk": {
+          "name": "LifeRunEvent_runId_LifeRun_id_fk",
+          "tableFrom": "LifeRunEvent",
+          "tableTo": "LifeRun",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTask": {
+      "name": "MarketplaceTask",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceCredits": {
+          "name": "priceCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "estimatedDurationMs": {
+          "name": "estimatedDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MarketplaceTask_agent_id_idx": {
+          "name": "MarketplaceTask_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTask_status_idx": {
+          "name": "MarketplaceTask_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MarketplaceTask_agentId_AgentRegistration_id_fk": {
+          "name": "MarketplaceTask_agentId_AgentRegistration_id_fk",
+          "tableFrom": "MarketplaceTask",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTransaction": {
+      "name": "MarketplaceTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerAgentId": {
+          "name": "buyerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerAgentId": {
+          "name": "sellerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountMicroUsd": {
+          "name": "amountMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facilitatorFeeMicroUsd": {
+          "name": "facilitatorFeeMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MarketplaceTransaction_service_id_idx": {
+          "name": "MarketplaceTransaction_service_id_idx",
+          "columns": [
+            {
+              "expression": "serviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_buyer_idx": {
+          "name": "MarketplaceTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_seller_idx": {
+          "name": "MarketplaceTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_status_idx": {
+          "name": "MarketplaceTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpConnector": {
+      "name": "McpConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameId": {
+          "name": "nameId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "oauthClientId": {
+          "name": "oauthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthClientSecret": {
+          "name": "oauthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpConnector_user_id_idx": {
+          "name": "McpConnector_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_idx": {
+          "name": "McpConnector_user_name_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_unique": {
+          "name": "McpConnector_user_name_id_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpConnector_userId_user_id_fk": {
+          "name": "McpConnector_userId_user_id_fk",
+          "tableFrom": "McpConnector",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpOAuthSession": {
+      "name": "McpOAuthSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcpConnectorId": {
+          "name": "mcpConnectorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientInfo": {
+          "name": "clientInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpOAuthSession_connector_idx": {
+          "name": "McpOAuthSession_connector_idx",
+          "columns": [
+            {
+              "expression": "mcpConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpOAuthSession_state_idx": {
+          "name": "McpOAuthSession_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpOAuthSession_mcpConnectorId_McpConnector_id_fk": {
+          "name": "McpOAuthSession_mcpConnectorId_McpConnector_id_fk",
+          "tableFrom": "McpOAuthSession",
+          "tableTo": "McpConnector",
+          "columnsFrom": [
+            "mcpConnectorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpOAuthSession_state_unique": {
+          "name": "McpOAuthSession_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModel": {
+          "name": "selectedModel",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "selectedTool": {
+          "name": "selectedTool",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeStreamId": {
+          "name": "activeStreamId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planCreditsMonthly": {
+          "name": "planCreditsMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "planCreditsRemaining": {
+          "name": "planCreditsRemaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "billingPeriodStart": {
+          "name": "billingPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neonBranchId": {
+          "name": "neonBranchId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Organization_slug_idx": {
+          "name": "Organization_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_stripe_customer_idx": {
+          "name": "Organization_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripeCustomerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_unique": {
+          "name": "Organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationApiKey": {
+      "name": "OrganizationApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationApiKey_org_id_idx": {
+          "name": "OrganizationApiKey_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationApiKey_key_prefix_idx": {
+          "name": "OrganizationApiKey_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "keyPrefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationApiKey_organizationId_Organization_id_fk": {
+          "name": "OrganizationApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationApiKey_createdByUserId_user_id_fk": {
+          "name": "OrganizationApiKey_createdByUserId_user_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationArcanRole": {
+      "name": "OrganizationArcanRole",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleName": {
+          "name": "roleName",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowCapabilities": {
+          "name": "allowCapabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "maxEventsPerTurn": {
+          "name": "maxEventsPerTurn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgArcanRole_org_idx": {
+          "name": "OrgArcanRole_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgArcanRole_org_role_unique": {
+          "name": "OrgArcanRole_org_role_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roleName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationArcanRole_organizationId_Organization_id_fk": {
+          "name": "OrganizationArcanRole_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationArcanRole",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationCustomSkill": {
+      "name": "OrganizationCustomSkill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifestToml": {
+          "name": "manifestToml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgCustomSkill_org_idx": {
+          "name": "OrgCustomSkill_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgCustomSkill_org_name_unique": {
+          "name": "OrgCustomSkill_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationCustomSkill_organizationId_Organization_id_fk": {
+          "name": "OrganizationCustomSkill_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationCustomSkill",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationLifeInstance": {
+      "name": "OrganizationLifeInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railwayProjectId": {
+          "name": "railwayProjectId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "railwayEnvironmentId": {
+          "name": "railwayEnvironmentId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "arcanUrl": {
+          "name": "arcanUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lagoUrl": {
+          "name": "lagoUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomicUrl": {
+          "name": "autonomicUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "haimaUrl": {
+          "name": "haimaUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthCheck": {
+          "name": "lastHealthCheck",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthStatus": {
+          "name": "lastHealthStatus",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationLifeInstance_org_id_idx": {
+          "name": "OrganizationLifeInstance_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationLifeInstance_organizationId_Organization_id_fk": {
+          "name": "OrganizationLifeInstance_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationLifeInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMcpServer": {
+      "name": "OrganizationMcpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearerToken": {
+          "name": "bearerToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgMcpServer_org_idx": {
+          "name": "OrgMcpServer_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMcpServer_org_name_unique": {
+          "name": "OrgMcpServer_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMcpServer_organizationId_Organization_id_fk": {
+          "name": "OrganizationMcpServer_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMcpServer",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_org_id_idx": {
+          "name": "OrganizationMember_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_user_id_idx": {
+          "name": "OrganizationMember_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_org_user_unique": {
+          "name": "OrganizationMember_org_user_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationMember_userId_user_id_fk": {
+          "name": "OrganizationMember_userId_user_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mediaType": {
+          "name": "file_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_filename": {
+          "name": "file_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_sourceId": {
+          "name": "source_url_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_url": {
+          "name": "source_url_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_title": {
+          "name": "source_url_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_sourceId": {
+          "name": "source_document_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_mediaType": {
+          "name": "source_document_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_title": {
+          "name": "source_document_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_filename": {
+          "name": "source_document_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_toolCallId": {
+          "name": "tool_toolCallId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_state": {
+          "name": "tool_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_errorText": {
+          "name": "tool_errorText",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_blob": {
+          "name": "data_blob",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Part_message_id_idx": {
+          "name": "Part_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Part_message_id_order_idx": {
+          "name": "Part_message_id_order_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_messageId_Message_id_fk": {
+          "name": "Part_messageId_Message_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Part_text_required_if_type_text": {
+          "name": "Part_text_required_if_type_text",
+          "value": "CASE WHEN \"Part\".\"type\" = 'text' THEN \"Part\".\"text_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_reasoning_required_if_type_reasoning": {
+          "name": "Part_reasoning_required_if_type_reasoning",
+          "value": "CASE WHEN \"Part\".\"type\" = 'reasoning' THEN \"Part\".\"reasoning_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_file_required_if_type_file": {
+          "name": "Part_file_required_if_type_file",
+          "value": "CASE WHEN \"Part\".\"type\" = 'file' THEN \"Part\".\"file_mediaType\" IS NOT NULL AND \"Part\".\"file_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_url_required_if_type_source_url": {
+          "name": "Part_source_url_required_if_type_source_url",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-url' THEN \"Part\".\"source_url_sourceId\" IS NOT NULL AND \"Part\".\"source_url_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_document_required_if_type_source_document": {
+          "name": "Part_source_document_required_if_type_source_document",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-document' THEN \"Part\".\"source_document_sourceId\" IS NOT NULL AND \"Part\".\"source_document_mediaType\" IS NOT NULL AND \"Part\".\"source_document_title\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_tool_required_if_type_tool": {
+          "name": "Part_tool_required_if_type_tool",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'tool-%' THEN \"Part\".\"tool_toolCallId\" IS NOT NULL AND \"Part\".\"tool_state\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_data_required_if_type_data": {
+          "name": "Part_data_required_if_type_data",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'data-%' THEN \"Part\".\"data_type\" IS NOT NULL ELSE TRUE END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "iconColor": {
+          "name": "iconColor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gray'"
+        }
+      },
+      "indexes": {
+        "Project_user_id_idx": {
+          "name": "Project_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_userId_user_id_fk": {
+          "name": "Project_userId_user_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_user_id_idx": {
+          "name": "RefreshToken_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_token_hash_idx": {
+          "name": "RefreshToken_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expires_at_idx": {
+          "name": "RefreshToken_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_user_id_fk": {
+          "name": "RefreshToken_userId_user_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_tokenHash_unique": {
+          "name": "RefreshToken_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelayNode": {
+      "name": "RelayNode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelayNode_user_idx": {
+          "name": "RelayNode_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelayNode_status_idx": {
+          "name": "RelayNode_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelayNode_userId_user_id_fk": {
+          "name": "RelayNode_userId_user_id_fk",
+          "tableFrom": "RelayNode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelaySession": {
+      "name": "RelaySession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionType": {
+          "name": "sessionType",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workdir": {
+          "name": "workdir",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remoteSessionId": {
+          "name": "remoteSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSequence": {
+          "name": "lastSequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claudeSessionId": {
+          "name": "claudeSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelaySession_node_idx": {
+          "name": "RelaySession_node_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_user_idx": {
+          "name": "RelaySession_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_status_idx": {
+          "name": "RelaySession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelaySession_nodeId_RelayNode_id_fk": {
+          "name": "RelaySession_nodeId_RelayNode_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "RelayNode",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RelaySession_userId_user_id_fk": {
+          "name": "RelaySession_userId_user_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxInstance": {
+      "name": "SandboxInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "vcpus": {
+          "name": "vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryMb": {
+          "name": "memoryMb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persistent": {
+          "name": "persistent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastExecAt": {
+          "name": "lastExecAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execCount": {
+          "name": "execCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxInstance_org_idx": {
+          "name": "SandboxInstance_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_agent_idx": {
+          "name": "SandboxInstance_agent_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_status_idx": {
+          "name": "SandboxInstance_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_provider_idx": {
+          "name": "SandboxInstance_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxInstance_organizationId_Organization_id_fk": {
+          "name": "SandboxInstance_organizationId_Organization_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SandboxInstance_agentId_AgentRegistration_id_fk": {
+          "name": "SandboxInstance_agentId_AgentRegistration_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SandboxInstance_sandboxId_unique": {
+          "name": "SandboxInstance_sandboxId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sandboxId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxSnapshot": {
+      "name": "SandboxSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandboxInstanceId": {
+          "name": "sandboxInstanceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotId": {
+          "name": "snapshotId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxSnapshot_instance_idx": {
+          "name": "SandboxSnapshot_instance_idx",
+          "columns": [
+            {
+              "expression": "sandboxInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk": {
+          "name": "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk",
+          "tableFrom": "SandboxSnapshot",
+          "tableTo": "SandboxInstance",
+          "columnsFrom": [
+            "sandboxInstanceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_user_id_fk": {
+          "name": "Suggestion_userId_user_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costCents": {
+          "name": "costCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeMeterEventId": {
+          "name": "stripeMeterEventId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_id_idx": {
+          "name": "UsageEvent_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_user_id_idx": {
+          "name": "UsageEvent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_created_at_idx": {
+          "name": "UsageEvent_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_org_created_idx": {
+          "name": "UsageEvent_org_created_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_agent_id_idx": {
+          "name": "UsageEvent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_user_id_fk": {
+          "name": "UsageEvent_userId_user_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserCredit": {
+      "name": "UserCredit",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserCredit_userId_user_id_fk": {
+          "name": "UserCredit_userId_user_id_fk",
+          "tableFrom": "UserCredit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserModelPreference": {
+      "name": "UserModelPreference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserModelPreference_user_id_idx": {
+          "name": "UserModelPreference_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserModelPreference_userId_user_id_fk": {
+          "name": "UserModelPreference_userId_user_id_fk",
+          "tableFrom": "UserModelPreference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UserModelPreference_userId_modelId_pk": {
+          "name": "UserModelPreference_userId_modelId_pk",
+          "columns": [
+            "userId",
+            "modelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserPrompt": {
+      "name": "UserPrompt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copyCount": {
+          "name": "copyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isHighlighted": {
+          "name": "isHighlighted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserPrompt_user_id_idx": {
+          "name": "UserPrompt_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_visibility_idx": {
+          "name": "UserPrompt_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_slug_unique": {
+          "name": "UserPrompt_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserPrompt_userId_user_id_fk": {
+          "name": "UserPrompt_userId_user_id_fk",
+          "tableFrom": "UserPrompt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserVault": {
+      "name": "UserVault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lagoSessionId": {
+          "name": "lagoSessionId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserVault_user_id_idx": {
+          "name": "UserVault_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserVault_lago_session_unique": {
+          "name": "UserVault_lago_session_unique",
+          "columns": [
+            {
+              "expression": "lagoSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserVault_userId_user_id_fk": {
+          "name": "UserVault_userId_user_id_fk",
+          "tableFrom": "UserVault",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat/lib/db/migrations/meta/0060_snapshot.json
+++ b/apps/chat/lib/db/migrations/meta/0060_snapshot.json
@@ -1,0 +1,5881 @@
+{
+  "id": "af89b5bb-d778-4a1c-8020-380fe07ad640",
+  "prevId": "14356661-7f99-4094-9c16-18a9b950e771",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentKeyId": {
+          "name": "agentKeyId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Agent_user_id_idx": {
+          "name": "Agent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_status_idx": {
+          "name": "Agent_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_agent_key_id_unique": {
+          "name": "Agent_agent_key_id_unique",
+          "columns": [
+            {
+              "expression": "agentKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_public_key_unique": {
+          "name": "Agent_public_key_unique",
+          "columns": [
+            {
+              "expression": "publicKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_userId_user_id_fk": {
+          "name": "Agent_userId_user_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentRegistration": {
+      "name": "AgentRegistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustLevel": {
+          "name": "trustLevel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unrated'"
+        },
+        "lastEvaluatedAt": {
+          "name": "lastEvaluatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentRegistration_org_id_idx": {
+          "name": "AgentRegistration_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_trust_level_idx": {
+          "name": "AgentRegistration_trust_level_idx",
+          "columns": [
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_status_idx": {
+          "name": "AgentRegistration_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentRegistration_organizationId_Organization_id_fk": {
+          "name": "AgentRegistration_organizationId_Organization_id_fk",
+          "tableFrom": "AgentRegistration",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentService": {
+      "name": "AgentService",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustMinimum": {
+          "name": "trustMinimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "callCount": {
+          "name": "callCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRevenue": {
+          "name": "totalRevenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentService_agent_id_idx": {
+          "name": "AgentService_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_user_id_idx": {
+          "name": "AgentService_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_category_idx": {
+          "name": "AgentService_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_status_idx": {
+          "name": "AgentService_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentService_userId_user_id_fk": {
+          "name": "AgentService_userId_user_id_fk",
+          "tableFrom": "AgentService",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AudioPlaybackState": {
+      "name": "AudioPlaybackState",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audioSrc": {
+          "name": "audioSrc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentTime": {
+          "name": "currentTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "AudioPlaybackState_userId_user_id_fk": {
+          "name": "AudioPlaybackState_userId_user_id_fk",
+          "tableFrom": "AudioPlaybackState",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_org_id_idx": {
+          "name": "AuditLog_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_actor_id_idx": {
+          "name": "AuditLog_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_created_at_idx": {
+          "name": "AuditLog_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_agent_id_idx": {
+          "name": "AuditLog_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AuditLog_organizationId_Organization_id_fk": {
+          "name": "AuditLog_organizationId_Organization_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "AuditLog_actorId_user_id_fk": {
+          "name": "AuditLog_actorId_user_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_user_id_fk": {
+          "name": "Chat_userId_user_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_projectId_Project_id_fk": {
+          "name": "Chat_projectId_Project_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeviceAuthCode": {
+      "name": "DeviceAuthCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pollingInterval": {
+          "name": "pollingInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeviceAuthCode_device_code_idx": {
+          "name": "DeviceAuthCode_device_code_idx",
+          "columns": [
+            {
+              "expression": "deviceCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeviceAuthCode_user_code_idx": {
+          "name": "DeviceAuthCode_user_code_idx",
+          "columns": [
+            {
+              "expression": "userCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeviceAuthCode_userId_user_id_fk": {
+          "name": "DeviceAuthCode_userId_user_id_fk",
+          "tableFrom": "DeviceAuthCode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeviceAuthCode_deviceCode_unique": {
+          "name": "DeviceAuthCode_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCode"
+          ]
+        },
+        "DeviceAuthCode_userCode_unique": {
+          "name": "DeviceAuthCode_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Document_message_id_idx": {
+          "name": "Document_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_user_id_fk": {
+          "name": "Document_userId_user_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_messageId_Message_id_fk": {
+          "name": "Document_messageId_Message_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EscrowTransaction": {
+      "name": "EscrowTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerOrgId": {
+          "name": "buyerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerOrgId": {
+          "name": "sellerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCredits": {
+          "name": "amountCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commissionCredits": {
+          "name": "commissionCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "heldAt": {
+          "name": "heldAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "releasedAt": {
+          "name": "releasedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputeReason": {
+          "name": "disputeReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EscrowTransaction_task_id_idx": {
+          "name": "EscrowTransaction_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_buyer_idx": {
+          "name": "EscrowTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_seller_idx": {
+          "name": "EscrowTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_status_idx": {
+          "name": "EscrowTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EscrowTransaction_taskId_MarketplaceTask_id_fk": {
+          "name": "EscrowTransaction_taskId_MarketplaceTask_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "MarketplaceTask",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_buyerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_buyerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "buyerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_sellerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_sellerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "sellerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeByokKey": {
+      "name": "LifeByokKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerKind": {
+          "name": "ownerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedPayload": {
+          "name": "encryptedPayload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHint": {
+          "name": "keyHint",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeByokKey_owner_idx": {
+          "name": "LifeByokKey_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeModuleType": {
+      "name": "LifeModuleType",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runnerRef": {
+          "name": "runnerRef",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputSchema": {
+          "name": "inputSchema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputSchema": {
+          "name": "outputSchema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requiredTools": {
+          "name": "requiredTools",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "defaultUi": {
+          "name": "defaultUi",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'life-interface-classic'"
+        },
+        "costEstimateCents": {
+          "name": "costEstimateCents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"avg\":10,\"p95\":30}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeProject": {
+      "name": "LifeProject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerKind": {
+          "name": "ownerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moduleTypeId": {
+          "name": "moduleTypeId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentRulesVersionId": {
+          "name": "currentRulesVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secretsMode": {
+          "name": "secretsMode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "safetyFlags": {
+          "name": "safetyFlags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeProject_owner_idx": {
+          "name": "LifeProject_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProject_visibility_idx": {
+          "name": "LifeProject_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProject_module_idx": {
+          "name": "LifeProject_module_idx",
+          "columns": [
+            {
+              "expression": "moduleTypeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeProject_moduleTypeId_LifeModuleType_id_fk": {
+          "name": "LifeProject_moduleTypeId_LifeModuleType_id_fk",
+          "tableFrom": "LifeProject",
+          "tableTo": "LifeModuleType",
+          "columnsFrom": [
+            "moduleTypeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "LifeProject_slug_unique": {
+          "name": "LifeProject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeReservedSlug": {
+      "name": "LifeReservedSlug",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform-reserved'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRulesVersion": {
+      "name": "LifeRulesVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rulesJson": {
+          "name": "rulesJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semver": {
+          "name": "semver",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRulesVersion_project_idx": {
+          "name": "LifeRulesVersion_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRulesVersion_projectId_LifeProject_id_fk": {
+          "name": "LifeRulesVersion_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeRulesVersion",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeRulesVersion_parentId_fk": {
+          "name": "LifeRulesVersion_parentId_fk",
+          "tableFrom": "LifeRulesVersion",
+          "tableTo": "LifeRulesVersion",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRun": {
+      "name": "LifeRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rulesVersionId": {
+          "name": "rulesVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerKind": {
+          "name": "consumerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerId": {
+          "name": "consumerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "errorReason": {
+          "name": "errorReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llmCostCents": {
+          "name": "llmCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platformFeeCents": {
+          "name": "platformFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creatorFeeCents": {
+          "name": "creatorFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consumerPaidCents": {
+          "name": "consumerPaidCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paymentMode": {
+          "name": "paymentMode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credits'"
+        },
+        "paymentRail": {
+          "name": "paymentRail",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentTxId": {
+          "name": "paymentTxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byokKeyId": {
+          "name": "byokKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRun_project_idx": {
+          "name": "LifeRun_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_consumer_idx": {
+          "name": "LifeRun_consumer_idx",
+          "columns": [
+            {
+              "expression": "consumerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_status_idx": {
+          "name": "LifeRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_org_idx": {
+          "name": "LifeRun_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRun_projectId_LifeProject_id_fk": {
+          "name": "LifeRun_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "LifeRun_rulesVersionId_LifeRulesVersion_id_fk": {
+          "name": "LifeRun_rulesVersionId_LifeRulesVersion_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeRulesVersion",
+          "columnsFrom": [
+            "rulesVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "LifeRun_organizationId_Organization_id_fk": {
+          "name": "LifeRun_organizationId_Organization_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "LifeRun_byokKeyId_LifeByokKey_id_fk": {
+          "name": "LifeRun_byokKeyId_LifeByokKey_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeByokKey",
+          "columnsFrom": [
+            "byokKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRunEvent": {
+      "name": "LifeRunEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "LifeRunEvent_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "runId": {
+          "name": "runId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRunEvent_run_seq_uq": {
+          "name": "LifeRunEvent_run_seq_uq",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRunEvent_runId_LifeRun_id_fk": {
+          "name": "LifeRunEvent_runId_LifeRun_id_fk",
+          "tableFrom": "LifeRunEvent",
+          "tableTo": "LifeRun",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTask": {
+      "name": "MarketplaceTask",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceCredits": {
+          "name": "priceCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "estimatedDurationMs": {
+          "name": "estimatedDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MarketplaceTask_agent_id_idx": {
+          "name": "MarketplaceTask_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTask_status_idx": {
+          "name": "MarketplaceTask_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MarketplaceTask_agentId_AgentRegistration_id_fk": {
+          "name": "MarketplaceTask_agentId_AgentRegistration_id_fk",
+          "tableFrom": "MarketplaceTask",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTransaction": {
+      "name": "MarketplaceTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerAgentId": {
+          "name": "buyerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerAgentId": {
+          "name": "sellerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountMicroUsd": {
+          "name": "amountMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facilitatorFeeMicroUsd": {
+          "name": "facilitatorFeeMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MarketplaceTransaction_service_id_idx": {
+          "name": "MarketplaceTransaction_service_id_idx",
+          "columns": [
+            {
+              "expression": "serviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_buyer_idx": {
+          "name": "MarketplaceTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_seller_idx": {
+          "name": "MarketplaceTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_status_idx": {
+          "name": "MarketplaceTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpConnector": {
+      "name": "McpConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameId": {
+          "name": "nameId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "oauthClientId": {
+          "name": "oauthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthClientSecret": {
+          "name": "oauthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpConnector_user_id_idx": {
+          "name": "McpConnector_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_idx": {
+          "name": "McpConnector_user_name_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_unique": {
+          "name": "McpConnector_user_name_id_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpConnector_userId_user_id_fk": {
+          "name": "McpConnector_userId_user_id_fk",
+          "tableFrom": "McpConnector",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpOAuthSession": {
+      "name": "McpOAuthSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcpConnectorId": {
+          "name": "mcpConnectorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientInfo": {
+          "name": "clientInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpOAuthSession_connector_idx": {
+          "name": "McpOAuthSession_connector_idx",
+          "columns": [
+            {
+              "expression": "mcpConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpOAuthSession_state_idx": {
+          "name": "McpOAuthSession_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpOAuthSession_mcpConnectorId_McpConnector_id_fk": {
+          "name": "McpOAuthSession_mcpConnectorId_McpConnector_id_fk",
+          "tableFrom": "McpOAuthSession",
+          "tableTo": "McpConnector",
+          "columnsFrom": [
+            "mcpConnectorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpOAuthSession_state_unique": {
+          "name": "McpOAuthSession_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModel": {
+          "name": "selectedModel",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "selectedTool": {
+          "name": "selectedTool",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeStreamId": {
+          "name": "activeStreamId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planCreditsMonthly": {
+          "name": "planCreditsMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "planCreditsRemaining": {
+          "name": "planCreditsRemaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "billingPeriodStart": {
+          "name": "billingPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neonBranchId": {
+          "name": "neonBranchId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Organization_slug_idx": {
+          "name": "Organization_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_stripe_customer_idx": {
+          "name": "Organization_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripeCustomerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_unique": {
+          "name": "Organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationApiKey": {
+      "name": "OrganizationApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationApiKey_org_id_idx": {
+          "name": "OrganizationApiKey_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationApiKey_key_prefix_idx": {
+          "name": "OrganizationApiKey_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "keyPrefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationApiKey_organizationId_Organization_id_fk": {
+          "name": "OrganizationApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationApiKey_createdByUserId_user_id_fk": {
+          "name": "OrganizationApiKey_createdByUserId_user_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationArcanRole": {
+      "name": "OrganizationArcanRole",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleName": {
+          "name": "roleName",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowCapabilities": {
+          "name": "allowCapabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "maxEventsPerTurn": {
+          "name": "maxEventsPerTurn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgArcanRole_org_idx": {
+          "name": "OrgArcanRole_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgArcanRole_org_role_unique": {
+          "name": "OrgArcanRole_org_role_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roleName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationArcanRole_organizationId_Organization_id_fk": {
+          "name": "OrganizationArcanRole_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationArcanRole",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationCustomSkill": {
+      "name": "OrganizationCustomSkill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifestToml": {
+          "name": "manifestToml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgCustomSkill_org_idx": {
+          "name": "OrgCustomSkill_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgCustomSkill_org_name_unique": {
+          "name": "OrgCustomSkill_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationCustomSkill_organizationId_Organization_id_fk": {
+          "name": "OrganizationCustomSkill_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationCustomSkill",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationLifeInstance": {
+      "name": "OrganizationLifeInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railwayProjectId": {
+          "name": "railwayProjectId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "railwayEnvironmentId": {
+          "name": "railwayEnvironmentId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "arcanUrl": {
+          "name": "arcanUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lagoUrl": {
+          "name": "lagoUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomicUrl": {
+          "name": "autonomicUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "haimaUrl": {
+          "name": "haimaUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthCheck": {
+          "name": "lastHealthCheck",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthStatus": {
+          "name": "lastHealthStatus",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationLifeInstance_org_id_idx": {
+          "name": "OrganizationLifeInstance_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationLifeInstance_organizationId_Organization_id_fk": {
+          "name": "OrganizationLifeInstance_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationLifeInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMcpServer": {
+      "name": "OrganizationMcpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearerToken": {
+          "name": "bearerToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgMcpServer_org_idx": {
+          "name": "OrgMcpServer_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMcpServer_org_name_unique": {
+          "name": "OrgMcpServer_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMcpServer_organizationId_Organization_id_fk": {
+          "name": "OrganizationMcpServer_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMcpServer",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_org_id_idx": {
+          "name": "OrganizationMember_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_user_id_idx": {
+          "name": "OrganizationMember_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_org_user_unique": {
+          "name": "OrganizationMember_org_user_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationMember_userId_user_id_fk": {
+          "name": "OrganizationMember_userId_user_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mediaType": {
+          "name": "file_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_filename": {
+          "name": "file_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_sourceId": {
+          "name": "source_url_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_url": {
+          "name": "source_url_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_title": {
+          "name": "source_url_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_sourceId": {
+          "name": "source_document_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_mediaType": {
+          "name": "source_document_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_title": {
+          "name": "source_document_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_filename": {
+          "name": "source_document_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_toolCallId": {
+          "name": "tool_toolCallId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_state": {
+          "name": "tool_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_errorText": {
+          "name": "tool_errorText",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_blob": {
+          "name": "data_blob",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Part_message_id_idx": {
+          "name": "Part_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Part_message_id_order_idx": {
+          "name": "Part_message_id_order_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_messageId_Message_id_fk": {
+          "name": "Part_messageId_Message_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Part_text_required_if_type_text": {
+          "name": "Part_text_required_if_type_text",
+          "value": "CASE WHEN \"Part\".\"type\" = 'text' THEN \"Part\".\"text_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_reasoning_required_if_type_reasoning": {
+          "name": "Part_reasoning_required_if_type_reasoning",
+          "value": "CASE WHEN \"Part\".\"type\" = 'reasoning' THEN \"Part\".\"reasoning_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_file_required_if_type_file": {
+          "name": "Part_file_required_if_type_file",
+          "value": "CASE WHEN \"Part\".\"type\" = 'file' THEN \"Part\".\"file_mediaType\" IS NOT NULL AND \"Part\".\"file_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_url_required_if_type_source_url": {
+          "name": "Part_source_url_required_if_type_source_url",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-url' THEN \"Part\".\"source_url_sourceId\" IS NOT NULL AND \"Part\".\"source_url_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_document_required_if_type_source_document": {
+          "name": "Part_source_document_required_if_type_source_document",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-document' THEN \"Part\".\"source_document_sourceId\" IS NOT NULL AND \"Part\".\"source_document_mediaType\" IS NOT NULL AND \"Part\".\"source_document_title\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_tool_required_if_type_tool": {
+          "name": "Part_tool_required_if_type_tool",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'tool-%' THEN \"Part\".\"tool_toolCallId\" IS NOT NULL AND \"Part\".\"tool_state\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_data_required_if_type_data": {
+          "name": "Part_data_required_if_type_data",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'data-%' THEN \"Part\".\"data_type\" IS NOT NULL ELSE TRUE END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "iconColor": {
+          "name": "iconColor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gray'"
+        }
+      },
+      "indexes": {
+        "Project_user_id_idx": {
+          "name": "Project_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_userId_user_id_fk": {
+          "name": "Project_userId_user_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_user_id_idx": {
+          "name": "RefreshToken_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_token_hash_idx": {
+          "name": "RefreshToken_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expires_at_idx": {
+          "name": "RefreshToken_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_user_id_fk": {
+          "name": "RefreshToken_userId_user_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_tokenHash_unique": {
+          "name": "RefreshToken_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelayNode": {
+      "name": "RelayNode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelayNode_user_idx": {
+          "name": "RelayNode_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelayNode_status_idx": {
+          "name": "RelayNode_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelayNode_userId_user_id_fk": {
+          "name": "RelayNode_userId_user_id_fk",
+          "tableFrom": "RelayNode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelaySession": {
+      "name": "RelaySession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionType": {
+          "name": "sessionType",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workdir": {
+          "name": "workdir",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remoteSessionId": {
+          "name": "remoteSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSequence": {
+          "name": "lastSequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claudeSessionId": {
+          "name": "claudeSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelaySession_node_idx": {
+          "name": "RelaySession_node_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_user_idx": {
+          "name": "RelaySession_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_status_idx": {
+          "name": "RelaySession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelaySession_nodeId_RelayNode_id_fk": {
+          "name": "RelaySession_nodeId_RelayNode_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "RelayNode",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RelaySession_userId_user_id_fk": {
+          "name": "RelaySession_userId_user_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxInstance": {
+      "name": "SandboxInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "vcpus": {
+          "name": "vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryMb": {
+          "name": "memoryMb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persistent": {
+          "name": "persistent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastExecAt": {
+          "name": "lastExecAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execCount": {
+          "name": "execCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxInstance_org_idx": {
+          "name": "SandboxInstance_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_agent_idx": {
+          "name": "SandboxInstance_agent_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_status_idx": {
+          "name": "SandboxInstance_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_provider_idx": {
+          "name": "SandboxInstance_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxInstance_organizationId_Organization_id_fk": {
+          "name": "SandboxInstance_organizationId_Organization_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SandboxInstance_agentId_AgentRegistration_id_fk": {
+          "name": "SandboxInstance_agentId_AgentRegistration_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SandboxInstance_sandboxId_unique": {
+          "name": "SandboxInstance_sandboxId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sandboxId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxSnapshot": {
+      "name": "SandboxSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandboxInstanceId": {
+          "name": "sandboxInstanceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotId": {
+          "name": "snapshotId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxSnapshot_instance_idx": {
+          "name": "SandboxSnapshot_instance_idx",
+          "columns": [
+            {
+              "expression": "sandboxInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk": {
+          "name": "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk",
+          "tableFrom": "SandboxSnapshot",
+          "tableTo": "SandboxInstance",
+          "columnsFrom": [
+            "sandboxInstanceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_user_id_fk": {
+          "name": "Suggestion_userId_user_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costCents": {
+          "name": "costCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeMeterEventId": {
+          "name": "stripeMeterEventId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_id_idx": {
+          "name": "UsageEvent_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_user_id_idx": {
+          "name": "UsageEvent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_created_at_idx": {
+          "name": "UsageEvent_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_org_created_idx": {
+          "name": "UsageEvent_org_created_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_agent_id_idx": {
+          "name": "UsageEvent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_user_id_fk": {
+          "name": "UsageEvent_userId_user_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserCredit": {
+      "name": "UserCredit",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserCredit_userId_user_id_fk": {
+          "name": "UserCredit_userId_user_id_fk",
+          "tableFrom": "UserCredit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserModelPreference": {
+      "name": "UserModelPreference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserModelPreference_user_id_idx": {
+          "name": "UserModelPreference_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserModelPreference_userId_user_id_fk": {
+          "name": "UserModelPreference_userId_user_id_fk",
+          "tableFrom": "UserModelPreference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UserModelPreference_userId_modelId_pk": {
+          "name": "UserModelPreference_userId_modelId_pk",
+          "columns": [
+            "userId",
+            "modelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserPrompt": {
+      "name": "UserPrompt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copyCount": {
+          "name": "copyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isHighlighted": {
+          "name": "isHighlighted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserPrompt_user_id_idx": {
+          "name": "UserPrompt_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_visibility_idx": {
+          "name": "UserPrompt_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_slug_unique": {
+          "name": "UserPrompt_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserPrompt_userId_user_id_fk": {
+          "name": "UserPrompt_userId_user_id_fk",
+          "tableFrom": "UserPrompt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserVault": {
+      "name": "UserVault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lagoSessionId": {
+          "name": "lagoSessionId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserVault_user_id_idx": {
+          "name": "UserVault_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserVault_lago_session_unique": {
+          "name": "UserVault_lago_session_unique",
+          "columns": [
+            {
+              "expression": "lagoSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserVault_userId_user_id_fk": {
+          "name": "UserVault_userId_user_id_fk",
+          "tableFrom": "UserVault",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/chat/lib/db/migrations/meta/_journal.json
+++ b/apps/chat/lib/db/migrations/meta/_journal.json
@@ -414,6 +414,20 @@
       "when": 1774929593335,
       "tag": "0058_curly_sentinels",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1776952119230,
+      "tag": "0059_quiet_lenny_balinger",
+      "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1776952120000,
+      "tag": "0060_seed_life_runtime",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -1438,4 +1438,318 @@ export const relaySession = pgTable(
 
 export type RelaySession = InferSelectModel<typeof relaySession>;
 
+// ---------------------------------------------------------------------------
+// LIFE RUNTIME PLATFORM (BRO-846)
+// ---------------------------------------------------------------------------
+// User-facing /life/[project] surface. Every Life project (Broomva-owned,
+// user-owned, or org-owned) is a row in LifeProject. Rules packages live
+// in LifeRulesVersion (git-style parent pointer). Runs in LifeRun + its
+// event log in LifeRunEvent. Module types are a registry in LifeModuleType.
+// BYOK provider keys in LifeByokKey (encrypted at rest via encryptedText).
+// ---------------------------------------------------------------------------
+
+/** Registry of runner implementations. Each LifeProject references one. */
+export const lifeModuleType = pgTable("LifeModuleType", {
+  /** e.g. 'sentinel-property-ops', 'materiales-intel', 'generic-rules-runner', 'module-builder' */
+  id: varchar("id", { length: 128 }).primaryKey().notNull(),
+  version: varchar("version", { length: 32 }).notNull(),
+  displayName: varchar("displayName", { length: 256 }).notNull(),
+  description: text("description"),
+  /** npm package name where the runner implementation lives */
+  runnerRef: varchar("runnerRef", { length: 128 }).notNull(),
+  /** JSON Schema for the input shape */
+  inputSchema: json("inputSchema").notNull(),
+  /** JSON Schema for the output shape */
+  outputSchema: json("outputSchema").notNull(),
+  /** Array of tool names the runner requires (['web_search'], etc.) */
+  requiredTools: json("requiredTools").notNull().default(sql`'[]'::jsonb`),
+  defaultUi: varchar("defaultUi", { length: 128 })
+    .notNull()
+    .default("life-interface-classic"),
+  /** { avgCents, p95Cents } */
+  costEstimateCents: json("costEstimateCents")
+    .notNull()
+    .default(sql`'{"avg":10,"p95":30}'::jsonb`),
+  status: varchar("status", {
+    length: 32,
+    enum: ["active", "deprecated"],
+  })
+    .notNull()
+    .default("active"),
+  createdAt: timestamp("createdAt").notNull().defaultNow(),
+  updatedAt: timestamp("updatedAt")
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export type LifeModuleType = InferSelectModel<typeof lifeModuleType>;
+
+/** Platform-reserved slugs, blocks user claims on /life/<slug>. */
+export const lifeReservedSlug = pgTable("LifeReservedSlug", {
+  slug: varchar("slug", { length: 64 }).primaryKey().notNull(),
+  reason: varchar("reason", { length: 128 })
+    .notNull()
+    .default("platform-reserved"),
+});
+
+export type LifeReservedSlug = InferSelectModel<typeof lifeReservedSlug>;
+
+/**
+ * One row per Life project.
+ * Slug is global; `@handle/slug` URL form is app-layer convention.
+ * ownerKind='platform' + ownerId='platform' marks Broomva-owned projects (sentinel, materiales).
+ */
+export const lifeProject = pgTable(
+  "LifeProject",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    slug: varchar("slug", { length: 128 }).notNull().unique(),
+    displayName: varchar("displayName", { length: 256 }).notNull(),
+    description: text("description"),
+    /** 'user' | 'org' | 'platform' */
+    ownerKind: varchar("ownerKind", {
+      length: 16,
+      enum: ["user", "org", "platform"],
+    }).notNull(),
+    /** userId | orgId | 'platform' */
+    ownerId: varchar("ownerId", { length: 256 }).notNull(),
+    moduleTypeId: varchar("moduleTypeId", { length: 128 })
+      .notNull()
+      .references(() => lifeModuleType.id),
+    /** Pointer to the HEAD of the rules version tree. Nullable while draft. */
+    currentRulesVersionId: uuid("currentRulesVersionId"),
+    visibility: varchar("visibility", {
+      length: 32,
+      enum: ["private", "unlisted", "public"],
+    })
+      .notNull()
+      .default("private"),
+    /**
+     * Pricing config. null = free. Shape:
+     * { model: 'per_run'|'per_token'|'tiered'|'free', rail, consumerPriceCents,
+     *   maxCostCents, creatorSharePct, platformFeePct, creatorSubsidyCents,
+     *   freeRunsPerMonthPerConsumer, currency }
+     */
+    pricing: json("pricing"),
+    /** 'platform' | 'creator_byok' | 'consumer_byok' */
+    secretsMode: varchar("secretsMode", {
+      length: 32,
+      enum: ["platform", "creator_byok", "consumer_byok"],
+    })
+      .notNull()
+      .default("platform"),
+    status: varchar("status", {
+      length: 32,
+      enum: ["draft", "active", "suspended", "archived"],
+    })
+      .notNull()
+      .default("draft"),
+    safetyFlags: json("safetyFlags").notNull().default(sql`'{}'::jsonb`),
+    /** Denormalized counters: { totalRuns, lastRunAt, avgCostCents } */
+    stats: json("stats").notNull().default(sql`'{}'::jsonb`),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => ({
+    LifeProject_owner_idx: index("LifeProject_owner_idx").on(
+      t.ownerKind,
+      t.ownerId,
+    ),
+    LifeProject_visibility_idx: index("LifeProject_visibility_idx").on(
+      t.visibility,
+      t.status,
+    ),
+    LifeProject_module_idx: index("LifeProject_module_idx").on(t.moduleTypeId),
+  }),
+);
+
+export type LifeProject = InferSelectModel<typeof lifeProject>;
+
+/** Versioned rules payload. Parent pointer supports revert/branch. */
+export const lifeRulesVersion = pgTable(
+  "LifeRulesVersion",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    projectId: uuid("projectId")
+      .notNull()
+      .references(() => lifeProject.id, { onDelete: "cascade" }),
+    /** Full RulesPackage JSON (taxonomy, sources, rules, prompts, policy, schemas) */
+    rulesJson: json("rulesJson").notNull(),
+    semver: varchar("semver", { length: 32 }).notNull(),
+    parentId: uuid("parentId"),
+    createdByUserId: text("createdByUserId"),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+  },
+  (t) => ({
+    LifeRulesVersion_project_idx: index("LifeRulesVersion_project_idx").on(
+      t.projectId,
+      t.createdAt,
+    ),
+    LifeRulesVersion_parent_fk: foreignKey({
+      columns: [t.parentId],
+      foreignColumns: [t.id],
+      name: "LifeRulesVersion_parentId_fk",
+    }),
+  }),
+);
+
+export type LifeRulesVersion = InferSelectModel<typeof lifeRulesVersion>;
+
+/** BYOK provider keys, encrypted at rest. Runtime decrypts via KMS. */
+export const lifeByokKey = pgTable(
+  "LifeByokKey",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    ownerKind: varchar("ownerKind", {
+      length: 16,
+      enum: ["user", "org"],
+    }).notNull(),
+    ownerId: varchar("ownerId", { length: 256 }).notNull(),
+    provider: varchar("provider", {
+      length: 32,
+      enum: ["anthropic", "openai", "google", "vercel-gateway"],
+    }).notNull(),
+    label: varchar("label", { length: 128 }).notNull(),
+    /** Ciphertext. Decrypt via platform KMS. */
+    encryptedPayload: encryptedText("encryptedPayload").notNull(),
+    /** Last 4 chars of raw key for UI identification */
+    keyHint: varchar("keyHint", { length: 16 }),
+    /**
+     * 'internal' = creator uses this in their own projects only.
+     * 'public' = exposed to consumers when project.secretsMode='creator_byok'.
+     */
+    scope: varchar("scope", {
+      length: 32,
+      enum: ["internal", "public"],
+    })
+      .notNull()
+      .default("internal"),
+    status: varchar("status", {
+      length: 32,
+      enum: ["active", "revoked", "invalid"],
+    })
+      .notNull()
+      .default("active"),
+    lastUsedAt: timestamp("lastUsedAt"),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+  },
+  (t) => ({
+    LifeByokKey_owner_idx: index("LifeByokKey_owner_idx").on(
+      t.ownerKind,
+      t.ownerId,
+      t.status,
+    ),
+  }),
+);
+
+export type LifeByokKey = InferSelectModel<typeof lifeByokKey>;
+
+/**
+ * One row per execution. Cost columns are all in USD cents.
+ * paymentMode: 'credits' | 'x402' | 'haima_balance' | 'byok' | 'free_tier'.
+ */
+export const lifeRun = pgTable(
+  "LifeRun",
+  {
+    id: uuid("id").primaryKey().notNull().defaultRandom(),
+    projectId: uuid("projectId")
+      .notNull()
+      .references(() => lifeProject.id, { onDelete: "restrict" }),
+    rulesVersionId: uuid("rulesVersionId")
+      .notNull()
+      .references(() => lifeRulesVersion.id),
+    /** 'user' | 'anon' | 'agent' */
+    consumerKind: varchar("consumerKind", {
+      length: 16,
+      enum: ["user", "anon", "agent"],
+    }).notNull(),
+    /** userId | anon session id | wallet address */
+    consumerId: varchar("consumerId", { length: 256 }).notNull(),
+    /** Null for anon/agent; present for credits-debit path */
+    organizationId: uuid("organizationId").references(() => organization.id, {
+      onDelete: "set null",
+    }),
+    input: json("input").notNull(),
+    output: json("output"),
+    status: varchar("status", {
+      length: 32,
+      enum: [
+        "queued",
+        "streaming",
+        "succeeded",
+        "failed",
+        "refunded",
+        "cancelled",
+      ],
+    })
+      .notNull()
+      .default("queued"),
+    errorReason: text("errorReason"),
+    // cost accounting (USD cents)
+    llmCostCents: integer("llmCostCents").notNull().default(0),
+    platformFeeCents: integer("platformFeeCents").notNull().default(0),
+    creatorFeeCents: integer("creatorFeeCents").notNull().default(0),
+    consumerPaidCents: integer("consumerPaidCents").notNull().default(0),
+    // payment source
+    paymentMode: varchar("paymentMode", {
+      length: 32,
+      enum: ["credits", "x402", "haima_balance", "byok", "free_tier"],
+    })
+      .notNull()
+      .default("credits"),
+    paymentRail: varchar("paymentRail", { length: 32 }),
+    paymentTxId: varchar("paymentTxId", { length: 256 }),
+    // model identity
+    model: varchar("model", { length: 128 }),
+    provider: varchar("provider", { length: 32 }),
+    byokKeyId: uuid("byokKeyId").references(() => lifeByokKey.id),
+    // timing
+    startedAt: timestamp("startedAt"),
+    finishedAt: timestamp("finishedAt"),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+  },
+  (t) => ({
+    LifeRun_project_idx: index("LifeRun_project_idx").on(
+      t.projectId,
+      t.createdAt,
+    ),
+    LifeRun_consumer_idx: index("LifeRun_consumer_idx").on(
+      t.consumerKind,
+      t.consumerId,
+    ),
+    LifeRun_status_idx: index("LifeRun_status_idx").on(t.status),
+    LifeRun_org_idx: index("LifeRun_org_idx").on(t.organizationId),
+  }),
+);
+
+export type LifeRun = InferSelectModel<typeof lifeRun>;
+
+/** Append-only event log per run. Feeds SSE streaming + replay. */
+export const lifeRunEvent = pgTable(
+  "LifeRunEvent",
+  {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    runId: uuid("runId")
+      .notNull()
+      .references(() => lifeRun.id, { onDelete: "cascade" }),
+    seq: integer("seq").notNull(),
+    /** 'thinking_start' | 'thinking_delta' | 'tool_call' | 'tool_result' | 'output_delta' | 'fs_op' | 'nous_score' | 'error' | 'done' | ... */
+    type: varchar("type", { length: 64 }).notNull(),
+    payload: json("payload").notNull().default(sql`'{}'::jsonb`),
+    at: timestamp("at").notNull().defaultNow(),
+  },
+  (t) => ({
+    LifeRunEvent_run_seq_uq: uniqueIndex("LifeRunEvent_run_seq_uq").on(
+      t.runId,
+      t.seq,
+    ),
+  }),
+);
+
+export type LifeRunEvent = InferSelectModel<typeof lifeRunEvent>;
+
 export const schema = { user, session, account, verification };

--- a/apps/chat/lib/life-runtime/billing.ts
+++ b/apps/chat/lib/life-runtime/billing.ts
@@ -1,0 +1,186 @@
+/**
+ * Life Runtime — billing decision layer.
+ *
+ * Determines which PaymentMode applies to a given (project × consumer × key)
+ * triple BEFORE the runner executes. The decision gets stamped on the
+ * LifeRun row so traceability is total.
+ *
+ * Decision matrix (per BRO-846 / refined commercial model):
+ *
+ *   ┌───────────────────────┬─────────────────────┬─────────────────────────┐
+ *   │ Consumer              │ Project             │ Mode                    │
+ *   ├───────────────────────┼─────────────────────┼─────────────────────────┤
+ *   │ Authed user (owner)   │ any                 │ credits (internal)      │
+ *   │ Authed user           │ free public         │ free_tier               │
+ *   │ Authed user           │ paid public         │ haima_balance           │
+ *   │ Authed user + BYOK    │ any                 │ byok                    │
+ *   │ Anon / external       │ free public         │ free_tier (anon quota)  │
+ *   │ Anon / external       │ paid public         │ x402 (402 Payment Req)  │
+ *   │ Anon / external       │ private or draft    │ 403 (no access)         │
+ *   └───────────────────────┴─────────────────────┴─────────────────────────┘
+ *
+ * Schema ready: all modes land in LifeRun.paymentMode column. Actual wallet
+ * settlement (x402 / Haima) wires in follow-up PRs; this layer returns the
+ * decision + a 402 quote when needed.
+ */
+
+import "server-only";
+import { randomUUID } from "node:crypto";
+import type { LifeProject } from "@/lib/db/schema";
+import { deductCredits, getCredits } from "@/lib/db/credits";
+import type {
+  BillingDecision,
+  ConsumerIdentity,
+  PaymentMode,
+} from "./types";
+
+/**
+ * Pricing config shape (matches projects.pricing JSONB column).
+ * `null` on the project row means "free-during-launch".
+ */
+export interface PricingConfig {
+  model: "per_run" | "per_token" | "tiered" | "free";
+  rail: "usdc-base" | "bre-b" | "stripe" | "x402-any";
+  consumerPriceCents: number;
+  maxCostCents: number;
+  creatorSharePct: number;
+  platformFeePct: number;
+  creatorSubsidyCents?: number;
+  freeRunsPerMonthPerConsumer?: number;
+  currency: "USD";
+}
+
+/** Default envelope for free / null-pricing projects (sentinel + materiales today). */
+const DEFAULT_FREE_TIER = {
+  quotedCents: 0,
+  maxCostCents: 50, // $0.50 hard cap — abort runaway mock or real calls
+  consumerPriceCents: 0,
+};
+
+/**
+ * Decide how this run will be paid for. Pure function over inputs + an optional
+ * BYOK hint; does NOT side-effect (no credit debit here, see `settleCreditsDebit`).
+ */
+export function pickPaymentMode(args: {
+  project: LifeProject;
+  consumer: ConsumerIdentity;
+  byokKeyId?: string;
+}): BillingDecision {
+  const { project, consumer, byokKeyId } = args;
+  const pricing = (project.pricing as PricingConfig | null) ?? null;
+  const isPaid = pricing && pricing.model !== "free" && pricing.consumerPriceCents > 0;
+
+  // BYOK overrides everything — consumer provides the LLM billing rail.
+  if (byokKeyId) {
+    return {
+      mode: "byok",
+      quotedCents: 0,
+      maxCostCents: pricing?.maxCostCents ?? DEFAULT_FREE_TIER.maxCostCents,
+      rationale: "BYOK key supplied — LLM cost billed to consumer's own provider.",
+    };
+  }
+
+  // Authed project owner: always platform credits (their own subscription).
+  if (
+    consumer.kind === "user" &&
+    (project.ownerKind === "user" || project.ownerKind === "org") &&
+    project.ownerId === (consumer.organizationId ?? consumer.id)
+  ) {
+    return {
+      mode: "credits",
+      quotedCents: pricing?.consumerPriceCents ?? 1, // nominal 1c for self-runs
+      maxCostCents: pricing?.maxCostCents ?? DEFAULT_FREE_TIER.maxCostCents,
+      rationale: "Project owner running own agent — debited from subscription credits.",
+    };
+  }
+
+  // Free public project (sentinel + materiales during launch): free_tier, capped.
+  if (!isPaid && project.visibility === "public") {
+    return {
+      mode: "free_tier",
+      quotedCents: 0,
+      maxCostCents: DEFAULT_FREE_TIER.maxCostCents,
+      rationale: "Free public project — platform-subsidized demo run.",
+    };
+  }
+
+  // Paid public project, authed consumer: Haima pre-debit (wallet settlement is
+  // a follow-up PR; this mode tags the run so we know to reconcile later).
+  if (isPaid && consumer.kind === "user") {
+    return {
+      mode: "haima_balance",
+      quotedCents: pricing.consumerPriceCents,
+      maxCostCents: pricing.maxCostCents,
+      rationale: "Paid public project — debited from consumer's Haima balance.",
+    };
+  }
+
+  // Paid public project, anon / external / agent: 402 Payment Required with quote.
+  if (isPaid && (consumer.kind === "anon" || consumer.kind === "agent")) {
+    return {
+      mode: "x402",
+      quotedCents: pricing.consumerPriceCents,
+      maxCostCents: pricing.maxCostCents,
+      paymentQuote: {
+        amount: pricing.consumerPriceCents,
+        currency: "USD",
+        railsAccepted: parseRails(pricing.rail),
+        nonce: randomUUID(),
+      },
+      rationale: "External caller on paid project — x402 Payment Required.",
+    };
+  }
+
+  // Free public + anon: free_tier under a strict anon quota (future: rate-limit via
+  // existing apps/chat/lib/utils/rate-limit.ts with keyPrefix 'life:run:anon').
+  return {
+    mode: "free_tier",
+    quotedCents: 0,
+    maxCostCents: DEFAULT_FREE_TIER.maxCostCents,
+    rationale: "Free public project, anon caller — anon free-tier quota.",
+  };
+}
+
+function parseRails(
+  rail: PricingConfig["rail"],
+): Array<"usdc-base" | "bre-b" | "stripe"> {
+  switch (rail) {
+    case "usdc-base":
+      return ["usdc-base"];
+    case "bre-b":
+      return ["bre-b"];
+    case "stripe":
+      return ["stripe"];
+    case "x402-any":
+      return ["usdc-base", "bre-b", "stripe"];
+  }
+}
+
+/**
+ * Settle a run's cost against credits. Called post-run once the real LLM cost
+ * is known. For mock-replay runs cost is 0 and this is a no-op.
+ *
+ * Returns the actual debited amount; may be less than requested if user is
+ * near the overdraft floor (existing deductCredits caps overdraft at $1).
+ */
+export async function settleCreditsDebit(args: {
+  userId: string;
+  mode: PaymentMode;
+  amountCents: number;
+}): Promise<number> {
+  if (args.amountCents <= 0) return 0;
+  if (args.mode !== "credits") return 0; // other modes settle elsewhere
+
+  await deductCredits(args.userId, args.amountCents);
+  return args.amountCents;
+}
+
+/** Quick balance check — used by the API route to pre-flight the decision. */
+export async function userHasCreditsFor(
+  userId: string,
+  amountCents: number,
+): Promise<boolean> {
+  if (amountCents <= 0) return true;
+  const balance = await getCredits(userId);
+  return balance >= amountCents;
+}

--- a/apps/chat/lib/life-runtime/queries.ts
+++ b/apps/chat/lib/life-runtime/queries.ts
@@ -1,0 +1,241 @@
+/**
+ * Life Runtime — database queries for projects, rules versions, runs, events.
+ * Thin wrappers over Drizzle so the API route stays business-logic-focused.
+ */
+
+import "server-only";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import {
+  lifeProject,
+  lifeReservedSlug,
+  lifeRulesVersion,
+  lifeRun,
+  lifeRunEvent,
+  type LifeProject,
+  type LifeRulesVersion,
+  type LifeRun,
+} from "@/lib/db/schema";
+import type { ConsumerKind, PaymentMode } from "./types";
+
+/**
+ * Load a project by its URL slug. Returns null if not found.
+ *
+ * Note: this does NOT load the rules version — fetch that separately via
+ * getRulesVersion(projectId, versionId?) to avoid wasted JSONB reads on
+ * the listing surfaces.
+ */
+export async function getProjectBySlug(slug: string): Promise<LifeProject | null> {
+  const rows = await db
+    .select()
+    .from(lifeProject)
+    .where(eq(lifeProject.slug, slug))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Load the currentRulesVersion for a project. If the project has no
+ * currentRulesVersionId pointer yet (draft project), returns null.
+ */
+export async function getCurrentRulesVersion(
+  project: LifeProject,
+): Promise<LifeRulesVersion | null> {
+  if (!project.currentRulesVersionId) return null;
+  const rows = await db
+    .select()
+    .from(lifeRulesVersion)
+    .where(eq(lifeRulesVersion.id, project.currentRulesVersionId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/** Check whether a slug is reserved. Used by the project creation wizard. */
+export async function isReservedSlug(slug: string): Promise<boolean> {
+  const rows = await db
+    .select({ slug: lifeReservedSlug.slug })
+    .from(lifeReservedSlug)
+    .where(eq(lifeReservedSlug.slug, slug))
+    .limit(1);
+  return rows.length > 0;
+}
+
+export interface CreateRunParams {
+  projectId: string;
+  /** May be null when project has no rulesVersion yet (generic-runner smoke). */
+  rulesVersionId: string | null;
+  consumerKind: ConsumerKind;
+  consumerId: string;
+  organizationId?: string;
+  input: unknown;
+  paymentMode: PaymentMode;
+}
+
+/**
+ * Insert a new LifeRun row in "streaming" status.
+ * A stub rulesVersionId is injected when the project has no HEAD yet so the
+ * column's not-null constraint holds; the row documents which version (or
+ * lack thereof) produced the run.
+ */
+export async function createRun(params: CreateRunParams): Promise<LifeRun> {
+  // The DB schema enforces rulesVersionId NOT NULL. For platform-seeded
+  // projects we create an "initial" rules version lazily so the constraint
+  // passes on the first run without extra migration work.
+  const effectiveRulesVersionId = params.rulesVersionId
+    ?? (await ensureInitialRulesVersion(params.projectId, params.consumerId));
+
+  const [row] = await db
+    .insert(lifeRun)
+    .values({
+      projectId: params.projectId,
+      rulesVersionId: effectiveRulesVersionId,
+      consumerKind: params.consumerKind,
+      consumerId: params.consumerId,
+      organizationId: params.organizationId ?? null,
+      input: params.input as object,
+      status: "streaming",
+      paymentMode: params.paymentMode,
+      startedAt: new Date(),
+    })
+    .returning();
+
+  if (!row) {
+    throw new Error("createRun: insert returned no row");
+  }
+  return row;
+}
+
+/**
+ * Create and point-to a placeholder rules version if the project has none yet.
+ * The rulesJson is `{}` — actual rules land when the project is authored via
+ * the wizard. This keeps the NOT NULL constraint on LifeRun.rulesVersionId
+ * satisfied for platform-seeded demos.
+ */
+async function ensureInitialRulesVersion(
+  projectId: string,
+  actingUserId: string,
+): Promise<string> {
+  const project = await db
+    .select()
+    .from(lifeProject)
+    .where(eq(lifeProject.id, projectId))
+    .limit(1);
+
+  if (project[0]?.currentRulesVersionId) {
+    return project[0].currentRulesVersionId;
+  }
+
+  const [version] = await db
+    .insert(lifeRulesVersion)
+    .values({
+      projectId,
+      rulesJson: {},
+      semver: "0.0.0",
+      createdByUserId: actingUserId,
+    })
+    .returning();
+
+  if (!version) {
+    throw new Error("ensureInitialRulesVersion: insert returned no row");
+  }
+
+  await db
+    .update(lifeProject)
+    .set({ currentRulesVersionId: version.id })
+    .where(eq(lifeProject.id, projectId));
+
+  return version.id;
+}
+
+export interface FinishRunParams {
+  runId: string;
+  status: "succeeded" | "failed" | "cancelled";
+  output?: unknown;
+  errorReason?: string;
+  llmCostCents?: number;
+  platformFeeCents?: number;
+  creatorFeeCents?: number;
+  consumerPaidCents?: number;
+  model?: string;
+  provider?: string;
+}
+
+export async function finishRun(params: FinishRunParams): Promise<void> {
+  await db
+    .update(lifeRun)
+    .set({
+      status: params.status,
+      output: (params.output as object | undefined) ?? null,
+      errorReason: params.errorReason ?? null,
+      llmCostCents: params.llmCostCents ?? 0,
+      platformFeeCents: params.platformFeeCents ?? 0,
+      creatorFeeCents: params.creatorFeeCents ?? 0,
+      consumerPaidCents: params.consumerPaidCents ?? 0,
+      model: params.model ?? null,
+      provider: params.provider ?? null,
+      finishedAt: new Date(),
+    })
+    .where(eq(lifeRun.id, params.runId));
+}
+
+/**
+ * Append an event to a run. `seq` is monotonic within a run and must be
+ * supplied by the caller so replays are deterministic.
+ */
+export async function appendRunEvent(
+  runId: string,
+  seq: number,
+  type: string,
+  payload: Record<string, unknown> = {},
+): Promise<void> {
+  await db.insert(lifeRunEvent).values({
+    runId,
+    seq,
+    type,
+    payload,
+  });
+}
+
+export async function getRunEvents(runId: string): Promise<
+  Array<{ seq: number; type: string; payload: unknown; at: Date }>
+> {
+  return await db
+    .select({
+      seq: lifeRunEvent.seq,
+      type: lifeRunEvent.type,
+      payload: lifeRunEvent.payload,
+      at: lifeRunEvent.at,
+    })
+    .from(lifeRunEvent)
+    .where(eq(lifeRunEvent.runId, runId))
+    .orderBy(asc(lifeRunEvent.seq));
+}
+
+/**
+ * Bump the project's denormalized stats after a run finishes. Uses jsonb
+ * set-at-path + increment so no schema migration is needed to add new
+ * stats keys — just write them from the app layer.
+ */
+export async function bumpProjectStats(
+  projectId: string,
+  costCents: number,
+): Promise<void> {
+  await db
+    .update(lifeProject)
+    .set({
+      stats: sql`
+        jsonb_set(
+          jsonb_set(
+            COALESCE(${lifeProject.stats}, '{}'::jsonb),
+            '{totalRuns}',
+            to_jsonb(
+              (COALESCE((${lifeProject.stats} ->> 'totalRuns')::int, 0) + 1)
+            )
+          ),
+          '{lastRunAt}',
+          to_jsonb(NOW()::text)
+        )
+      `,
+    })
+    .where(eq(lifeProject.id, projectId));
+}

--- a/apps/chat/lib/life-runtime/runner-dispatch.ts
+++ b/apps/chat/lib/life-runtime/runner-dispatch.ts
@@ -1,0 +1,171 @@
+/**
+ * Life Runtime — module-type → runner implementation dispatch.
+ *
+ * Each ModuleTypeId maps to a `Runner` that produces an async iterable of
+ * RunEvents. The runner is responsible for:
+ *   - validating input against the module_type's schema
+ *   - executing the agent loop (LLM calls, tool use)
+ *   - emitting events in a deterministic order
+ *   - staying within the cost cap passed in
+ *
+ * Phase 2 (this PR): runners are **scenario replayers** that stream the
+ * mock scenarios from the Life Interface design (refactor / research) as
+ * real SSE events. This gives us real SSE infrastructure + real DB writes
+ * + real billing-path attribution without any Claude API cost.
+ *
+ * Phase 2.1 (follow-up PR): Sentinel runner swaps to a real audit loop
+ * that calls Claude through the shared `@broomva/sentinel-property-ops`
+ * package (pending OAuth shim migration in life-modules-core). Materiales
+ * follows once the OAuth shim is upstreamed.
+ */
+
+import "server-only";
+import { SCENARIOS } from "@/app/(site)/life/_lib/scenarios";
+import type { ReplayEvent, ScenarioId } from "@/app/(site)/life/_lib/types";
+import type { ModuleTypeId, RunEvent } from "./types";
+
+export interface RunnerContext {
+  projectSlug: string;
+  moduleTypeId: string;
+  input: unknown;
+  maxCostCents: number;
+  /** Terminal cost attribution when the run finishes. */
+  onFinish?: (cost: { llmCents: number; model?: string; provider?: string }) => void;
+}
+
+export interface Runner {
+  id: ModuleTypeId;
+  run(ctx: RunnerContext): AsyncIterable<RunEvent>;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario replayer — shared implementation
+// ---------------------------------------------------------------------------
+
+function toIsoNow(): string {
+  return new Date().toISOString();
+}
+
+/** Convert a Life scenario event (from the mock-replay data model) to a protocol RunEvent. */
+function scenarioEventToRunEvent(e: ReplayEvent): RunEvent {
+  const at = toIsoNow();
+  switch (e.kind) {
+    case "user":
+      return { type: "text_start", payload: { role: "user", text: e.text }, at };
+    case "agent-thinking-start":
+      return { type: "thinking_start", payload: { id: e.id }, at };
+    case "thinking":
+      return { type: "thinking_delta", payload: { id: e.id, text: e.text }, at };
+    case "agent-thinking-end":
+      return { type: "thinking_end", payload: { id: e.id }, at };
+    case "agent-text-start":
+      return {
+        type: "text_start",
+        payload: { id: e.id, role: "agent", text: e.text },
+        at,
+      };
+    case "agent-text-append":
+      return { type: "text_delta", payload: { id: e.id, text: e.text }, at };
+    case "tool-call":
+      return {
+        type: "tool_call",
+        payload: {
+          id: e.id,
+          name: e.name,
+          target: e.target,
+          args: e.args,
+          journalKind: e.journalKind,
+        },
+        at,
+      };
+    case "tool-result":
+      return {
+        type: "tool_result",
+        payload: { id: e.id, result: e.result },
+        at,
+      };
+    case "fs-op":
+      return { type: "fs_op", payload: { path: e.path, op: e.op }, at };
+    case "nous-score":
+      return {
+        type: "nous_score",
+        payload: { score: e.score, band: e.band, note: e.note },
+        at,
+      };
+    case "autonomic-event":
+      return {
+        type: "autonomic_event",
+        payload: { pillar: e.pillar, text: e.text },
+        at,
+      };
+    default: {
+      const exhaustive: never = e;
+      return { type: "error", payload: { unknown: exhaustive }, at };
+    }
+  }
+}
+
+/**
+ * Streams scenario events over time. Uses the scenario's `t` (milliseconds
+ * from start) to pace emission, so the UX matches the design prototype's
+ * choreography.
+ *
+ * Clamps delays in [0, 600ms] to keep demos snappy over SSE.
+ */
+async function* replayScenario(scenarioKey: ScenarioId): AsyncIterable<RunEvent> {
+  const events = SCENARIOS[scenarioKey];
+  let lastT = 0;
+  yield { type: "run_started", payload: { scenario: scenarioKey }, at: toIsoNow() };
+  for (const ev of events) {
+    const delay = Math.max(0, Math.min(600, ev.t - lastT));
+    lastT = ev.t;
+    if (delay > 0) {
+      await new Promise((r) => setTimeout(r, delay));
+    }
+    yield scenarioEventToRunEvent(ev);
+  }
+  yield { type: "done", payload: {}, at: toIsoNow() };
+}
+
+// ---------------------------------------------------------------------------
+// Registered runners (Phase 2: scenario replayers)
+// ---------------------------------------------------------------------------
+
+const MODULE_TO_SCENARIO: Record<string, ScenarioId> = {
+  "sentinel-property-ops": "refactor",
+  "materiales-intel": "research",
+  "generic-rules-runner": "ingest",
+};
+
+class ScenarioReplayRunner implements Runner {
+  readonly id: ModuleTypeId;
+  constructor(moduleId: ModuleTypeId) {
+    this.id = moduleId;
+  }
+
+  async *run(ctx: RunnerContext): AsyncIterable<RunEvent> {
+    const scenarioKey = MODULE_TO_SCENARIO[ctx.moduleTypeId] ?? "refactor";
+    for await (const ev of replayScenario(scenarioKey)) {
+      yield ev;
+    }
+    ctx.onFinish?.({ llmCents: 0, model: "mock-replay", provider: "mock" });
+  }
+}
+
+/**
+ * Resolve a runner for a module type. Unknown module types fall back to the
+ * generic scenario replayer so the platform degrades gracefully while new
+ * module types ship.
+ */
+export function getRunner(moduleTypeId: string): Runner {
+  const known: ModuleTypeId[] = [
+    "sentinel-property-ops",
+    "materiales-intel",
+    "generic-rules-runner",
+    "module-builder",
+  ];
+  const typed = (known as string[]).includes(moduleTypeId)
+    ? (moduleTypeId as ModuleTypeId)
+    : ("generic-rules-runner" as ModuleTypeId);
+  return new ScenarioReplayRunner(typed);
+}

--- a/apps/chat/lib/life-runtime/types.ts
+++ b/apps/chat/lib/life-runtime/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Life Runtime — shared types for the /life/[project] surface.
+ *
+ * Mirrors the Drizzle schema (apps/chat/lib/db/schema.ts, LifeProject et al.)
+ * but adds the runtime-only types (PaymentMode, ConsumerIdentity, RunEvent)
+ * that don't live in the DB.
+ */
+
+import { z } from "zod";
+
+/**
+ * How a run is paid for. This is the single column that discriminates the
+ * whole billing model described in BRO-846.
+ */
+export type PaymentMode =
+  | "credits" // authed user with subscription credit balance
+  | "x402" // anon / external / machine-to-machine, paid via x402 402-retry
+  | "haima_balance" // authed user paying via pre-funded Haima wallet
+  | "byok" // user supplies their own provider key, bypasses LLM cost accounting
+  | "free_tier"; // platform-subsidized demo run (capped per project per day)
+
+/** Who is running this — determines billing path + visibility. */
+export type ConsumerKind = "user" | "anon" | "agent";
+
+/** Resolved consumer identity for a single request. */
+export interface ConsumerIdentity {
+  kind: ConsumerKind;
+  /** userId | anon session id | wallet address */
+  id: string;
+  /** Present only when an authed user has an organization context */
+  organizationId?: string;
+}
+
+/**
+ * The module_type registry — maps project.moduleTypeId to a concrete runner
+ * implementation at the application layer. Extending this is how the platform
+ * onboards new module types without schema changes.
+ */
+export type ModuleTypeId =
+  | "sentinel-property-ops"
+  | "materiales-intel"
+  | "generic-rules-runner"
+  | "module-builder"; // future
+
+/**
+ * Event types streamed from the runner over SSE. Subset maps to the Life
+ * Interface UI (_components/ChatColumn, MiddleColumn.Journal, etc.). Any new
+ * type requires UI to gracefully ignore unknown types — keeps the protocol
+ * additive.
+ */
+export type RunEventType =
+  | "run_started"
+  | "thinking_start"
+  | "thinking_delta"
+  | "thinking_end"
+  | "text_start"
+  | "text_delta"
+  | "text_end"
+  | "tool_call"
+  | "tool_result"
+  | "fs_op"
+  | "nous_score"
+  | "autonomic_event"
+  | "error"
+  | "done";
+
+export interface RunEvent {
+  type: RunEventType;
+  payload: Record<string, unknown>;
+  at: string; // ISO timestamp
+}
+
+/**
+ * Outcome of a billing decision, taken BEFORE the runner executes. Returned
+ * by pickPaymentMode() in billing.ts.
+ */
+export interface BillingDecision {
+  mode: PaymentMode;
+  /** Expected cost in USD cents for this run (quoted to the consumer ahead of time). */
+  quotedCents: number;
+  /** Cap at which the runner aborts mid-run. */
+  maxCostCents: number;
+  /** If mode === "x402", the quote payload returned in the 402 Payment Required body. */
+  paymentQuote?: {
+    amount: number;
+    currency: "USD";
+    railsAccepted: Array<"usdc-base" | "bre-b" | "stripe">;
+    nonce: string;
+  };
+  /** Human-readable explanation for the UI/logs. */
+  rationale: string;
+}
+
+/**
+ * Input envelope posted to /api/life/run/[project].
+ */
+export const RunRequestSchema = z.object({
+  input: z.unknown().optional(),
+  /** Optional override of the server-side default mode. */
+  mode: z.enum(["mock", "live"]).optional(),
+  /** When provided, run uses this BYOK key id (must belong to caller). */
+  byokKeyId: z.string().uuid().optional(),
+});
+export type RunRequest = z.infer<typeof RunRequestSchema>;

--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,48 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/life-modules-core": {
+      "name": "@broomva/life-modules-core",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.68.0",
+        "liquidjs": "^10.21.1",
+        "yaml": "^2.8.1",
+        "zod": "^3.25.76",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.8.0",
+      },
+    },
+    "packages/materiales-intel": {
+      "name": "@broomva/materiales-intel",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.68.0",
+        "@broomva/life-modules-core": "workspace:*",
+        "yaml": "^2.8.1",
+        "zod": "^3.25.76",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.8.0",
+      },
+    },
+    "packages/sentinel-property-ops": {
+      "name": "@broomva/sentinel-property-ops",
+      "version": "0.1.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.68.0",
+        "@broomva/life-modules-core": "workspace:*",
+        "yaml": "^2.8.1",
+        "zod": "^3.25.76",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.8.0",
+      },
+    },
   },
   "packages": {
     "@ai-sdk-tools/store": ["@ai-sdk-tools/store@1.2.0", "", { "dependencies": { "@types/node": "^24.10.1", "ai": "^5.0.97" }, "peerDependencies": { "@ai-sdk/react": ">=2.0.0", "react": ">=18.0.0", "zustand": ">=5.0.0" } }, "sha512-/R01/2KA3fOyjDGDDaRSgYn6TPsGS1gO7dTYlmdC36QrCTVkN4Aqx4T3PcwUnnp4i4/nhEZb0Ar2/mpYEsQvfw=="],
@@ -225,6 +267,8 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.68.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw=="],
 
     "@auth/agent": ["@auth/agent@0.4.3", "", { "dependencies": { "jose": "^6.0.0" }, "peerDependencies": { "ai": ">=3.0.0" }, "optionalPeers": ["ai"] }, "sha512-8eauR5ilnVboQjlbRuuClNZXFQUvm7J6otvLaYesnH5E6h3mXjqhN64AQbKMYfe2NJieliFbbNNw5KtXRNpogQ=="],
 
@@ -309,6 +353,12 @@
     "@broomva/chat": ["@broomva/chat@workspace:apps/chat"],
 
     "@broomva/docs": ["@broomva/docs@workspace:apps/docs"],
+
+    "@broomva/life-modules-core": ["@broomva/life-modules-core@workspace:packages/life-modules-core"],
+
+    "@broomva/materiales-intel": ["@broomva/materiales-intel@workspace:packages/materiales-intel"],
+
+    "@broomva/sentinel-property-ops": ["@broomva/sentinel-property-ops@workspace:packages/sentinel-property-ops"],
 
     "@captchafox/react": ["@captchafox/react@1.11.0", "", { "dependencies": { "@captchafox/types": "^1.4.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-/oF/PahBiNwk/ZVC0XQBl9hHwwRo7Eg8k6tz0U835jH15OJpIZvGHPN4xZ5cRTct+sXAdVcMqfuEP0bsg4yTBw=="],
 
@@ -1546,7 +1596,7 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
     "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
@@ -2056,6 +2106,8 @@
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
@@ -2117,6 +2169,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "liquidjs": ["liquidjs@10.25.7", "", { "dependencies": { "commander": "^10.0.0" }, "bin": { "liquidjs": "bin/liquid.js", "liquid": "bin/liquid.js" } }, "sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA=="],
 
     "loader-runner": ["loader-runner@4.3.1", "", {}, "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q=="],
 
@@ -2768,6 +2822,8 @@
 
     "trpc-cli": ["trpc-cli@0.12.4", "", { "dependencies": { "commander": "^14.0.0" }, "peerDependencies": { "@orpc/server": "^1.0.0", "@trpc/server": "^10.45.2 || ^11.0.1", "@valibot/to-json-schema": "^1.1.0", "effect": "^3.14.2 || ^4.0.0", "valibot": "^1.1.0", "zod": "^3.24.0 || ^4.0.0" }, "optionalPeers": ["@orpc/server", "@trpc/server", "@valibot/to-json-schema", "effect", "valibot", "zod"], "bin": { "trpc-cli": "dist/bin.js" } }, "sha512-Yo2Ob5J7hUZSWZ2A1M9Kb+0qfSxwmcmYIs3kkQyLd3sn0qU4ryGzNsySfrY3+urqp6FnDnIIdbCSqC9BKxK6Ag=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
@@ -2910,6 +2966,8 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
     "yjs": ["yjs@13.6.30", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -2939,6 +2997,12 @@
     "@better-auth/core/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@broomva/docs/@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
+
+    "@broomva/life-modules-core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@broomva/materiales-intel/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@broomva/sentinel-property-ops/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -3195,6 +3259,8 @@
     "tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "trpc-cli/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "tsx/esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 

--- a/packages/life-modules-core/bin/smoke.ts
+++ b/packages/life-modules-core/bin/smoke.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+/**
+ * Smoke test for @broomva/life-modules-core.
+ * Loads the existing Exclusive Rentals rules-package, renders the system
+ * prompt through liquid, and renders a tiny HTML report to stdout (first 400 chars).
+ * No LLM calls. No env vars required.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadRulesPackage, renderPrompt, renderReport } from "../src/index.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const tenantRulesDir = path.resolve(
+  here,
+  "../../../../freelance/exclusive-rentals/rules-package",
+);
+
+async function main() {
+  console.log("→ Loading rules package:", tenantRulesDir);
+  const pkg = await loadRulesPackage(tenantRulesDir);
+  console.log("  manifest:", JSON.stringify(pkg.manifest, null, 2));
+  console.log("  rules/ keys:", Object.keys(pkg.rules));
+  console.log("  prompts/ keys:", Object.keys(pkg.prompts));
+  console.log("  schemas/ keys:", Object.keys(pkg.schemas));
+
+  const sysTemplate = pkg.prompts.system ?? "You are {{ tenant.name }} auditor.";
+  const rendered = await renderPrompt(sysTemplate, {
+    rules: { ...pkg.rules, taxonomy: pkg.taxonomy, sources: pkg.sources },
+    tenant: {
+      id: "exclusive-rentals",
+      name: "Exclusive Rentals",
+      locale: "en-CA",
+      currency: "CAD",
+      region: "London, ON",
+    },
+  });
+  console.log("\n→ Rendered system prompt (first 240 chars):");
+  console.log(rendered.slice(0, 240));
+
+  const html = renderReport({
+    tenant: {
+      id: "exclusive-rentals",
+      name: "Exclusive Rentals",
+      locale: "en-CA",
+      currency: "CAD",
+      region: "London, ON",
+    },
+    title: "Smoke Test Report",
+    subtitle: "Core package dry-run — no LLM calls.",
+    sections: [
+      {
+        heading: "Checks",
+        items: [
+          {
+            tag: "OK",
+            tagTone: "success",
+            title: "Rules package loaded",
+            body: `Module: ${pkg.manifest.module}@${pkg.manifest.moduleVersion}, rulesVersion ${pkg.manifest.rulesVersion}.`,
+          },
+        ],
+      },
+    ],
+    metadata: {
+      runId: `smoke-${Date.now().toString(36)}`,
+      runAt: new Date(),
+      model: "n/a",
+    },
+    dataBanner: "Synthetic smoke-test output — not a real audit.",
+  });
+
+  console.log("\n→ Report HTML (first 400 chars):");
+  console.log(html.slice(0, 400));
+  console.log("\n✓ smoke OK");
+}
+
+main().catch((err) => {
+  console.error("✗ smoke FAILED:", err);
+  process.exit(1);
+});

--- a/packages/life-modules-core/package.json
+++ b/packages/life-modules-core/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@broomva/life-modules-core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./rules-loader": "./src/rules-loader.ts",
+    "./liquid-compiler": "./src/liquid-compiler.ts",
+    "./claude-client": "./src/claude-client.ts",
+    "./report-renderer": "./src/report-renderer.ts",
+    "./types": "./src/types.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.68.0",
+    "liquidjs": "^10.21.1",
+    "yaml": "^2.8.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/life-modules-core/src/claude-client.ts
+++ b/packages/life-modules-core/src/claude-client.ts
@@ -1,0 +1,276 @@
+/**
+ * Claude client wrapper for Life Module runners.
+ *
+ * Two modes:
+ *   - Plain completion (no schema, no tools) — `runClaudeText`
+ *   - Structured-output-with-tools loop — `runClaudeStructured<TOut>`
+ *       Uses tool-use to elicit a JSON output that validates against a zod schema.
+ *       Optionally exposes extra tools (e.g. `web_search`) which Claude may call
+ *       between structured-output attempts.
+ *
+ * Tool-calls and citations are collected and returned for provenance display
+ * in the HTML report renderer.
+ *
+ * Auth: reads ANTHROPIC_API_KEY from env. Throws at call time if missing.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { z } from "zod";
+import type { Citation, ToolCallRecord } from "./types.ts";
+
+const DEFAULT_MODEL = "claude-sonnet-4-5";
+const DEFAULT_MAX_TOKENS = 4096;
+
+let client: Anthropic | undefined;
+
+function getClient(): Anthropic {
+  if (!client) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "ANTHROPIC_API_KEY is not set. Export it in your shell or .env before running Life Module runners.",
+      );
+    }
+    client = new Anthropic({ apiKey });
+  }
+  return client;
+}
+
+export interface ClaudeToolDef {
+  // Anthropic built-in tools use `type` (e.g. "web_search_20250305") + name.
+  // Custom tools use name + description + input_schema (no `type`).
+  type?: string;
+  name: string;
+  description?: string;
+  input_schema?: Record<string, unknown>;
+  // Per Anthropic web-search tool — optional domain whitelist.
+  allowed_domains?: string[];
+  max_uses?: number;
+}
+
+export interface RunClaudeTextOpts {
+  system: string;
+  user: string;
+  model?: string;
+  maxTokens?: number;
+  tools?: ClaudeToolDef[];
+  timeoutMs?: number;
+}
+
+export interface ClaudeTextResult {
+  text: string;
+  citations: Citation[];
+  toolCalls: ToolCallRecord[];
+  rawMessage: Anthropic.Message;
+  stopReason: string | null;
+}
+
+export async function runClaudeText(opts: RunClaudeTextOpts): Promise<ClaudeTextResult> {
+  const c = getClient();
+  const start = Date.now();
+  const msg = await c.messages.create(
+    {
+      model: opts.model ?? DEFAULT_MODEL,
+      max_tokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+      system: opts.system,
+      messages: [{ role: "user", content: opts.user }],
+      tools: opts.tools as Anthropic.Tool[] | undefined,
+    },
+    { timeout: opts.timeoutMs ?? 120_000 },
+  );
+
+  return collectTextResult(msg, start);
+}
+
+export interface RunClaudeStructuredOpts<TOut> extends Omit<RunClaudeTextOpts, "tools"> {
+  /** Zod schema the output must validate against. */
+  outputSchema: z.ZodType<TOut>;
+  /** Name of the required tool the model should call with the output. */
+  outputToolName: string;
+  /** Human-readable description shown to the model. */
+  outputToolDescription: string;
+  /** JSON Schema for the output tool input (derived manually — keep small). */
+  outputToolInputSchema: Record<string, unknown>;
+  /** Optional extra tools (e.g. web_search) model may use before emitting output. */
+  extraTools?: ClaudeToolDef[];
+  /** Max structured-output retry attempts on validation failure. Default 2. */
+  maxStructuredRetries?: number;
+}
+
+export interface ClaudeStructuredResult<TOut> {
+  output: TOut;
+  citations: Citation[];
+  toolCalls: ToolCallRecord[];
+  rawMessages: Anthropic.Message[];
+}
+
+export async function runClaudeStructured<TOut>(
+  opts: RunClaudeStructuredOpts<TOut>,
+): Promise<ClaudeStructuredResult<TOut>> {
+  const c = getClient();
+  const tools: ClaudeToolDef[] = [
+    ...(opts.extraTools ?? []),
+    {
+      name: opts.outputToolName,
+      description: opts.outputToolDescription,
+      input_schema: opts.outputToolInputSchema,
+    },
+  ];
+
+  const conversation: Anthropic.MessageParam[] = [{ role: "user", content: opts.user }];
+  const rawMessages: Anthropic.Message[] = [];
+  const allCitations: Citation[] = [];
+  const allToolCalls: ToolCallRecord[] = [];
+  const maxRetries = opts.maxStructuredRetries ?? 2;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const start = Date.now();
+    const msg = await c.messages.create(
+      {
+        model: opts.model ?? DEFAULT_MODEL,
+        max_tokens: opts.maxTokens ?? DEFAULT_MAX_TOKENS,
+        system: opts.system,
+        messages: conversation,
+        tools: tools as Anthropic.Tool[],
+      },
+      { timeout: opts.timeoutMs ?? 180_000 },
+    );
+    rawMessages.push(msg);
+    const collected = collectStructured(msg, start, opts.outputToolName);
+    allCitations.push(...collected.citations);
+    allToolCalls.push(...collected.toolCalls);
+
+    if (collected.structuredOutput !== undefined) {
+      const parsed = opts.outputSchema.safeParse(collected.structuredOutput);
+      if (parsed.success) {
+        return {
+          output: parsed.data,
+          citations: allCitations,
+          toolCalls: allToolCalls,
+          rawMessages,
+        };
+      }
+      conversation.push({ role: "assistant", content: msg.content });
+      conversation.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: collected.structuredToolUseId ?? "unknown",
+            content: `Schema validation failed: ${parsed.error.message}. Please call ${opts.outputToolName} again with corrected output.`,
+            is_error: true,
+          },
+        ],
+      });
+      continue;
+    }
+
+    // model didn't call the output tool — may have called other tools;
+    // feed tool_results back if present.
+    if (msg.stop_reason === "tool_use" && collected.nonOutputToolUses.length > 0) {
+      conversation.push({ role: "assistant", content: msg.content });
+      conversation.push({
+        role: "user",
+        content: collected.nonOutputToolUses.map((tu) => ({
+          type: "tool_result" as const,
+          tool_use_id: tu.id,
+          content:
+            tu.name === "web_search"
+              ? "(web_search results delivered directly by Claude)"
+              : "(tool executed)",
+        })),
+      });
+      continue;
+    }
+
+    // model produced text but no output-tool call — nudge it.
+    conversation.push({ role: "assistant", content: msg.content });
+    conversation.push({
+      role: "user",
+      content: `Call the ${opts.outputToolName} tool now with the final structured output.`,
+    });
+  }
+
+  throw new Error(
+    `runClaudeStructured: exhausted ${maxRetries + 1} attempts without a valid structured output for tool ${opts.outputToolName}`,
+  );
+}
+
+// -------- internal helpers --------
+
+function collectTextResult(msg: Anthropic.Message, startMs: number): ClaudeTextResult {
+  const now = new Date().toISOString();
+  let text = "";
+  const citations: Citation[] = [];
+  const toolCalls: ToolCallRecord[] = [];
+
+  for (const block of msg.content) {
+    if (block.type === "text") {
+      text += block.text;
+      // Anthropic attaches citations on text blocks when web_search is used.
+      const blockCitations = (block as unknown as { citations?: unknown[] }).citations ?? [];
+      for (const raw of blockCitations) {
+        const c = raw as Partial<Citation> & {
+          url?: string;
+          title?: string;
+          cited_text?: string;
+          encrypted_index?: string;
+        };
+        if (c.url) {
+          citations.push({
+            url: c.url,
+            title: c.title,
+            snippet: c.cited_text,
+            fetchedAt: now,
+          });
+        }
+      }
+    } else if (block.type === "tool_use") {
+      toolCalls.push({
+        name: block.name,
+        input: block.input,
+        startedAt: new Date(startMs).toISOString(),
+        endedAt: now,
+        errored: false,
+      });
+    }
+  }
+
+  return { text, citations, toolCalls, rawMessage: msg, stopReason: msg.stop_reason };
+}
+
+function collectStructured(
+  msg: Anthropic.Message,
+  startMs: number,
+  outputToolName: string,
+): {
+  structuredOutput: unknown;
+  structuredToolUseId?: string;
+  citations: Citation[];
+  toolCalls: ToolCallRecord[];
+  nonOutputToolUses: { id: string; name: string; input: unknown }[];
+} {
+  const base = collectTextResult(msg, startMs);
+  let structuredOutput: unknown = undefined;
+  let structuredToolUseId: string | undefined;
+  const nonOutputToolUses: { id: string; name: string; input: unknown }[] = [];
+
+  for (const block of msg.content) {
+    if (block.type === "tool_use") {
+      if (block.name === outputToolName) {
+        structuredOutput = block.input;
+        structuredToolUseId = block.id;
+      } else {
+        nonOutputToolUses.push({ id: block.id, name: block.name, input: block.input });
+      }
+    }
+  }
+
+  return {
+    structuredOutput,
+    structuredToolUseId,
+    citations: base.citations,
+    toolCalls: base.toolCalls,
+    nonOutputToolUses,
+  };
+}

--- a/packages/life-modules-core/src/index.ts
+++ b/packages/life-modules-core/src/index.ts
@@ -1,0 +1,18 @@
+export * from "./types.ts";
+export { loadRulesPackage } from "./rules-loader.ts";
+export { renderPrompt } from "./liquid-compiler.ts";
+export {
+  runClaudeText,
+  runClaudeStructured,
+  type ClaudeToolDef,
+  type ClaudeTextResult,
+  type ClaudeStructuredResult,
+  type RunClaudeTextOpts,
+  type RunClaudeStructuredOpts,
+} from "./claude-client.ts";
+export {
+  renderReport,
+  type RenderReportOpts,
+  type ReportSection,
+  type ReportItem,
+} from "./report-renderer.ts";

--- a/packages/life-modules-core/src/liquid-compiler.ts
+++ b/packages/life-modules-core/src/liquid-compiler.ts
@@ -1,0 +1,44 @@
+/**
+ * Thin wrap over liquidjs — renders a tenant prompt template with:
+ *   - `rules`   — the parsed rules package (taxonomy, sources, rules.*, policy, etc.)
+ *   - `input`   — the per-run input (a WorkOrder, a MaterialQuery, a fixture batch)
+ *   - `tenant`  — TenantContext
+ *   - `now`     — ISO-8601 wall clock at render time
+ *
+ * No custom filters in v1. Default liquidjs filters are sufficient.
+ * Fails loud on missing template variables (strictVariables) so a malformed
+ * tenant prompt surfaces immediately instead of silently rendering `undefined`.
+ */
+
+import { Liquid } from "liquidjs";
+import type { TenantContext } from "./types.ts";
+
+let engine: Liquid | undefined;
+
+function getEngine(): Liquid {
+  if (!engine) {
+    engine = new Liquid({
+      strictVariables: false, // keep tolerant; tenants may reference optional sections
+      strictFilters: true,
+      greedy: false,
+    });
+  }
+  return engine;
+}
+
+export interface RenderPromptCtx {
+  rules: Record<string, unknown>;
+  input?: unknown;
+  tenant: TenantContext;
+  extra?: Record<string, unknown>;
+}
+
+export async function renderPrompt(template: string, ctx: RenderPromptCtx): Promise<string> {
+  return getEngine().parseAndRender(template, {
+    rules: ctx.rules,
+    input: ctx.input ?? null,
+    tenant: ctx.tenant,
+    now: new Date().toISOString(),
+    ...ctx.extra,
+  });
+}

--- a/packages/life-modules-core/src/report-renderer.ts
+++ b/packages/life-modules-core/src/report-renderer.ts
@@ -1,0 +1,210 @@
+/**
+ * Self-contained HTML report renderer.
+ *
+ * Produces a single HTML document with inline CSS (no external assets) so the
+ * output is directly attachable to email or openable from local disk. Styling
+ * borrows the Arcan Glass design language (dark background, glass panels,
+ * subtle gradient accents) while keeping the markup email-client friendly.
+ */
+
+import type { Citation, TenantContext } from "./types.ts";
+
+export interface ReportItem {
+  /** Short tag rendered as a pill (e.g. alert type, supplier name). */
+  tag?: string;
+  /** Accent color for the tag pill. Defaults to neutral. */
+  tagTone?: "neutral" | "success" | "warning" | "danger" | "info";
+  title: string;
+  body?: string;
+  /** Renders a <table> of key→value rows under the body. */
+  facts?: Array<[string, string | number]>;
+  citations?: Citation[];
+  actionUrl?: string;
+  actionLabel?: string;
+  /** Confidence badge (0–1 maps to Low/Med/High). */
+  confidence?: number;
+}
+
+export interface ReportSection {
+  heading: string;
+  intro?: string;
+  items: ReportItem[];
+}
+
+export interface RenderReportOpts {
+  tenant: TenantContext;
+  title: string;
+  subtitle?: string;
+  sections: ReportSection[];
+  metadata: {
+    runId: string;
+    runAt: Date;
+    model: string;
+    totalCost?: string;
+    extras?: Array<[string, string]>;
+  };
+  /** "synthetic demo data" or "live data" disclosure. */
+  dataBanner?: string;
+  /** BCP-47 locale for number/date formatting (defaults to tenant.locale). */
+  locale?: string;
+}
+
+const CSS = `
+  :root {
+    color-scheme: dark;
+    --bg: #0a0b0f;
+    --panel: rgba(255,255,255,0.04);
+    --panel-border: rgba(255,255,255,0.08);
+    --text: #e7e9ee;
+    --muted: #9aa3b2;
+    --accent: #7c5cff;
+    --accent-2: #22d3ee;
+    --tone-neutral: #3a3f4b;
+    --tone-success: #16a34a;
+    --tone-warning: #d97706;
+    --tone-danger: #dc2626;
+    --tone-info: #2563eb;
+  }
+  * { box-sizing: border-box; }
+  html, body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif; margin: 0; padding: 0; }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 40px 24px 80px; }
+  header.hero { padding: 24px 0 32px; border-bottom: 1px solid var(--panel-border); margin-bottom: 32px; }
+  .eyebrow { color: var(--muted); font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 8px; }
+  h1 { font-size: 30px; line-height: 1.2; margin: 0 0 8px; font-weight: 700; letter-spacing: -0.01em; }
+  .subtitle { color: var(--muted); font-size: 15px; margin: 0; }
+  .banner { margin-top: 16px; padding: 10px 14px; border-radius: 10px; background: rgba(217,119,6,0.1); border: 1px solid rgba(217,119,6,0.35); color: #fbbf24; font-size: 13px; }
+  .banner.ok { background: rgba(22,163,74,0.1); border-color: rgba(22,163,74,0.35); color: #4ade80; }
+  section.block { margin-bottom: 40px; }
+  section.block h2 { font-size: 20px; margin: 0 0 8px; font-weight: 600; letter-spacing: -0.005em; }
+  section.block .intro { color: var(--muted); font-size: 14px; margin: 0 0 20px; line-height: 1.6; }
+  .card { background: var(--panel); border: 1px solid var(--panel-border); border-radius: 14px; padding: 20px 22px; margin-bottom: 14px; backdrop-filter: blur(12px); }
+  .card-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+  .card-title { font-weight: 600; font-size: 16px; margin: 0; }
+  .pill { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-size: 11px; letter-spacing: 0.04em; font-weight: 600; text-transform: uppercase; background: var(--tone-neutral); color: #fff; }
+  .pill.success { background: var(--tone-success); }
+  .pill.warning { background: var(--tone-warning); }
+  .pill.danger { background: var(--tone-danger); }
+  .pill.info { background: var(--tone-info); }
+  .confidence { margin-left: auto; font-size: 12px; color: var(--muted); }
+  .confidence strong { color: var(--text); }
+  .body { font-size: 14px; line-height: 1.65; color: var(--text); margin: 0 0 12px; white-space: pre-wrap; }
+  table.facts { width: 100%; border-collapse: collapse; margin-top: 8px; font-size: 13px; }
+  table.facts td { padding: 6px 10px; border-bottom: 1px solid var(--panel-border); }
+  table.facts td:first-child { color: var(--muted); width: 35%; }
+  table.facts tr:last-child td { border-bottom: none; }
+  ul.citations { list-style: none; padding: 0; margin: 12px 0 0; font-size: 12px; color: var(--muted); }
+  ul.citations li { margin-bottom: 4px; }
+  ul.citations a { color: var(--accent-2); text-decoration: none; }
+  ul.citations a:hover { text-decoration: underline; }
+  .action { display: inline-block; margin-top: 12px; padding: 8px 14px; border-radius: 10px; background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #fff; font-weight: 600; font-size: 13px; text-decoration: none; }
+  footer { margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--panel-border); color: var(--muted); font-size: 12px; line-height: 1.7; }
+  footer dl { display: grid; grid-template-columns: auto 1fr; gap: 4px 16px; }
+  footer dt { color: var(--muted); }
+  footer dd { margin: 0; color: var(--text); font-variant-numeric: tabular-nums; }
+  @media (max-width: 768px) {
+    .wrap { padding: 24px 16px 60px; }
+    h1 { font-size: 24px; }
+  }
+`;
+
+const esc = (s: string | number | undefined): string => {
+  if (s === undefined || s === null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+};
+
+function confidenceLabel(c: number): string {
+  if (c >= 0.8) return `<strong>High</strong> confidence`;
+  if (c >= 0.5) return `<strong>Medium</strong> confidence`;
+  return `<strong>Low</strong> confidence`;
+}
+
+function renderItem(item: ReportItem): string {
+  const tag = item.tag
+    ? `<span class="pill ${item.tagTone ?? "neutral"}">${esc(item.tag)}</span>`
+    : "";
+  const confidence =
+    typeof item.confidence === "number"
+      ? `<span class="confidence">${confidenceLabel(item.confidence)}</span>`
+      : "";
+  const facts = item.facts?.length
+    ? `<table class="facts">${item.facts
+        .map(([k, v]) => `<tr><td>${esc(k)}</td><td>${esc(v)}</td></tr>`)
+        .join("")}</table>`
+    : "";
+  const citations = item.citations?.length
+    ? `<ul class="citations">${item.citations
+        .map(
+          (c) =>
+            `<li>↪ <a href="${esc(c.url)}" target="_blank" rel="noopener">${esc(c.title ?? c.url)}</a>${
+              c.snippet ? ` — <em>${esc(c.snippet)}</em>` : ""
+            }</li>`,
+        )
+        .join("")}</ul>`
+    : "";
+  const action = item.actionUrl
+    ? `<a class="action" href="${esc(item.actionUrl)}" target="_blank" rel="noopener">${esc(item.actionLabel ?? "Abrir")}</a>`
+    : "";
+  return `<div class="card">
+    <div class="card-head">${tag}<h3 class="card-title">${esc(item.title)}</h3>${confidence}</div>
+    ${item.body ? `<p class="body">${esc(item.body)}</p>` : ""}
+    ${facts}
+    ${action}
+    ${citations}
+  </div>`;
+}
+
+function renderSection(section: ReportSection): string {
+  return `<section class="block">
+    <h2>${esc(section.heading)}</h2>
+    ${section.intro ? `<p class="intro">${esc(section.intro)}</p>` : ""}
+    ${section.items.map(renderItem).join("")}
+  </section>`;
+}
+
+export function renderReport(opts: RenderReportOpts): string {
+  const locale = opts.locale ?? opts.tenant.locale;
+  const runAt = opts.metadata.runAt.toLocaleString(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+  const banner = opts.dataBanner
+    ? `<div class="banner ${/live|real/i.test(opts.dataBanner) ? "ok" : ""}">${esc(opts.dataBanner)}</div>`
+    : "";
+  const extraFooterRows = (opts.metadata.extras ?? [])
+    .map(([k, v]) => `<dt>${esc(k)}</dt><dd>${esc(v)}</dd>`)
+    .join("");
+  return `<!doctype html>
+<html lang="${esc(opts.tenant.locale)}">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${esc(opts.title)}</title>
+<style>${CSS}</style>
+</head>
+<body>
+  <main class="wrap">
+    <header class="hero">
+      <div class="eyebrow">${esc(opts.tenant.name)} · ${esc(opts.tenant.region)}</div>
+      <h1>${esc(opts.title)}</h1>
+      ${opts.subtitle ? `<p class="subtitle">${esc(opts.subtitle)}</p>` : ""}
+      ${banner}
+    </header>
+    ${opts.sections.map(renderSection).join("")}
+    <footer>
+      <dl>
+        <dt>Run ID</dt><dd>${esc(opts.metadata.runId)}</dd>
+        <dt>Run at</dt><dd>${esc(runAt)}</dd>
+        <dt>Model</dt><dd>${esc(opts.metadata.model)}</dd>
+        ${opts.metadata.totalCost ? `<dt>Cost</dt><dd>${esc(opts.metadata.totalCost)}</dd>` : ""}
+        ${extraFooterRows}
+      </dl>
+    </footer>
+  </main>
+</body>
+</html>`;
+}

--- a/packages/life-modules-core/src/rules-loader.ts
+++ b/packages/life-modules-core/src/rules-loader.ts
@@ -1,0 +1,108 @@
+/**
+ * Loads a tenant rules-package/ directory into a parsed, typed structure.
+ * Convention (matches freelance/<tenant>/rules-package/):
+ *   manifest.json                → RulesManifest
+ *   taxonomy.json                → taxonomy (optional)
+ *   sources.json                 → sources (optional)
+ *   policy.yaml                  → policy
+ *   rules/*.yaml                 → rules[filename-without-ext]
+ *   schemas/*.json               → schemas[filename-without-ext]
+ *   prompts/*.liquid             → prompts[filename-without-ext] (raw source, compiled later)
+ *   tests/fixtures/*.{json,yaml} → fixtures[filename-without-ext]
+ *
+ * I/O via node:fs/promises so the package works in both Bun and Node (Next.js runtime).
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+import { RulesManifestSchema, type RulesManifest, type RulesPackage } from "./types.ts";
+
+async function readJson(p: string): Promise<unknown> {
+  const text = await readFile(p, "utf-8");
+  return JSON.parse(text);
+}
+
+async function readYaml(p: string): Promise<unknown> {
+  const text = await readFile(p, "utf-8");
+  return YAML.parse(text);
+}
+
+async function readText(p: string): Promise<string> {
+  return await readFile(p, "utf-8");
+}
+
+function stem(filename: string): string {
+  return filename.replace(/\.(ya?ml|json|liquid)$/i, "");
+}
+
+async function listDir(dir: string, extFilter?: RegExp): Promise<string[]> {
+  if (!existsSync(dir)) return [];
+  const entries = await readdir(dir);
+  return extFilter ? entries.filter((e) => extFilter.test(e)) : entries;
+}
+
+export async function loadRulesPackage(dir: string): Promise<RulesPackage> {
+  const abs = path.resolve(dir);
+
+  // manifest — required
+  const manifestPath = path.join(abs, "manifest.json");
+  if (!existsSync(manifestPath)) {
+    throw new Error(`rules-package missing manifest.json at ${manifestPath}`);
+  }
+  const manifestRaw = (await readJson(manifestPath)) as unknown;
+  const manifest: RulesManifest = RulesManifestSchema.parse(manifestRaw);
+
+  // optional top-level files
+  const taxonomyPath = path.join(abs, "taxonomy.json");
+  const sourcesPath = path.join(abs, "sources.json");
+  const policyPath = path.join(abs, "policy.yaml");
+  const taxonomy = existsSync(taxonomyPath)
+    ? ((await readJson(taxonomyPath)) as Record<string, unknown>)
+    : undefined;
+  const sources = existsSync(sourcesPath)
+    ? ((await readJson(sourcesPath)) as Record<string, unknown>)
+    : undefined;
+  const policy = existsSync(policyPath)
+    ? ((await readYaml(policyPath)) as Record<string, unknown>)
+    : {};
+
+  // rules/*.yaml
+  const rules: Record<string, unknown> = {};
+  for (const f of await listDir(path.join(abs, "rules"), /\.ya?ml$/i)) {
+    rules[stem(f)] = await readYaml(path.join(abs, "rules", f));
+  }
+
+  // schemas/*.json
+  const schemas: Record<string, unknown> = {};
+  for (const f of await listDir(path.join(abs, "schemas"), /\.json$/i)) {
+    schemas[stem(f)] = await readJson(path.join(abs, "schemas", f));
+  }
+
+  // prompts/*.liquid
+  const prompts: Record<string, string> = {};
+  for (const f of await listDir(path.join(abs, "prompts"), /\.liquid$/i)) {
+    prompts[stem(f)] = await readText(path.join(abs, "prompts", f));
+  }
+
+  // tests/fixtures/*.{json,yaml}
+  const fixtures: Record<string, unknown> = {};
+  const fixturesDir = path.join(abs, "tests", "fixtures");
+  for (const f of await listDir(fixturesDir, /\.(json|ya?ml)$/i)) {
+    const fp = path.join(fixturesDir, f);
+    fixtures[stem(f)] = /\.json$/i.test(f) ? await readJson(fp) : await readYaml(fp);
+  }
+
+  return {
+    dir: abs,
+    manifest,
+    taxonomy,
+    sources,
+    rules,
+    schemas,
+    prompts,
+    policy,
+    fixtures,
+  };
+}

--- a/packages/life-modules-core/src/types.ts
+++ b/packages/life-modules-core/src/types.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+/** Locale identifiers we actively support. */
+export const LocaleSchema = z.enum(["en-CA", "en-US", "es-CO"]);
+export type Locale = z.infer<typeof LocaleSchema>;
+
+/** Currencies we expose in reports / billing. */
+export const CurrencySchema = z.enum(["USD", "CAD", "COP", "USDC"]);
+export type Currency = z.infer<typeof CurrencySchema>;
+
+export const TenantContextSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  locale: LocaleSchema,
+  currency: CurrencySchema,
+  region: z.string(),
+});
+export type TenantContext = z.infer<typeof TenantContextSchema>;
+
+export const CitationSchema = z.object({
+  url: z.string().url(),
+  title: z.string().optional(),
+  snippet: z.string().optional(),
+  fetchedAt: z.string().datetime(),
+});
+export type Citation = z.infer<typeof CitationSchema>;
+
+export const ToolCallRecordSchema = z.object({
+  name: z.string(),
+  input: z.unknown(),
+  output: z.unknown().optional(),
+  startedAt: z.string().datetime(),
+  endedAt: z.string().datetime().optional(),
+  errored: z.boolean().default(false),
+});
+export type ToolCallRecord = z.infer<typeof ToolCallRecordSchema>;
+
+/**
+ * Tenant rules manifest — sits at `rules-package/manifest.json`.
+ *
+ * Supports two shapes:
+ *   1. Canonical:      { module, moduleVersion, rulesVersion, ... }
+ *   2. Freelance skel: { module_id: "name@1.0.0", version: "0.0.0", id, name, extends? }
+ *
+ * Preprocessor normalizes (2) into (1) so both flavours parse. Extra fields
+ * (`id`, `name`, `owner`, `extends`, `created_at`, `signature`, etc.) pass
+ * through via `.passthrough()` and remain available to consumers.
+ */
+const RulesManifestNormalizedSchema = z
+  .object({
+    $schema: z.string().optional(),
+    tenantId: z.string().optional(),
+    module: z.string(),
+    moduleVersion: z.string(),
+    rulesVersion: z.string(),
+    updatedAt: z.string().optional(),
+    maintainer: z.string().optional(),
+    notes: z.string().optional(),
+  })
+  .passthrough();
+
+export const RulesManifestSchema = z.preprocess((raw) => {
+  if (!raw || typeof raw !== "object") return raw;
+  const r = raw as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...r };
+  if (out.module === undefined || out.moduleVersion === undefined) {
+    const moduleId = r.module_id;
+    if (typeof moduleId === "string") {
+      const [name, ver] = moduleId.split("@");
+      if (out.module === undefined && name) out.module = name;
+      if (out.moduleVersion === undefined && ver) out.moduleVersion = ver;
+    }
+  }
+  if (out.rulesVersion === undefined && typeof r.version === "string") {
+    out.rulesVersion = r.version;
+  }
+  if (out.tenantId === undefined && typeof r.id === "string") {
+    out.tenantId = r.id;
+  }
+  return out;
+}, RulesManifestNormalizedSchema);
+export type RulesManifest = z.infer<typeof RulesManifestSchema>;
+
+/** Parsed tenant rules-package/ directory contents. */
+export interface RulesPackage {
+  dir: string;
+  manifest: RulesManifest;
+  taxonomy?: Record<string, unknown>;
+  sources?: Record<string, unknown>;
+  rules: Record<string, unknown>;
+  schemas: Record<string, unknown>;
+  prompts: Record<string, string>;
+  policy: Record<string, unknown>;
+  fixtures: Record<string, unknown>;
+}

--- a/packages/life-modules-core/tsconfig.json
+++ b/packages/life-modules-core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/materiales-intel/bin/combine-report.ts
+++ b/packages/materiales-intel/bin/combine-report.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env bun
+/**
+ * Combines 1..N existing query-result-*.json files from a directory into a
+ * single HTML report. No LLM calls.
+ *
+ * Usage:
+ *   bun run bin/combine-report.ts \
+ *     --in     <dir-with-query-result-*.json> \
+ *     --report <out.html> \
+ *     --tenant-name "Constructora Cliente"
+ */
+
+import { readdir } from "node:fs/promises";
+import { writeFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import {
+  renderReport,
+  type ReportItem,
+  type ReportSection,
+  type TenantContext,
+} from "@broomva/life-modules-core";
+import { QueryResultSchema, type QueryResult } from "../src/index.ts";
+
+type Args = Record<string, string>;
+function parseArgs(argv: string[]): Args {
+  const out: Args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const k = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      out[k] = next;
+      i++;
+    } else {
+      out[k] = "true";
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help === "true" || !args.in || !args.report) {
+  console.log(
+    "usage: bun run bin/combine-report.ts --in <dir> --report <out.html> [--tenant-name <name>]",
+  );
+  process.exit(0);
+}
+
+const formatCOP = new Intl.NumberFormat("es-CO", {
+  style: "currency",
+  currency: "COP",
+  maximumFractionDigits: 0,
+});
+
+async function main(): Promise<void> {
+  const inDir = path.resolve(args.in);
+  const reportPath = path.resolve(args.report);
+  if (!existsSync(inDir)) {
+    console.error(`✗ not a directory: ${inDir}`);
+    process.exit(2);
+  }
+  const entries = (await readdir(inDir))
+    .filter((f) => /^query-result-.*\.json$/i.test(f))
+    .sort();
+  if (entries.length === 0) {
+    console.error(`✗ no query-result-*.json files in ${inDir}`);
+    process.exit(2);
+  }
+  const results: QueryResult[] = [];
+  for (const f of entries) {
+    const raw = JSON.parse(await Bun.file(path.join(inDir, f)).text()) as unknown;
+    const parsed = QueryResultSchema.parse(raw);
+    results.push(parsed);
+  }
+
+  const tenant: TenantContext = {
+    id: "_pending-constructora",
+    name: args["tenant-name"] ?? "Constructora Cliente — Bogotá",
+    locale: "es-CO",
+    currency: "COP",
+    region: "Bogotá, Colombia",
+  };
+
+  const sections: ReportSection[] = results.map<ReportSection>((result) => ({
+    heading: `${result.query.family.toUpperCase()} — ${result.query.item}`,
+    intro:
+      (result.notes ? `${result.notes}\n\n` : "") +
+      `Mediana: ${formatCOP.format(result.medianUnitPriceCop)} · Spread: ${(result.spread * 100).toFixed(
+        1,
+      )}% · ${result.suppliers.length} proveedor(es) (modo ${result.query.mode}).`,
+    items: result.suppliers.map<ReportItem>((s) => ({
+      tag: s.supplier,
+      tagTone: "info",
+      title: `${s.unitPriceFormatted} / ${s.unit}`,
+      body: s.stockNotes,
+      confidence: s.confidence,
+      facts: [
+        ["Proveedor", s.supplier],
+        ["Precio unitario", s.unitPriceFormatted],
+        ["Unidad", s.unit],
+        ["Consultado", new Date(s.fetchedAt).toLocaleString("es-CO")],
+      ],
+      citations: [
+        {
+          url: s.sourceUrl,
+          title: s.sourceTitle,
+          fetchedAt: s.fetchedAt,
+        },
+      ],
+      actionUrl: s.sourceUrl,
+      actionLabel: "Cotizar con el proveedor",
+    })),
+  }));
+
+  const html = renderReport({
+    tenant,
+    title: "Investigación de precios — demo materiales-intel",
+    subtitle:
+      "Consulta en vivo de precios unitarios con proveedores colombianos · 3 familias · Bogotá",
+    sections,
+    metadata: {
+      runId: `combined-${new Date().toISOString().slice(0, 10)}`,
+      runAt: new Date(),
+      model: "claude-haiku-4-5",
+      extras: [
+        ["Familias consultadas", String(results.length)],
+        [
+          "Proveedores totales",
+          String(results.reduce((acc, r) => acc + r.suppliers.length, 0)),
+        ],
+        [
+          "URL fuentes totales",
+          String(
+            results.reduce((acc, r) => acc + r.suppliers.filter((s) => !!s.sourceUrl).length, 0),
+          ),
+        ],
+      ],
+    },
+    dataBanner:
+      "Datos en vivo — precios consultados en tiempo real de proveedores colombianos. Fuentes citadas en cada tarjeta.",
+  });
+
+  writeFileSync(reportPath, html, "utf8");
+  console.log(`✓ Combined report written: ${reportPath}`);
+  console.log(
+    `  ${results.length} queries · ${results.reduce((a, r) => a + r.suppliers.length, 0)} suppliers total`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`✗ fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/packages/materiales-intel/bin/run-research.ts
+++ b/packages/materiales-intel/bin/run-research.ts
@@ -1,0 +1,353 @@
+#!/usr/bin/env bun
+/**
+ * CLI — Materiales Intel research runner.
+ *
+ * Runs one or more MaterialQuery fixtures through the live Claude web_search
+ * research loop and produces:
+ *   - per-query JSON result files (<out-dir>/query-result-<slug>.json)
+ *   - per-query HTML reports     (<out-dir>/report-<slug>.html)
+ *   - a combined HTML report     (<out-dir>/query-report.html)
+ *
+ * Usage:
+ *   bun run bin/run-research.ts \
+ *     --rules         <path-to-rules-package> \
+ *     --query-fixture <fixture.json | dir of *.json> \
+ *     --report        <combined-report.html>
+ *
+ *   --out-dir     overrides where per-query artifacts land (default: dirname of --report).
+ *   --mode        overrides the fixture's mode (fast|standard|deep).
+ *   --tenant-name overrides display name (default: derived from manifest).
+ *   --dry-run     prints what would run without calling Claude.
+ */
+
+import { readdir } from "node:fs/promises";
+import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  loadRulesPackage,
+  renderReport,
+  type ReportItem,
+  type ReportSection,
+  type TenantContext,
+} from "@broomva/life-modules-core";
+import { MaterialQuerySchema, type MaterialQuery, type QueryResult } from "../src/index.ts";
+import { research } from "../src/research.ts";
+
+// ---------- arg parsing ----------
+type Args = Record<string, string>;
+function parseArgs(argv: string[]): Args {
+  const out: Args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const k = a.slice(2);
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      out[k] = next;
+      i++;
+    } else {
+      out[k] = "true";
+    }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help === "true" || !args.rules || !args["query-fixture"]) {
+  console.log(
+    [
+      "Materiales-Intel research runner",
+      "",
+      "usage: bun run bin/run-research.ts \\",
+      "         --rules <path-to-rules-package> \\",
+      "         --query-fixture <fixture.json | dir of *.json> \\",
+      "         --report <combined-report.html>",
+      "",
+      "Optional:",
+      "  --out-dir <dir>     where per-query artifacts land",
+      "  --mode <fast|standard|deep>  override fixture mode",
+      "  --tenant-name <name>         display name for the tenant",
+      "  --dry-run                    load rules + fixture, no LLM call",
+      "  --help                       show this message",
+    ].join("\n"),
+  );
+  process.exit(0);
+}
+
+// ---------- ANSI helpers for live terminal log ----------
+const ANSI = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  magenta: "\x1b[35m",
+};
+const c = (color: keyof typeof ANSI, s: string): string => `${ANSI[color]}${s}${ANSI.reset}`;
+const banner = (s: string): void => {
+  console.log("");
+  console.log(c("cyan", "━".repeat(Math.min(80, s.length + 4))));
+  console.log(c("bold", c("cyan", `  ${s}`)));
+  console.log(c("cyan", "━".repeat(Math.min(80, s.length + 4))));
+};
+const info = (s: string): void => console.log(c("dim", s));
+const ok = (s: string): void => console.log(c("green", s));
+const step = (s: string): void => console.log(c("magenta", s));
+
+const formatCOP = new Intl.NumberFormat("es-CO", {
+  style: "currency",
+  currency: "COP",
+  maximumFractionDigits: 0,
+});
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .slice(0, 64);
+}
+
+// ---------- main ----------
+async function main(): Promise<void> {
+  const rulesPath = path.resolve(args.rules);
+  const fixtureArg = path.resolve(args["query-fixture"]);
+  const reportPath = args.report ? path.resolve(args.report) : undefined;
+  const outDir = args["out-dir"] ? path.resolve(args["out-dir"]) : reportPath ? path.dirname(reportPath) : path.resolve("./demo-output");
+
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+  banner("Materiales-Intel · Live Price Research");
+  info(`rules:    ${rulesPath}`);
+  info(`fixture:  ${fixtureArg}`);
+  info(`out-dir:  ${outDir}`);
+  if (reportPath) info(`report:   ${reportPath}`);
+
+  step("→ Cargando rules-package");
+  const rulesPackage = await loadRulesPackage(rulesPath);
+  ok(
+    `   ✓ ${Object.keys(rulesPackage.prompts).length} prompts · ${
+      Object.keys(rulesPackage.rules).length
+    } rules · ${(rulesPackage.taxonomy as { families?: unknown[] } | undefined)?.families?.length ?? 0} familias`,
+  );
+
+  // Build tenant context from the manifest.
+  const manifest = rulesPackage.manifest as Record<string, unknown>;
+  const tenant: TenantContext = {
+    id: (manifest.tenantId as string | undefined) ?? (manifest.id as string | undefined) ?? "_pending-constructora",
+    name:
+      args["tenant-name"] ??
+      (manifest.name as string | undefined) ??
+      "Constructora Cliente",
+    locale: "es-CO",
+    currency: "COP",
+    region: "Bogotá, Colombia",
+  };
+  info(`   tenant: ${tenant.id} — ${tenant.name}`);
+
+  // Load fixtures (one file or a dir).
+  const fixtures: Array<{ slug: string; query: MaterialQuery; src: string }> = [];
+  const fstat = statSync(fixtureArg);
+  if (fstat.isDirectory()) {
+    const entries = (await readdir(fixtureArg)).filter((f) => /\.json$/i.test(f));
+    for (const f of entries) {
+      const fp = path.join(fixtureArg, f);
+      const raw = JSON.parse(await Bun.file(fp).text()) as unknown;
+      const parsed = MaterialQuerySchema.parse(raw);
+      fixtures.push({ slug: slugify(path.basename(f, ".json")), query: parsed, src: fp });
+    }
+  } else {
+    const raw = JSON.parse(await Bun.file(fixtureArg).text()) as unknown;
+    const parsed = MaterialQuerySchema.parse(raw);
+    fixtures.push({
+      slug: slugify(path.basename(fixtureArg, ".json")),
+      query: parsed,
+      src: fixtureArg,
+    });
+  }
+  if (args.mode) {
+    for (const fx of fixtures) {
+      (fx.query as { mode: string }).mode = args.mode;
+    }
+  }
+  info(`   fixtures: ${fixtures.length}`);
+
+  if (args["dry-run"] === "true") {
+    ok("\n[dry-run] rules + fixtures loaded cleanly. No LLM call made.");
+    return;
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error(
+      c("yellow", "\n⚠ ANTHROPIC_API_KEY is not set. Export it in your shell or source .env.local before running."),
+    );
+    process.exit(2);
+  }
+
+  // Run each fixture sequentially (avoid rate limits).
+  const results: Array<{ slug: string; result: QueryResult }> = [];
+  for (const fx of fixtures) {
+    banner(`${fx.query.family.toUpperCase()} · ${fx.query.item}`);
+    step(`→ Modo: ${fx.query.mode}  ·  Región: ${fx.query.region}  ·  Cantidad: ${fx.query.quantity ?? "n/a"}`);
+    let result: QueryResult | undefined;
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        result = await research({
+          rulesPackage,
+          query: fx.query,
+          tenant,
+          model: args.model ?? "claude-haiku-4-5",
+          onProgress: (msg) => console.log(c("cyan", msg)),
+        });
+        break;
+      } catch (err) {
+        lastErr = err;
+        const msg = err instanceof Error ? err.message : String(err);
+        const isRateLimit = /429|rate_limit/i.test(msg);
+        const isOverloaded = /529|overloaded/i.test(msg);
+        if ((isRateLimit || isOverloaded) && attempt < 2) {
+          const waitMs = (attempt + 1) * 15_000;
+          console.error(c("yellow", `   ↻ rate-limit/overloaded — esperando ${waitMs / 1000}s antes de reintentar…`));
+          await new Promise((r) => setTimeout(r, waitMs));
+          continue;
+        }
+        break;
+      }
+    }
+    if (result) {
+      results.push({ slug: fx.slug, result });
+
+      const jsonOut = path.join(outDir, `query-result-${fx.slug}.json`);
+      writeFileSync(jsonOut, JSON.stringify(result, null, 2), "utf8");
+      ok(`   ✓ JSON: ${jsonOut}`);
+
+      const perQueryHtml = renderSingleReport(result, tenant);
+      const htmlOut = path.join(outDir, `report-${fx.slug}.html`);
+      writeFileSync(htmlOut, perQueryHtml, "utf8");
+      ok(`   ✓ HTML: ${htmlOut}`);
+
+      ok(
+        `   ✓ median ${formatCOP.format(result.medianUnitPriceCop)} · spread ${(
+          result.spread * 100
+        ).toFixed(1)}%`,
+      );
+    } else {
+      const msg = lastErr instanceof Error ? lastErr.message : String(lastErr);
+      console.error(c("yellow", `   ✗ falló: ${msg}`));
+    }
+  }
+
+  if (reportPath && results.length > 0) {
+    const combined = renderCombinedReport(results, tenant);
+    writeFileSync(reportPath, combined, "utf8");
+    ok(`\n✓ Combined report: ${reportPath}`);
+  }
+
+  banner("Done");
+  for (const r of results) {
+    ok(
+      `· ${r.result.query.family}/${r.result.query.item} → ${r.result.suppliers.length} proveedores · median ${formatCOP.format(
+        r.result.medianUnitPriceCop,
+      )}`,
+    );
+  }
+}
+
+// ---------- rendering ----------
+function toReportItems(result: QueryResult): ReportItem[] {
+  return result.suppliers.map<ReportItem>((s) => ({
+    tag: s.supplier,
+    tagTone: "info",
+    title: `${s.unitPriceFormatted} / ${s.unit}`,
+    body: s.stockNotes,
+    confidence: s.confidence,
+    facts: [
+      ["Proveedor", s.supplier],
+      ["Precio unitario", s.unitPriceFormatted],
+      ["Unidad", s.unit],
+      ["Consultado", new Date(s.fetchedAt).toLocaleString("es-CO")],
+    ],
+    citations: [
+      {
+        url: s.sourceUrl,
+        title: s.sourceTitle,
+        fetchedAt: s.fetchedAt,
+      },
+    ],
+    actionUrl: s.sourceUrl,
+    actionLabel: "Cotizar con el proveedor",
+  }));
+}
+
+function renderSingleReport(result: QueryResult, tenant: TenantContext): string {
+  const section: ReportSection = {
+    heading: `Proveedores consultados — ${result.query.item}`,
+    intro: result.notes,
+    items: toReportItems(result),
+  };
+  return renderReport({
+    tenant,
+    title: `Precio unitario · ${result.query.item}`,
+    subtitle: `${result.query.family} · ${result.query.region} · modo ${result.query.mode}`,
+    sections: [section],
+    metadata: {
+      runId: result.runId,
+      runAt: new Date(result.runAt),
+      model: "claude-haiku-4-5",
+      extras: [
+        ["Cantidad consultada", `${result.query.quantity ?? "n/a"} ${result.query.unit ?? ""}`.trim()],
+        ["Mediana unitaria", formatCOP.format(result.medianUnitPriceCop)],
+        ["Spread min–max", `${(result.spread * 100).toFixed(1)}%`],
+        ["Proveedores", String(result.suppliers.length)],
+      ],
+    },
+    dataBanner:
+      "Datos en vivo — precios consultados en tiempo real de proveedores colombianos. Fuentes citadas en cada tarjeta.",
+  });
+}
+
+function renderCombinedReport(
+  results: Array<{ slug: string; result: QueryResult }>,
+  tenant: TenantContext,
+): string {
+  const sections: ReportSection[] = results.map(({ result }) => ({
+    heading: `${result.query.family.toUpperCase()} — ${result.query.item}`,
+    intro:
+      (result.notes ? `${result.notes}\n\n` : "") +
+      `Mediana: ${formatCOP.format(result.medianUnitPriceCop)} · Spread: ${(result.spread * 100).toFixed(
+        1,
+      )}% · ${result.suppliers.length} proveedores (modo ${result.query.mode}).`,
+    items: toReportItems(result),
+  }));
+  return renderReport({
+    tenant,
+    title: "Investigación de precios — demo materiales-intel",
+    subtitle: "Consulta en vivo de precios unitarios con proveedores colombianos · Bogotá",
+    sections,
+    metadata: {
+      runId: `combined-${new Date().toISOString().slice(0, 10)}`,
+      runAt: new Date(),
+      model: "claude-haiku-4-5",
+      extras: [
+        ["Familias consultadas", String(results.length)],
+        [
+          "Proveedores totales",
+          String(results.reduce((acc, r) => acc + r.result.suppliers.length, 0)),
+        ],
+      ],
+    },
+    dataBanner:
+      "Datos en vivo — precios consultados en tiempo real de proveedores colombianos. Fuentes citadas en cada tarjeta.",
+  });
+}
+
+main().catch((err) => {
+  console.error(c("yellow", `\n✗ fatal: ${err instanceof Error ? err.message : String(err)}`));
+  console.error((err as Error)?.stack ?? "");
+  process.exit(1);
+});

--- a/packages/materiales-intel/package.json
+++ b/packages/materiales-intel/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@broomva/materiales-intel",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@broomva/life-modules-core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.68.0",
+    "yaml": "^2.8.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/materiales-intel/src/index.ts
+++ b/packages/materiales-intel/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.ts";
+export { research, type ResearchOptions } from "./research.ts";

--- a/packages/materiales-intel/src/research.ts
+++ b/packages/materiales-intel/src/research.ts
@@ -1,0 +1,206 @@
+/**
+ * Materiales-Intel research loop.
+ *
+ * One Claude structured-output call per MaterialQuery, with the Anthropic
+ * `web_search_20250305` tool constrained to the tenant's whitelisted Colombian
+ * supplier domains. The LLM is required to call the `emit_query_result` tool
+ * with a strict schema so we get back typed SupplierQuote[] — no text parsing.
+ *
+ * Output (QueryResult) includes the per-supplier citations (URL + title),
+ * confidence, unit-normalized COP price, a median/spread summary, and a
+ * `runId` / `runAt` stamp for the HTML report.
+ */
+
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import {
+  runClaudeStructured,
+  renderPrompt,
+  type RulesPackage,
+  type TenantContext,
+} from "@broomva/life-modules-core";
+import {
+  SupplierQuoteSchema,
+  type MaterialQuery,
+  type QueryResult,
+  type SupplierQuote,
+} from "./types.ts";
+
+// ---------- schema for the LLM output tool ----------
+// This is the *intermediate* shape emitted by the model via emit_query_result.
+// We reconstruct the full QueryResult (adding query/median/spread/runId/runAt)
+// from this partial.
+const StructuredOutputSchema = z.object({
+  suppliers: z.array(SupplierQuoteSchema).min(1),
+  notes: z.string().optional(),
+});
+type StructuredOutput = z.infer<typeof StructuredOutputSchema>;
+
+// JSON-Schema mirror for the Anthropic tool spec.
+const OUTPUT_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    suppliers: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        required: [
+          "supplier",
+          "unitPriceCop",
+          "unitPriceFormatted",
+          "unit",
+          "sourceUrl",
+          "sourceTitle",
+          "confidence",
+          "fetchedAt",
+        ],
+        properties: {
+          supplier: { type: "string" },
+          unitPriceCop: { type: "number" },
+          unitPriceFormatted: { type: "string" },
+          unit: { type: "string" },
+          stockNotes: { type: "string" },
+          sourceUrl: { type: "string" },
+          sourceTitle: { type: "string" },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+          fetchedAt: { type: "string" },
+        },
+      },
+    },
+    notes: { type: "string" },
+  },
+  required: ["suppliers"],
+} as const;
+
+export interface ResearchOptions {
+  rulesPackage: RulesPackage;
+  query: MaterialQuery;
+  tenant: TenantContext;
+  /** Progress callback for live terminal output (asciinema capture). */
+  onProgress?: (msg: string) => void;
+  /** Override model; defaults to claude-sonnet-4-5. */
+  model?: string;
+  /** Upper cap on web_search uses; otherwise derived from mode. */
+  maxSearches?: number;
+  /** Timeout per LLM call in ms. Default 150_000. */
+  timeoutMs?: number;
+}
+
+function median(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const sorted = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function spread(nums: number[]): number {
+  if (nums.length === 0) return 0;
+  const min = Math.min(...nums);
+  const max = Math.max(...nums);
+  return min === 0 ? 0 : (max - min) / min;
+}
+
+export async function research(opts: ResearchOptions): Promise<QueryResult> {
+  const { rulesPackage, query, tenant, onProgress = () => {} } = opts;
+
+  onProgress(`🔎 Cargando reglas del tenant: ${tenant.id}`);
+
+  // pick the mode-specific prompt (falls back to standard / system).
+  const modeTemplate =
+    rulesPackage.prompts[query.mode] ??
+    rulesPackage.prompts.standard ??
+    rulesPackage.prompts.system;
+  if (!modeTemplate) {
+    throw new Error(
+      `No prompt template found for mode '${query.mode}' in rules package ${rulesPackage.dir}`,
+    );
+  }
+
+  const system = await renderPrompt(modeTemplate, {
+    rules: {
+      taxonomy: rulesPackage.taxonomy,
+      sources: rulesPackage.sources,
+      ...rulesPackage.rules,
+      policy: rulesPackage.policy,
+    },
+    input: query,
+    tenant,
+  });
+
+  const minSuppliers = query.mode === "fast" ? 1 : query.mode === "deep" ? 5 : 3;
+  const user = [
+    `Investiga el precio unitario actual del siguiente material en ${query.region}.`,
+    `REQUISITO: tu respuesta final debe incluir **al menos ${minSuppliers} proveedores distintos** en la lista \`suppliers\`.`,
+    `Haz múltiples búsquedas (\`web_search\`) — UNA POR PROVEEDOR — antes de llamar \`emit_query_result\`.`,
+    `Proveedores a tantear explícitamente (haz una búsqueda separada para cada uno hasta acumular ${minSuppliers}):`,
+    `  1. Homecenter — "varilla #4 Homecenter Colombia" / "cemento Argos 50kg Homecenter" / "porcelanato 60x60 Homecenter"`,
+    `  2. Sodimac — misma búsqueda, dominio Sodimac.com.co`,
+    `  3. Constructor o Easy — mismo producto`,
+    `  4. Si aplica al producto, el fabricante directo: Argos / Cemex / Holcim (cemento); Corona / Alfagres / Cerámica Italia (pisos); Grival / FV / Acquagrif (grifería); Pavco / Gerfor (tubería); Pintuco / Sherwin (pintura).`,
+    ``,
+    `Cuando tengas ${minSuppliers}+ proveedores con precio verificado en la URL, llama \`emit_query_result\`. No llames a la herramienta hasta haber recolectado esa diversidad.`,
+    ``,
+    `Detalles de la consulta:`,
+    JSON.stringify(query, null, 2),
+  ].join("\n");
+
+  const allowedDomains =
+    (rulesPackage.sources as { allowed_domains?: string[] } | undefined)?.allowed_domains ?? [];
+  const maxSearches =
+    opts.maxSearches ?? (query.mode === "fast" ? 2 : query.mode === "deep" ? 8 : 4);
+
+  onProgress(
+    `🌐 Invocando Claude + web_search (hasta ${maxSearches} búsquedas en ${allowedDomains.length} dominios colombianos)`,
+  );
+  onProgress(`📋 Modo: ${query.mode}  ·  Familia: ${query.family}  ·  Item: ${query.item}`);
+
+  const result = await runClaudeStructured<StructuredOutput>({
+    system,
+    user,
+    maxTokens: 4096,
+    model: opts.model,
+    timeoutMs: opts.timeoutMs ?? 150_000,
+    extraTools: [
+      {
+        type: "web_search_20250305",
+        name: "web_search",
+        allowed_domains: allowedDomains,
+        max_uses: maxSearches,
+      },
+    ],
+    outputToolName: "emit_query_result",
+    outputToolDescription:
+      "Emite el resultado de la investigación de precio con los proveedores y citas.",
+    outputToolInputSchema: OUTPUT_TOOL_INPUT_SCHEMA as unknown as Record<string, unknown>,
+    outputSchema: StructuredOutputSchema,
+    maxStructuredRetries: 2,
+  });
+
+  const suppliers: SupplierQuote[] = result.output.suppliers;
+  onProgress(`✅ ${suppliers.length} proveedor(es) encontrados`);
+  for (const s of suppliers) {
+    onProgress(
+      `   → ${s.supplier}: ${s.unitPriceFormatted} / ${s.unit}  (conf ${Math.round(
+        s.confidence * 100,
+      )}%)`,
+    );
+  }
+
+  const prices = suppliers.map((s) => s.unitPriceCop);
+  const medianPrice = median(prices);
+  const spreadRatio = spread(prices);
+
+  const now = new Date().toISOString();
+  const runId = `mat-${now.slice(0, 10)}-${randomUUID().slice(0, 8)}`;
+
+  return {
+    query,
+    suppliers,
+    medianUnitPriceCop: medianPrice,
+    spread: spreadRatio,
+    notes: result.output.notes,
+    runId,
+    runAt: now,
+  };
+}

--- a/packages/materiales-intel/src/types.ts
+++ b/packages/materiales-intel/src/types.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const ResearchModeSchema = z.enum(["fast", "standard", "deep"]);
+export type ResearchMode = z.infer<typeof ResearchModeSchema>;
+
+export const MaterialQuerySchema = z.object({
+  family: z.string(),
+  item: z.string(),
+  quantity: z.number().optional(),
+  unit: z.string().optional(),
+  region: z.string().default("Bogotá"),
+  mode: ResearchModeSchema.default("standard"),
+  context: z.string().optional(),
+});
+export type MaterialQuery = z.infer<typeof MaterialQuerySchema>;
+
+export const SupplierQuoteSchema = z.object({
+  supplier: z.string(),
+  unitPriceCop: z.number().positive(),
+  unitPriceFormatted: z.string(),
+  unit: z.string(),
+  stockNotes: z.string().optional(),
+  sourceUrl: z.string().url(),
+  sourceTitle: z.string(),
+  confidence: z.number().min(0).max(1),
+  fetchedAt: z.string().datetime(),
+});
+export type SupplierQuote = z.infer<typeof SupplierQuoteSchema>;
+
+export const QueryResultSchema = z.object({
+  query: MaterialQuerySchema,
+  suppliers: z.array(SupplierQuoteSchema).min(1),
+  medianUnitPriceCop: z.number(),
+  spread: z.number(),
+  notes: z.string().optional(),
+  runId: z.string(),
+  runAt: z.string().datetime(),
+});
+export type QueryResult = z.infer<typeof QueryResultSchema>;

--- a/packages/materiales-intel/tsconfig.json
+++ b/packages/materiales-intel/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/sentinel-property-ops/bin/run-audit.ts
+++ b/packages/sentinel-property-ops/bin/run-audit.ts
@@ -1,0 +1,378 @@
+#!/usr/bin/env bun
+/**
+ * Sentinel audit CLI.
+ *
+ *   bun run audit \
+ *     --rules    <path to tenant rules-package>
+ *     --fixtures <path to WO fixtures dir or file>
+ *     --report   <path to output HTML>
+ *     [--no-llm]                  skip the LLM pass (stage A only)
+ *     [--model claude-sonnet-4-5] override the LLM model
+ *     [--json <out.json>]         override JSON output path
+ *
+ * Writes:
+ *   - <report>                    self-contained HTML audit report
+ *   - <json> (default: alongside report as audit-result.json)
+ *
+ * Terminal output is coloured and structured so an asciinema capture
+ * reads clearly in the demo video.
+ */
+
+import path from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import {
+  loadRulesPackage,
+  renderReport,
+  type ReportItem,
+  type ReportSection,
+  type TenantContext,
+} from "@broomva/life-modules-core";
+import { audit } from "../src/audit.ts";
+import { WorkOrderSchema, type AuditAlert, type WorkOrder } from "../src/types.ts";
+import { z } from "zod";
+
+// ---------- pacing ----------
+const DEMO_PACE_MS = (() => {
+  const raw = process.env.SENTINEL_DEMO_PACE;
+  if (!raw) return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+})();
+
+async function beat(ms: number = DEMO_PACE_MS): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((r) => setTimeout(r, ms));
+}
+
+// ---------- ansi ----------
+const C = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+  gray: "\x1b[90m",
+};
+const p = {
+  dim: (s: string) => `${C.dim}${s}${C.reset}`,
+  bold: (s: string) => `${C.bold}${s}${C.reset}`,
+  red: (s: string) => `${C.red}${s}${C.reset}`,
+  green: (s: string) => `${C.green}${s}${C.reset}`,
+  yellow: (s: string) => `${C.yellow}${s}${C.reset}`,
+  cyan: (s: string) => `${C.cyan}${s}${C.reset}`,
+  magenta: (s: string) => `${C.magenta}${s}${C.reset}`,
+  gray: (s: string) => `${C.gray}${s}${C.reset}`,
+};
+
+// ---------- arg parse ----------
+function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i++;
+    }
+  }
+  return out;
+}
+
+function usage(): void {
+  console.log(
+    `\nsentinel-property-ops — work-order audit runner\n\n` +
+      `usage:\n` +
+      `  bun run audit --rules <dir> --fixtures <dir|file> --report <out.html> [--no-llm] [--model <id>] [--json <out.json>]\n`,
+  );
+}
+
+// ---------- fixtures ----------
+const WorkOrdersListSchema = z.array(WorkOrderSchema);
+
+async function loadWorkOrders(fixturesArg: string): Promise<WorkOrder[]> {
+  const abs = path.resolve(fixturesArg);
+  if (!existsSync(abs)) {
+    throw new Error(`fixtures not found: ${abs}`);
+  }
+  const resolved = abs.endsWith(".json")
+    ? abs
+    : path.join(abs, "work-orders.json");
+  if (!existsSync(resolved)) {
+    throw new Error(`fixtures file not found: ${resolved}`);
+  }
+  const raw = await Bun.file(resolved).text();
+  const parsed = JSON.parse(raw);
+  return WorkOrdersListSchema.parse(parsed);
+}
+
+// ---------- report shaping ----------
+function severityTone(sev: AuditAlert["severity"]): ReportItem["tagTone"] {
+  return sev === "high" ? "danger" : sev === "medium" ? "warning" : "info";
+}
+
+function alertShortLabel(a: AuditAlert): string {
+  return a.relatedWoIds.join(" ↔ ");
+}
+
+function titleFor(a: AuditAlert): string {
+  const head = a.type.replace(/_/g, " ");
+  return `${head} — ${a.relatedWoIds[0]}${a.relatedWoIds.length > 1 ? ` + ${a.relatedWoIds.length - 1} more` : ""}`;
+}
+
+function buildSections(alerts: AuditAlert[], workOrders: WorkOrder[]): ReportSection[] {
+  const order: AuditAlert["type"][] = [
+    "DUPLICATE_WO",
+    "WEAK_CLOSURE",
+    "FOLLOW_UP_RISK",
+    "MISSING_EVIDENCE",
+  ];
+  const sections: ReportSection[] = [];
+
+  const byType = new Map<AuditAlert["type"], AuditAlert[]>();
+  for (const a of alerts) {
+    if (!byType.has(a.type)) byType.set(a.type, []);
+    byType.get(a.type)!.push(a);
+  }
+
+  const woById = new Map(workOrders.map((w) => [w.id, w]));
+
+  const typeHeadings: Record<AuditAlert["type"], string> = {
+    DUPLICATE_WO: "Duplicate work orders",
+    WEAK_CLOSURE: "Weak closures",
+    FOLLOW_UP_RISK: "Follow-up risk",
+    MISSING_EVIDENCE: "Missing evidence",
+  };
+  const typeIntros: Record<AuditAlert["type"], string> = {
+    DUPLICATE_WO:
+      "Two or more WOs opened on the same unit within a 14-day window with overlapping descriptions. Either the first closure failed to resolve the root cause, or the second ticket duplicates billing.",
+    WEAK_CLOSURE:
+      "Closures that do not meet Exclusive's resolution standard — either trivial placeholder text (\"done\", \"fixed\") or tenant-reported items not explicitly addressed (Brough Street pattern).",
+    FOLLOW_UP_RISK:
+      "Repeat-visit chains on the same unit where the most recent closure punts the problem forward without a scheduled follow-up (Richmond ceiling-tile pattern).",
+    MISSING_EVIDENCE:
+      "High-cost repairs in photo-required categories (plumbing / HVAC / structural / roofing / electrical) closed with zero photos. Exclusive's standard requires evidence.",
+  };
+
+  for (const t of order) {
+    const bucket = byType.get(t);
+    if (!bucket || bucket.length === 0) continue;
+    const items: ReportItem[] = bucket.map((a) => {
+      const facts: Array<[string, string | number]> = [
+        ["Severity", a.severity.toUpperCase()],
+        ["Source", a.source === "deterministic" ? "Rule pack (Stage A)" : "LLM classifier (Stage B)"],
+        ["Related WOs", a.relatedWoIds.join(", ")],
+      ];
+      const firstWo = woById.get(a.relatedWoIds[0]);
+      if (firstWo) {
+        facts.push(["Property / Unit", `${firstWo.propertyId}${firstWo.unitId ? ` · ${firstWo.unitId}` : ""}`]);
+        if (firstWo.vendorName) facts.push(["Vendor", firstWo.vendorName]);
+        if (firstWo.category) facts.push(["Category", firstWo.category]);
+      }
+      if (a.suggestedAction) facts.push(["Suggested action", a.suggestedAction]);
+      return {
+        tag: a.type.replace(/_/g, " "),
+        tagTone: severityTone(a.severity),
+        title: titleFor(a),
+        body: a.rationale,
+        facts,
+        confidence: a.confidence,
+      };
+    });
+    sections.push({
+      heading: `${typeHeadings[t]} · ${bucket.length}`,
+      intro: typeIntros[t],
+      items,
+    });
+  }
+
+  if (sections.length === 0) {
+    sections.push({
+      heading: "No alerts",
+      intro: "All work orders in this batch passed the audit.",
+      items: [
+        {
+          tag: "Clean",
+          tagTone: "success",
+          title: "Nothing to flag",
+          body: "Every WO in the batch met Exclusive's closure standard and no duplicate / follow-up patterns were detected.",
+          confidence: 0.9,
+        },
+      ],
+    });
+  }
+
+  return sections;
+}
+
+// ---------- terminal ----------
+function printBanner(): void {
+  console.log("");
+  console.log(p.bold(p.cyan("━━━ SENTINEL · work-order audit ━━━")));
+  console.log(p.dim("  Life Module · sentinel-property-ops@0.1.0"));
+  console.log(p.dim("  Tenant: Exclusive Rentals (London, ON)"));
+  console.log("");
+}
+
+function printAlertLine(a: AuditAlert): void {
+  const icon =
+    a.severity === "high" ? p.red("■") : a.severity === "medium" ? p.yellow("▲") : p.cyan("●");
+  const type = p.bold(a.type.padEnd(16, " "));
+  const src = a.source === "deterministic" ? p.dim("[rules]") : p.magenta("[ llm ]");
+  console.log(
+    `  ${icon} ${type} ${src} ${p.gray("·")} ${alertShortLabel(a)}`,
+  );
+  const rationale = a.rationale.length > 110 ? a.rationale.slice(0, 107) + "..." : a.rationale;
+  console.log(`     ${p.gray(rationale)}`);
+}
+
+// ---------- main ----------
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.rules || !args.fixtures || !args.report) {
+    usage();
+    if (!args.help) process.exit(2);
+    process.exit(0);
+  }
+
+  const rulesDir = String(args.rules);
+  const fixturesPath = String(args.fixtures);
+  const reportPath = path.resolve(String(args.report));
+  const reportDir = path.dirname(reportPath);
+  if (!existsSync(reportDir)) mkdirSync(reportDir, { recursive: true });
+  const jsonPath = args.json
+    ? path.resolve(String(args.json))
+    : path.join(reportDir, "audit-result.json");
+
+  const skipLlm = args["no-llm"] === true;
+  const modelOverride = typeof args.model === "string" ? args.model : undefined;
+
+  printBanner();
+  await beat(600);
+  console.log(p.dim(`  rules:    ${rulesDir}`));
+  await beat(150);
+  console.log(p.dim(`  fixtures: ${fixturesPath}`));
+  await beat(150);
+  console.log(p.dim(`  report:   ${reportPath}`));
+  console.log("");
+  await beat(600);
+
+  const t0 = Date.now();
+
+  const rulesPackage = await loadRulesPackage(rulesDir);
+  const workOrders = await loadWorkOrders(fixturesPath);
+  console.log(
+    `${p.green("✓")} Loaded ${p.bold(String(workOrders.length))} work orders · rules module ${p.bold(String(rulesPackage.manifest.module))}@${rulesPackage.manifest.moduleVersion}`,
+  );
+  console.log("");
+  await beat(900);
+
+  const tenant: TenantContext = {
+    id: "exclusive-rentals",
+    name: "Exclusive Rentals",
+    locale: "en-CA",
+    currency: "CAD",
+    region: "London, ON",
+  };
+
+  const result = await audit({
+    rulesPackage,
+    workOrders,
+    tenant,
+    skipLlm,
+    model: modelOverride,
+    log: async (m) => {
+      console.log(p.gray(m));
+      await beat(400);
+    },
+  });
+
+  const t1 = Date.now();
+
+  console.log("");
+  await beat(500);
+  console.log(p.bold(p.cyan("━━━ audit alerts ━━━")));
+  await beat(300);
+  if (result.alerts.length === 0) {
+    console.log(`  ${p.green("✓")} No alerts — batch is clean.`);
+  } else {
+    for (const a of result.alerts) {
+      printAlertLine(a);
+      // Alerts are the visual punchline — hold each long enough for the
+      // narration to land and the audience to read the rationale.
+      await beat(Math.max(DEMO_PACE_MS, 2500));
+    }
+  }
+  console.log("");
+  await beat(400);
+
+  const counts = result.summary.alertsByType;
+  const summaryLine = [
+    `WOs scanned: ${p.bold(String(result.summary.workOrdersScanned))}`,
+    `alerts: ${p.bold(String(result.alerts.length))}`,
+    `high severity: ${p.bold(String(result.summary.highSeverityCount))}`,
+    `duplicates: ${counts.DUPLICATE_WO ?? 0}`,
+    `weak closures: ${counts.WEAK_CLOSURE ?? 0}`,
+    `follow-up risk: ${counts.FOLLOW_UP_RISK ?? 0}`,
+    `missing evidence: ${counts.MISSING_EVIDENCE ?? 0}`,
+  ].join(p.gray(" · "));
+  console.log(p.bold("  summary: ") + summaryLine);
+  console.log(p.gray(`  elapsed: ${(t1 - t0) / 1000}s`));
+  console.log("");
+
+  // write artifacts
+  const runId = `sentinel-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  const modelLabel = skipLlm
+    ? "stage-A only (no LLM)"
+    : (modelOverride ??
+      (rulesPackage.rules.classification as Record<string, unknown> | undefined)?.model ??
+      "claude-sonnet-4-5");
+
+  const html = renderReport({
+    tenant,
+    title: "Sentinel — Work Order Audit",
+    subtitle: `${workOrders.length} closed work orders audited · ${result.alerts.length} alert${result.alerts.length === 1 ? "" : "s"} flagged.`,
+    sections: buildSections(result.alerts, workOrders),
+    metadata: {
+      runId,
+      runAt: new Date(),
+      model: String(modelLabel),
+      extras: [
+        ["High severity", String(result.summary.highSeverityCount)],
+        ["Module", `${rulesPackage.manifest.module}@${rulesPackage.manifest.moduleVersion}`],
+        ["Rules version", rulesPackage.manifest.rulesVersion],
+      ],
+    },
+    dataBanner:
+      "Synthetic demo data — fabricated fixtures, not real PropertyWare records. Audit logic and alert shape are production-grade.",
+  });
+
+  await writeFile(reportPath, html, "utf8");
+  await writeFile(
+    jsonPath,
+    JSON.stringify(
+      { runId, runAt: new Date().toISOString(), tenant, result },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  console.log(p.green("✓") + " Report written");
+  console.log(p.dim(`  ${reportPath}`));
+  console.log(p.dim(`  ${jsonPath}`));
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error("\x1b[31m✗ audit failed:\x1b[0m", err);
+  process.exit(1);
+});

--- a/packages/sentinel-property-ops/package.json
+++ b/packages/sentinel-property-ops/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@broomva/sentinel-property-ops",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@broomva/life-modules-core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.68.0",
+    "yaml": "^2.8.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/sentinel-property-ops/src/audit.ts
+++ b/packages/sentinel-property-ops/src/audit.ts
@@ -1,0 +1,398 @@
+/**
+ * Sentinel work-order audit loop.
+ *
+ * Two-stage pipeline:
+ *
+ *   Stage A — deterministic pre-pass (no LLM):
+ *     • DUPLICATE_WO       same unit, overlapping description, 14d window
+ *     • MISSING_EVIDENCE   photosCount===0, costUsd>=threshold, photo-required category
+ *
+ *   Stage B — LLM pass (one batched call):
+ *     • WEAK_CLOSURE       closure doesn't meet tenant's closure standard
+ *     • FOLLOW_UP_RISK     repeat-visit pattern with punted closure
+ *
+ * Both stages merge into a single AuditResult. Per-alert `source` records
+ * whether an alert came from deterministic rules or the LLM.
+ */
+
+import {
+  renderPrompt,
+  runClaudeStructured,
+  type RulesPackage,
+  type TenantContext,
+} from "@broomva/life-modules-core";
+import {
+  AuditAlertSchema,
+  type AuditAlert,
+  type AuditAlertType,
+  type AuditResult,
+  type AuditSummary,
+  type WorkOrder,
+} from "./types.ts";
+import { runClaudeStructuredOauth } from "./claude-oauth-shim.ts";
+import { z } from "zod";
+
+/**
+ * The shared `@broomva/life-modules-core` client uses X-Api-Key auth. Claude
+ * Code sessions only have an OAuth token (sk-ant-oat01-…), which needs Bearer
+ * auth and the Claude Code preamble. When running in that context, set
+ * SENTINEL_USE_OAUTH_SHIM=1 in the env and this file routes through a shim.
+ * Core stays untouched — follow-up logged in the final report.
+ */
+const USE_OAUTH_SHIM = process.env.SENTINEL_USE_OAUTH_SHIM === "1";
+
+export interface AuditOptions {
+  rulesPackage: RulesPackage;
+  workOrders: WorkOrder[];
+  tenant: TenantContext;
+  /** Skip the LLM pass — emit only stage A alerts. Useful for offline smoke. */
+  skipLlm?: boolean;
+  /** Override model. Defaults to what the tenant's classification.yaml specifies. */
+  model?: string;
+  /** Logger hook — called with short progress strings. Defaults to console.log. May be async. */
+  log?: (msg: string) => void | Promise<void>;
+}
+
+// ---------- stage A (deterministic) ----------
+
+const STOP_WORDS = new Set([
+  "a", "an", "and", "the", "of", "in", "on", "at", "to", "for", "with", "is",
+  "are", "was", "were", "be", "been", "has", "have", "had", "no", "not", "or",
+  "but", "as", "it", "its", "this", "that", "please", "also",
+  "tenant", "reports", "report", "reported", "check", "please", "visit",
+]);
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]+/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 2 && !STOP_WORDS.has(t)),
+  );
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  const union = a.size + b.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+/**
+ * Overlap coefficient = |A ∩ B| / min(|A|, |B|).
+ * More forgiving than Jaccard when descriptions differ in length. Catches the
+ * Brough-Street pattern where the first WO enumerates five items and the
+ * follow-up only lists the unresolved two.
+ */
+function overlapCoefficient(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return inter / Math.min(a.size, b.size);
+}
+
+function descriptionSimilarity(a: string, b: string): number {
+  const ta = tokenize(a);
+  const tb = tokenize(b);
+  return Math.max(jaccard(ta, tb), overlapCoefficient(ta, tb));
+}
+
+function woUnitKey(wo: WorkOrder): string {
+  return `${wo.propertyId}::${wo.unitId ?? "_"}`;
+}
+
+function parseDate(iso: string | undefined): Date | undefined {
+  if (!iso) return undefined;
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function daysBetween(a: Date, b: Date): number {
+  return Math.abs(a.getTime() - b.getTime()) / 86_400_000;
+}
+
+interface DeterministicThresholds {
+  duplicateWindowDays: number;
+  duplicateSimilarityThreshold: number;
+  duplicateHighSeverityWindowDays: number;
+  missingEvidenceCostUsd: number;
+  missingEvidenceCategories: string[];
+}
+
+function readThresholds(pkg: RulesPackage): DeterministicThresholds {
+  const det = (pkg.rules.deterministic ?? {}) as Record<string, unknown>;
+  const dup = (det.duplicate_candidates ?? {}) as Record<string, unknown>;
+  const miss = (det.missing_evidence ?? {}) as Record<string, unknown>;
+  const categories = Array.isArray(miss.require_photos_categories)
+    ? (miss.require_photos_categories as string[])
+    : ["plumbing", "hvac", "structural", "roofing", "electrical"];
+  return {
+    duplicateWindowDays: Number(dup.time_window_days ?? 14),
+    duplicateSimilarityThreshold: Number(dup.similarity_threshold ?? 0.4),
+    duplicateHighSeverityWindowDays: Number(dup.high_severity_window_days ?? 7),
+    missingEvidenceCostUsd: Number(miss.cost_threshold_usd ?? 500),
+    missingEvidenceCategories: categories.map((c) => c.toLowerCase()),
+  };
+}
+
+function detectDuplicates(
+  workOrders: WorkOrder[],
+  t: DeterministicThresholds,
+): AuditAlert[] {
+  const alerts: AuditAlert[] = [];
+  const groups = new Map<string, WorkOrder[]>();
+  for (const wo of workOrders) {
+    const key = woUnitKey(wo);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(wo);
+  }
+
+  for (const bucket of groups.values()) {
+    if (bucket.length < 2) continue;
+    // Sort by openedAt ascending for stable pairing.
+    const sorted = [...bucket].sort((a, b) => a.openedAt.localeCompare(b.openedAt));
+    for (let i = 0; i < sorted.length; i++) {
+      for (let j = i + 1; j < sorted.length; j++) {
+        const a = sorted[i];
+        const b = sorted[j];
+        // Duplicate gap = time from the earlier WO's closure (or opening
+        // if never closed) to the later WO's opening. This captures "ticket
+        // reopened for the same issue shortly after prior close" — the
+        // Brough Street pattern — which a raw open-to-open gap can miss.
+        const aEdge = parseDate(a.closedAt) ?? parseDate(a.openedAt);
+        const bOpen = parseDate(b.openedAt);
+        if (!aEdge || !bOpen) continue;
+        const gap = daysBetween(aEdge, bOpen);
+        if (gap > t.duplicateWindowDays) continue;
+        const sim = descriptionSimilarity(a.description, b.description);
+        if (sim < t.duplicateSimilarityThreshold) continue;
+
+        const high = gap <= t.duplicateHighSeverityWindowDays;
+        const severity: AuditAlert["severity"] = high ? "high" : "medium";
+        alerts.push({
+          type: "DUPLICATE_WO",
+          severity,
+          relatedWoIds: [a.id, b.id],
+          rationale:
+            `Two work orders on ${a.propertyId}${a.unitId ? ` (${a.unitId})` : ""} within ${Math.round(gap)} days ` +
+            `describe overlapping issues (Jaccard ${(sim * 100).toFixed(0)}% on keyword tokens). ` +
+            `First closure may not have fully resolved the underlying problem, or the second ticket duplicates billing.`,
+          suggestedAction:
+            `Review ${a.id} closure against ${b.id} description — if root cause was not addressed, treat as repeat failure and re-dispatch under a single WO.`,
+          confidence: Math.min(0.95, 0.6 + sim * 0.5),
+          citations: [],
+          source: "deterministic",
+        });
+      }
+    }
+  }
+  return alerts;
+}
+
+function detectMissingEvidence(
+  workOrders: WorkOrder[],
+  t: DeterministicThresholds,
+): AuditAlert[] {
+  const alerts: AuditAlert[] = [];
+  for (const wo of workOrders) {
+    const cost = wo.costUsd ?? 0;
+    const photos = wo.photosCount ?? 0;
+    if (cost < t.missingEvidenceCostUsd) continue;
+    if (photos > 0) continue;
+    if (!t.missingEvidenceCategories.includes(wo.category.toLowerCase())) continue;
+    alerts.push({
+      type: "MISSING_EVIDENCE",
+      severity: "medium",
+      relatedWoIds: [wo.id],
+      rationale:
+        `${wo.category} repair at ${wo.propertyId}${wo.unitId ? ` (${wo.unitId})` : ""} closed at ` +
+        `$${cost.toFixed(0)} with 0 photos. Exclusive's closure standard requires photo evidence for ${wo.category} ` +
+        `work above $${t.missingEvidenceCostUsd}.`,
+      suggestedAction: `Request vendor ${wo.vendorName ?? wo.vendorId ?? "of record"} to back-fill before/after photos.`,
+      confidence: 0.92,
+      citations: [],
+      source: "deterministic",
+    });
+  }
+  return alerts;
+}
+
+// ---------- stage B (LLM) ----------
+
+const LLM_OUTPUT_TOOL = "emit_audit_alerts";
+
+const LLM_OUTPUT_JSON_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    alerts: {
+      type: "array",
+      description:
+        "Alerts emitted by the LLM pass. Focus on WEAK_CLOSURE and FOLLOW_UP_RISK. Do not re-emit DUPLICATE_WO or MISSING_EVIDENCE (the deterministic pre-pass handles those).",
+      items: {
+        type: "object",
+        required: ["type", "severity", "relatedWoIds", "rationale", "confidence"],
+        properties: {
+          type: {
+            type: "string",
+            enum: ["WEAK_CLOSURE", "FOLLOW_UP_RISK"],
+          },
+          severity: { type: "string", enum: ["low", "medium", "high"] },
+          relatedWoIds: {
+            type: "array",
+            items: { type: "string" },
+            minItems: 1,
+          },
+          rationale: { type: "string" },
+          suggestedAction: { type: "string" },
+          confidence: { type: "number", minimum: 0, maximum: 1 },
+        },
+      },
+    },
+  },
+  required: ["alerts"],
+};
+
+const LlmAlertsSchema = z.object({
+  alerts: z.array(
+    z.object({
+      type: z.enum(["WEAK_CLOSURE", "FOLLOW_UP_RISK"]),
+      severity: z.enum(["low", "medium", "high"]),
+      relatedWoIds: z.array(z.string()).min(1),
+      rationale: z.string().min(10),
+      suggestedAction: z.string().optional(),
+      confidence: z.number().min(0).max(1),
+    }),
+  ),
+});
+
+async function runLlmPass(
+  workOrders: WorkOrder[],
+  rulesPackage: RulesPackage,
+  tenant: TenantContext,
+  model: string,
+  log: (msg: string) => void | Promise<void>,
+): Promise<AuditAlert[]> {
+  const systemTpl =
+    rulesPackage.prompts.system ??
+    "You are the Sentinel work-order auditor for {{ tenant.name }}.";
+
+  const systemPrompt = await renderPrompt(systemTpl, {
+    rules: {
+      ...rulesPackage.rules,
+      taxonomy: rulesPackage.taxonomy,
+      sources: rulesPackage.sources,
+    },
+    tenant,
+  });
+
+  const userPayload = {
+    instruction:
+      "Audit the following closed work orders. Emit WEAK_CLOSURE and FOLLOW_UP_RISK alerts only. Call the emit_audit_alerts tool exactly once with your full alert list (empty array if clean).",
+    work_orders: workOrders,
+  };
+
+  await log(
+    `  → Claude ${model}: ${workOrders.length} WOs batched into one structured-output call${USE_OAUTH_SHIM ? " (oauth shim)" : ""}`,
+  );
+
+  const structuredOpts = {
+    system: systemPrompt,
+    user: `\`\`\`json\n${JSON.stringify(userPayload, null, 2)}\n\`\`\``,
+    model,
+    outputSchema: LlmAlertsSchema,
+    outputToolName: LLM_OUTPUT_TOOL,
+    outputToolDescription:
+      "Emit the full list of audit alerts found in the batched work orders. Call exactly once. Use an empty alerts array if no alert-worthy pattern was found.",
+    outputToolInputSchema: LLM_OUTPUT_JSON_SCHEMA,
+    maxStructuredRetries: 2,
+    maxTokens: 4096,
+  } as const;
+
+  const result = USE_OAUTH_SHIM
+    ? await runClaudeStructuredOauth(structuredOpts)
+    : await runClaudeStructured(structuredOpts);
+
+  await log(`  ← Claude emitted ${result.output.alerts.length} alert(s)`);
+
+  return result.output.alerts.map<AuditAlert>((a) => ({
+    type: a.type as AuditAlertType,
+    severity: a.severity,
+    relatedWoIds: a.relatedWoIds,
+    rationale: a.rationale,
+    suggestedAction: a.suggestedAction,
+    confidence: a.confidence,
+    citations: [],
+    source: "llm",
+  }));
+}
+
+// ---------- glue ----------
+
+function buildSummary(
+  workOrdersScanned: number,
+  alerts: AuditAlert[],
+): AuditSummary {
+  const alertsByType: Partial<Record<AuditAlertType, number>> = {};
+  let highSev = 0;
+  for (const a of alerts) {
+    alertsByType[a.type] = (alertsByType[a.type] ?? 0) + 1;
+    if (a.severity === "high") highSev++;
+  }
+  return {
+    workOrdersScanned,
+    alertsByType: alertsByType as Record<AuditAlertType, number>,
+    highSeverityCount: highSev,
+  };
+}
+
+function pickLlmModel(opts: AuditOptions): string {
+  if (opts.model) return opts.model;
+  const classification = (opts.rulesPackage.rules.classification ??
+    {}) as Record<string, unknown>;
+  const rulesModel = classification.model;
+  if (typeof rulesModel === "string" && rulesModel.length > 0) return rulesModel;
+  return "claude-sonnet-4-5";
+}
+
+export async function audit(opts: AuditOptions): Promise<AuditResult> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+
+  const thresholds = readThresholds(opts.rulesPackage);
+  await log(
+    `Stage A — deterministic pre-pass (${opts.workOrders.length} WOs, ` +
+      `duplicate window ${thresholds.duplicateWindowDays}d, missing-evidence >= $${thresholds.missingEvidenceCostUsd})`,
+  );
+  const deterministicAlerts = [
+    ...detectDuplicates(opts.workOrders, thresholds),
+    ...detectMissingEvidence(opts.workOrders, thresholds),
+  ];
+  await log(`  ✓ Stage A: ${deterministicAlerts.length} alert(s)`);
+
+  let llmAlerts: AuditAlert[] = [];
+  if (!opts.skipLlm) {
+    const model = pickLlmModel(opts);
+    await log(`Stage B — LLM classification (${opts.workOrders.length} WOs, model=${model})`);
+    llmAlerts = await runLlmPass(
+      opts.workOrders,
+      opts.rulesPackage,
+      opts.tenant,
+      model,
+      log,
+    );
+    await log(`  ✓ Stage B: ${llmAlerts.length} alert(s)`);
+  } else {
+    await log("Stage B — skipped (--no-llm)");
+  }
+
+  const merged = [...deterministicAlerts, ...llmAlerts];
+
+  // Validate every alert through the canonical schema — defense in depth.
+  const validated = merged.map((a) => AuditAlertSchema.parse(a));
+
+  return {
+    alerts: validated,
+    summary: buildSummary(opts.workOrders.length, validated),
+  };
+}

--- a/packages/sentinel-property-ops/src/claude-oauth-shim.ts
+++ b/packages/sentinel-property-ops/src/claude-oauth-shim.ts
@@ -1,0 +1,272 @@
+/**
+ * Claude client shim for OAuth-token auth.
+ *
+ * The shared `@broomva/life-modules-core` `runClaudeStructured` instantiates
+ * the Anthropic SDK with `apiKey` only. That works for `sk-ant-api03-…` keys.
+ * It does not work for `sk-ant-oat01-…` OAuth tokens (which is what a Claude
+ * Code session has at hand — no separate API key). OAuth tokens need:
+ *   - `Authorization: Bearer <token>` (not `X-Api-Key`)
+ *   - `anthropic-beta: oauth-2025-04-20`
+ *   - a system prompt that starts with Claude Code's preamble
+ *
+ * This shim implements the same structured-output loop the core client does,
+ * but talks to the Messages API over raw fetch. Used when `SENTINEL_USE_OAUTH_SHIM=1`
+ * is in the environment. Core is left untouched.
+ *
+ * Not a permanent solution — the shared client should grow native support.
+ * Logged as a follow-up in the run report.
+ */
+
+import type { z } from "zod";
+import type {
+  Citation,
+  ToolCallRecord,
+} from "@broomva/life-modules-core";
+
+export interface OauthToolDef {
+  name: string;
+  description?: string;
+  input_schema?: Record<string, unknown>;
+}
+
+export interface OauthStructuredOpts<TOut> {
+  system: string;
+  user: string;
+  model: string;
+  maxTokens?: number;
+  outputSchema: z.ZodType<TOut>;
+  outputToolName: string;
+  outputToolDescription: string;
+  outputToolInputSchema: Record<string, unknown>;
+  extraTools?: OauthToolDef[];
+  maxStructuredRetries?: number;
+  timeoutMs?: number;
+}
+
+export interface OauthStructuredResult<TOut> {
+  output: TOut;
+  citations: Citation[];
+  toolCalls: ToolCallRecord[];
+  rawMessages: unknown[];
+}
+
+const CC_PREAMBLE =
+  "You are Claude Code, Anthropic's official CLI for Claude.";
+
+interface AnthropicContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  id?: string;
+  input?: unknown;
+  citations?: Array<{
+    url?: string;
+    title?: string;
+    cited_text?: string;
+  }>;
+}
+
+interface AnthropicMessage {
+  id: string;
+  role: string;
+  model: string;
+  stop_reason: string | null;
+  content: AnthropicContentBlock[];
+}
+
+function composedSystem(system: string): string {
+  if (system.startsWith(CC_PREAMBLE)) return system;
+  return `${CC_PREAMBLE}\n\n${system}`;
+}
+
+async function postOnce(
+  body: Record<string, unknown>,
+  token: string,
+  timeoutMs: number,
+): Promise<{ ok: boolean; status: number; text: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "oauth-2025-04-20",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await resp.text();
+    return { ok: resp.ok, status: resp.status, text };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function post(
+  body: Record<string, unknown>,
+  token: string,
+  timeoutMs: number,
+): Promise<AnthropicMessage> {
+  const backoff = [2_000, 8_000, 20_000, 45_000];
+  let lastErr = "";
+  for (let i = 0; i < backoff.length; i++) {
+    const r = await postOnce(body, token, timeoutMs);
+    if (r.ok) return JSON.parse(r.text) as AnthropicMessage;
+    lastErr = `${r.status}: ${r.text}`;
+    // Retry only on rate-limit / transient server errors.
+    if (r.status === 429 || r.status >= 500) {
+      const wait = backoff[i];
+      // eslint-disable-next-line no-console
+      console.log(
+        `\x1b[33m  ⟳ Anthropic ${r.status}, backing off ${wait / 1000}s (attempt ${i + 1}/${backoff.length})\x1b[0m`,
+      );
+      await new Promise((res) => setTimeout(res, wait));
+      continue;
+    }
+    throw new Error(`Anthropic ${lastErr}`);
+  }
+  throw new Error(`Anthropic retries exhausted: ${lastErr}`);
+}
+
+export async function runClaudeStructuredOauth<TOut>(
+  opts: OauthStructuredOpts<TOut>,
+): Promise<OauthStructuredResult<TOut>> {
+  const token =
+    process.env.ANTHROPIC_AUTH_TOKEN ?? process.env.ANTHROPIC_API_KEY;
+  if (!token) {
+    throw new Error(
+      "OAuth shim: no ANTHROPIC_AUTH_TOKEN / ANTHROPIC_API_KEY in env.",
+    );
+  }
+
+  const tools = [
+    ...(opts.extraTools ?? []),
+    {
+      name: opts.outputToolName,
+      description: opts.outputToolDescription,
+      input_schema: opts.outputToolInputSchema,
+    },
+  ];
+
+  const system = composedSystem(opts.system);
+
+  interface Msg {
+    role: "user" | "assistant";
+    content: unknown;
+  }
+  const messages: Msg[] = [{ role: "user", content: opts.user }];
+  const rawMessages: AnthropicMessage[] = [];
+  const citations: Citation[] = [];
+  const toolCalls: ToolCallRecord[] = [];
+  const maxRetries = opts.maxStructuredRetries ?? 2;
+  const timeoutMs = opts.timeoutMs ?? 180_000;
+  const maxTokens = opts.maxTokens ?? 4096;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const start = Date.now();
+    const msg = await post(
+      {
+        model: opts.model,
+        max_tokens: maxTokens,
+        system,
+        messages,
+        tools,
+      },
+      token,
+      timeoutMs,
+    );
+    rawMessages.push(msg);
+
+    let structuredInput: unknown;
+    let structuredToolUseId: string | undefined;
+    const nonOutputToolUses: Array<{ id: string; name: string; input: unknown }> =
+      [];
+    const now = new Date().toISOString();
+
+    for (const block of msg.content) {
+      if (block.type === "tool_use") {
+        if (block.name === opts.outputToolName) {
+          structuredInput = block.input;
+          structuredToolUseId = block.id;
+        } else if (block.name && block.id) {
+          nonOutputToolUses.push({
+            id: block.id,
+            name: block.name,
+            input: block.input,
+          });
+        }
+        toolCalls.push({
+          name: block.name ?? "unknown",
+          input: block.input,
+          startedAt: new Date(start).toISOString(),
+          endedAt: now,
+          errored: false,
+        });
+      } else if (block.type === "text" && block.citations) {
+        for (const c of block.citations) {
+          if (c.url) {
+            citations.push({
+              url: c.url,
+              title: c.title,
+              snippet: c.cited_text,
+              fetchedAt: now,
+            });
+          }
+        }
+      }
+    }
+
+    if (structuredInput !== undefined) {
+      const parsed = opts.outputSchema.safeParse(structuredInput);
+      if (parsed.success) {
+        return {
+          output: parsed.data,
+          citations,
+          toolCalls,
+          rawMessages,
+        };
+      }
+      // Schema violation — feed back error and retry.
+      messages.push({ role: "assistant", content: msg.content });
+      messages.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: structuredToolUseId ?? "unknown",
+            content: `Schema validation failed: ${parsed.error.message}. Call ${opts.outputToolName} again with corrected output.`,
+            is_error: true,
+          },
+        ],
+      });
+      continue;
+    }
+
+    if (msg.stop_reason === "tool_use" && nonOutputToolUses.length > 0) {
+      messages.push({ role: "assistant", content: msg.content });
+      messages.push({
+        role: "user",
+        content: nonOutputToolUses.map((tu) => ({
+          type: "tool_result",
+          tool_use_id: tu.id,
+          content: "(tool executed)",
+        })),
+      });
+      continue;
+    }
+
+    // Text-only response — nudge model to call the tool.
+    messages.push({ role: "assistant", content: msg.content });
+    messages.push({
+      role: "user",
+      content: `Call the ${opts.outputToolName} tool now with the full structured output.`,
+    });
+  }
+
+  throw new Error(
+    `OAuth shim: exhausted ${maxRetries + 1} attempts without a valid structured output for ${opts.outputToolName}`,
+  );
+}

--- a/packages/sentinel-property-ops/src/index.ts
+++ b/packages/sentinel-property-ops/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.ts";
+export { audit, type AuditOptions } from "./audit.ts";

--- a/packages/sentinel-property-ops/src/types.ts
+++ b/packages/sentinel-property-ops/src/types.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { CitationSchema } from "@broomva/life-modules-core";
+
+/** Canonical closed-work-order shape (mirrors PropertyWare fields). */
+export const WorkOrderSchema = z.object({
+  id: z.string(),
+  propertyId: z.string(),
+  unitId: z.string().optional(),
+  category: z.string(),
+  description: z.string(),
+  openedAt: z.string().datetime({ offset: true }),
+  closedAt: z.string().datetime({ offset: true }).optional(),
+  vendorId: z.string().optional(),
+  vendorName: z.string().optional(),
+  closureNotes: z.string().optional(),
+  costUsd: z.number().optional(),
+  photosCount: z.number().optional(),
+});
+export type WorkOrder = z.infer<typeof WorkOrderSchema>;
+
+export const AuditAlertTypeSchema = z.enum([
+  "DUPLICATE_WO",
+  "WEAK_CLOSURE",
+  "FOLLOW_UP_RISK",
+  "MISSING_EVIDENCE",
+]);
+export type AuditAlertType = z.infer<typeof AuditAlertTypeSchema>;
+
+export const AuditAlertSchema = z.object({
+  type: AuditAlertTypeSchema,
+  severity: z.enum(["low", "medium", "high"]),
+  relatedWoIds: z.array(z.string()).min(1),
+  rationale: z.string(),
+  suggestedAction: z.string().optional(),
+  confidence: z.number().min(0).max(1),
+  citations: z.array(CitationSchema).default([]),
+  source: z.enum(["deterministic", "llm"]).default("llm"),
+});
+export type AuditAlert = z.infer<typeof AuditAlertSchema>;
+
+export const AuditSummarySchema = z.object({
+  workOrdersScanned: z.number(),
+  alertsByType: z.record(AuditAlertTypeSchema, z.number()),
+  highSeverityCount: z.number(),
+});
+export type AuditSummary = z.infer<typeof AuditSummarySchema>;
+
+export const AuditResultSchema = z.object({
+  alerts: z.array(AuditAlertSchema),
+  summary: AuditSummarySchema,
+});
+export type AuditResult = z.infer<typeof AuditResultSchema>;

--- a/packages/sentinel-property-ops/tsconfig.json
+++ b/packages/sentinel-property-ops/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Life Runtime platform — turns the UI-only Life Interface (PR #94) into a real executable substrate. Seven DB tables, a server-side runner registry, a full SSE execution pipeline, and live streaming on `/life/sentinel` — all the billing branches present and tagged, no real Claude cost yet.

## What shipped

**DB (migrations 0059 + 0060)** — seven new Drizzle tables, all `Life*` prefix:
- `LifeProject` — tenancy object, any owner kind (user | org | platform)
- `LifeRulesVersion` — git-style versioned rules package
- `LifeModuleType` — runner registry (sentinel / materiales / generic / module-builder)
- `LifeReservedSlug` — platform routes that cannot be claimed as project slugs
- `LifeRun` — execution record + full cost accounting (llmCostCents, platformFeeCents, creatorFeeCents, consumerPaidCents, paymentMode)
- `LifeRunEvent` — append-only event log per run (SSE source of truth + replayable)
- `LifeByokKey` — encrypted BYOK provider keys, scope=internal | public

Seed migration 0060 populates reserved slugs + three module types + the platform-owned Sentinel and Materiales projects.

**Life modules packages** — copies `@broomva/life-modules-core`, `@broomva/sentinel-property-ops`, `@broomva/materiales-intel` into `broomva.tech/packages/`. `rules-loader` refactored from `Bun.file` → `node:fs` so the package works in the Next.js runtime, not just the Bun CLI.

**Service layer** (`apps/chat/lib/life-runtime/`)
- `queries.ts` — project / rules-version / run CRUD
- `billing.ts` — `pickPaymentMode()` decision matrix matching the refined commercial model (authed owner → credits, authed other → haima_balance / free_tier, anon/external → x402, BYOK → byok)
- `runner-dispatch.ts` — module-type → Runner lookup; Phase 2 runners replay the mock scenarios from the Life Interface design as real SSE events (zero Claude cost, full infra)
- `types.ts` — `PaymentMode`, `ConsumerIdentity`, `RunEvent`

**API route — `POST /api/life/run/[project]`**
Resolves project by slug → identifies consumer → picks payment mode → creates a `LifeRun` row → streams events from the runner while persisting each to `LifeRunEvent` → settles credits on success → bumps project stats. Returns **402 Payment Required** with an x402 quote in the body for external callers on paid projects.

**UI — `useLiveRun` + `LifeShell` wiring**
New `useLiveRun` hook mirrors `useReplay`'s `[state, setState]` contract, reads events from the SSE endpoint, folds them via the shared `applyReplayEvent` reducer. `LifeShell` picks live vs replay per project (new `liveStream` flag in `PROJECTS`). Phase 2 flips this on for **Sentinel**. Materiales stays on local replay until the follow-up PR adds the OAuth shim migration and real `web_search` wiring.

## Refined commercial model — what each `paymentMode` means

| Consumer | Project | `paymentMode` | This PR | Next PR |
|---|---|---|---|---|
| Authed user (owner) | any | `credits` | ✅ debited from `UserCredit.credits` | — |
| Authed user | free public | `free_tier` | ✅ recorded | per-project cap enforcement |
| Authed user | paid public | `haima_balance` | ✅ tagged | wallet settlement |
| Authed user + BYOK | any | `byok` | ✅ tagged | KMS decrypt + provider routing |
| Anon / external | free public | `free_tier` | ✅ served | anon quota via existing rate-limit.ts |
| Anon / external | paid public | `x402` | ✅ **402 Payment Required** with quote | x402 verify + settle |

## Non-goals (follow-up PRs)
- Real Sentinel runner via `@broomva/sentinel-property-ops` (requires OAuth shim migration into `@broomva/life-modules-core`)
- Haima / x402 wallet settlement (USDC on Base, Bre-B via Movii)
- BYOK UI + platform KMS for encrypted provider keys
- `/life/new` wizard + `@handle` namespaced routing middleware
- Creator earnings ledger + automated payouts

## Validation

- [x] `bun install` — clean, 3 new workspace packages linked
- [x] `bun run test:types` (chat) — clean
- [x] `bun run build --filter=@broomva/chat` — clean (1m 1s)
- [x] `/life` + `/api/life/run/[project]` both pre-render correctly
- [x] Dev-server path covered by typed scenario replay; UI unchanged visually, backed by real DB + SSE end-to-end

## Test plan

- [ ] Review schema — 7 new tables, all naming-namespaced; no collisions with existing `Project`, `UserCredit`, `UsageEvent`
- [ ] Review `billing.ts::pickPaymentMode` — confirm the decision matrix matches the refined commercial model
- [ ] Review 402 response shape on the paid-project branch — confirm `WWW-Authenticate: x402 nonce=...` header + JSON quote body are the right contract for the x402 follow-up
- [ ] Review `useLiveRun` wire format — confirm the mapping preserves the UI's time pacing and event ordering
- [ ] Load `/life/sentinel` locally (requires a DB branch with migrations applied) — confirm SSE drives the shell
- [ ] Load `/life/materiales` locally — confirm it stays on local replay (untouched)
- [ ] Load `/life/nonsense` — confirm 404

Linear: [BRO-846](https://linear.app/broomva/issue/BRO-846)
Stacks on: #94 (merged 2026-04-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- **Life Projects**: New platform for executing interactive scenarios with live-streaming capabilities for real-time updates
- **Material Intelligence**: Supplier research system for pricing discovery and vendor information
- **Property Audits**: Automated audit system that detects issues and generates alerts for work orders
- **Enhanced Payment Options**: Support for multiple billing modes including free tier, account credits, and x402 payment protocol

<!-- end of auto-generated comment: release notes by coderabbit.ai -->