### PR TITLE
fix(life): add /api/life to public API prefix allowlist

### DIFF
--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -46,6 +46,11 @@ const PUBLIC_API_PREFIXES = [
   "/api/relay",
   "/api/install",
   "/api/debug",
+  // Life Runtime: the /api/life/run/[project] route does its own consumer
+  // resolution (session | anon | x402) inside the handler and responds
+  // with 402 Payment Required when payment is needed. Middleware must let
+  // the request through so the handler can pick the right path.
+  "/api/life",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */


### PR DESCRIPTION
## Summary

Hotfix for Phase 2. The \`/api/life/run/[project]\` handler from PR #95 was being intercepted by the auth proxy before it could run its own consumer-resolution logic (session / anon / x402). Result: every POST returned **405 Method Not Allowed** with a \`text/html\` body, and the \`useLiveRun\` hook on \`/life/sentinel\` silently failed — the UI sat at \"Idle · tick 0.0s\" forever.

## Root cause

\`apps/chat/proxy.ts\` had \`/life\` in \`PUBLIC_PAGE_PREFIXES\` but \`/api/life\` was missing from \`PUBLIC_API_PREFIXES\`. The middleware treated the API path as authenticated-required and returned 405 instead of letting the handler take ownership of its own auth flow.

## Fix

Add \`/api/life\` to \`PUBLIC_API_PREFIXES\`. Security is preserved — the route handler still:

- Checks \`project.status === 'active'\` and returns 403 otherwise
- Calls \`resolveConsumer()\` and returns a proper billing decision
- Returns **402 Payment Required** (with an x402 quote body + \`WWW-Authenticate\` header) when the consumer is anon/external on a paid project
- Enforces credits balance for authed users on their own projects

## Verification

Pre-fix, direct browser-context \`fetch('/api/life/run/sentinel', { method: 'POST' })\` from production returned:
\`\`\`
{ status: 405, contentType: 'text/html', body: '' }
\`\`\`

Post-fix (expected):
\`\`\`
{ status: 200, contentType: 'text/event-stream', body: 'event: run_metadata\\ndata: ...' }
\`\`\`

Browser QA will re-verify on the preview deploy URL attached to this PR.

Linear: [BRO-846](https://linear.app/broomva/issue/BRO-846) (hotfix)
Stacks on: #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)