### PR TITLE
fix(life): default LifeRun.input to {} + revert diag surface

### DIFF
--- a/apps/chat/app/api/life/run/[project]/route.ts
+++ b/apps/chat/app/api/life/run/[project]/route.ts
@@ -165,14 +165,13 @@ export async function POST(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error("[life/run] uncaught handler error:", err);
-    const stack = err instanceof Error ? err.stack : undefined;
     return NextResponse.json(
       {
         error: "Internal error while starting run.",
-        // Temporary — Phase 2 QA. Surface message + stack in prod until the
-        // live-run path is fully debugged. No secrets in these strings.
-        detail: message,
-        stack: stack ? stack.split("\n").slice(0, 6) : undefined,
+        detail:
+          process.env.VERCEL_ENV === "production"
+            ? "See function logs for trace."
+            : message,
       },
       { status: 500 },
     );
@@ -216,7 +215,9 @@ async function handlePost(
   if (!parsedBody.success) {
     return jsonError(400, "Invalid body.", { issues: parsedBody.error.issues });
   }
-  const { input = null, byokKeyId } = parsedBody.data;
+  // `input` column is JSONB NOT NULL — default to {} so the "start a demo
+  // without structured input" path (e.g. /life/sentinel landing) still works.
+  const { input = {}, byokKeyId } = parsedBody.data;
 
   // 4. Billing decision
   const decision = pickPaymentMode({ project, consumer, byokKeyId });

--- a/apps/chat/lib/life-runtime/queries.ts
+++ b/apps/chat/lib/life-runtime/queries.ts
@@ -84,6 +84,10 @@ export async function createRun(params: CreateRunParams): Promise<LifeRun> {
   const effectiveRulesVersionId = params.rulesVersionId
     ?? (await ensureInitialRulesVersion(params.projectId, params.consumerId));
 
+  // LifeRun.input is JSONB NOT NULL — coerce nullish callers to an empty
+  // object so "start a run with no structured input" is always legal.
+  const inputValue = (params.input ?? {}) as object;
+
   const [row] = await db
     .insert(lifeRun)
     .values({
@@ -92,7 +96,7 @@ export async function createRun(params: CreateRunParams): Promise<LifeRun> {
       consumerKind: params.consumerKind,
       consumerId: params.consumerId,
       organizationId: params.organizationId ?? null,
-      input: params.input as object,
+      input: inputValue,
       status: "streaming",
       paymentMode: params.paymentMode,
       startedAt: new Date(),


### PR DESCRIPTION
Root cause fix for the /api/life/run/[project] 500 identified via PR #98 trace. Insert into LifeRun was passing null for JSONB NOT NULL column. Default to {} on both route + query sides; also reverts the diagnostic error-surface from #98.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API error responses now provide contextual messaging based on environment—generic messages in production and detailed errors in development for better troubleshooting
  * Improved handling when initiating runs without pre-defined structured input parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->