### PR TITLE
fix(life): bumpProjectStats non-fatal + read-modify-write rewrite

### DIFF
--- a/apps/chat/app/api/life/run/[project]/route.ts
+++ b/apps/chat/app/api/life/run/[project]/route.ts
@@ -388,13 +388,20 @@ async function handlePost(
           provider,
         });
         if (decision.mode === "credits" && consumer.kind === "user") {
+          // Credits debit failure is critical — let it bubble.
           await settleCreditsDebit({
             userId: consumer.id,
             mode: decision.mode,
             amountCents: decision.quotedCents,
           });
         }
-        await bumpProjectStats(project.id, finalCostCents);
+        // Stats bump is a denormalized counter — failure here shouldn't
+        // poison the run or the UI's success state. Best-effort, logged.
+        try {
+          await bumpProjectStats(project.id, finalCostCents);
+        } catch (statsErr) {
+          console.warn("[life/run] bumpProjectStats failed (non-fatal):", statsErr);
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         await emit({ type: "error", payload: { message: msg } });

--- a/apps/chat/lib/life-runtime/queries.ts
+++ b/apps/chat/lib/life-runtime/queries.ts
@@ -303,30 +303,36 @@ export async function getRunEvents(runId: string): Promise<
 }
 
 /**
- * Bump the project's denormalized stats after a run finishes. Uses jsonb
- * set-at-path + increment so no schema migration is needed to add new
- * stats keys — just write them from the app layer.
+ * Bump the project's denormalized stats after a run finishes.
+ *
+ * Read-modify-write in TS instead of an SQL jsonb_set expression — simpler,
+ * one round trip, and avoids Drizzle/Postgres idiosyncrasies around column
+ * references on the RHS of an UPDATE ... SET clause with jsonb functions.
+ * Race condition on concurrent finishes is acceptable for a denormalized
+ * counter (the authoritative run data lives in LifeRun).
  */
 export async function bumpProjectStats(
   projectId: string,
   costCents: number,
 ): Promise<void> {
+  const rows = await db
+    .select({ stats: lifeProject.stats })
+    .from(lifeProject)
+    .where(eq(lifeProject.id, projectId))
+    .limit(1);
+  const current = (rows[0]?.stats as Record<string, unknown> | null) ?? {};
+  const prevTotal =
+    typeof current.totalRuns === "number" ? current.totalRuns : 0;
+  const prevCostTotal =
+    typeof current.totalCostCents === "number" ? current.totalCostCents : 0;
+  const next = {
+    ...current,
+    totalRuns: prevTotal + 1,
+    lastRunAt: new Date().toISOString(),
+    totalCostCents: prevCostTotal + (costCents || 0),
+  };
   await db
     .update(lifeProject)
-    .set({
-      stats: sql`
-        jsonb_set(
-          jsonb_set(
-            COALESCE(${lifeProject.stats}, '{}'::jsonb),
-            '{totalRuns}',
-            to_jsonb(
-              (COALESCE((${lifeProject.stats} ->> 'totalRuns')::int, 0) + 1)
-            )
-          ),
-          '{lastRunAt}',
-          to_jsonb(NOW()::text)
-        )
-      `,
-    })
+    .set({ stats: next })
     .where(eq(lifeProject.id, projectId));
 }


### PR DESCRIPTION
Polish following Phase 3 browser QA. bumpProjectStats was failing with a jsonb_set SQL issue at the end of every real run and poisoning the run status in the UI. Wrapped in its own try/catch + rewritten as a simple read-modify-write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of run completion: project statistics updates no longer block the overall run flow if errors occur.
  * Enhanced error handling ensures run data is persisted even when auxiliary operations fail, providing better stability during project runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->