### PR TITLE
fix(life): bare layout + per-project empty state for /life/[project]

### DIFF
--- a/apps/chat/app/(site)/layout.tsx
+++ b/apps/chat/app/(site)/layout.tsx
@@ -1,21 +1,9 @@
-import { TopNav } from "@/components/site/top-nav";
-import { SiteHeader } from "@/components/site/site-header";
-import { ConditionalFooter } from "@/components/site/conditional-footer";
-import { ToolbarDockProvider } from "@/components/site/toolbar-dock-context";
+import { ConditionalSiteChrome } from "@/components/site/conditional-site-chrome";
 
 export default function SiteLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <ToolbarDockProvider>
-      <div className="flex min-h-screen flex-col bg-bg-deep pt-16 text-text-primary">
-        <SiteHeader />
-        <main className="flex-1 pb-24">{children}</main>
-        <ConditionalFooter />
-        <TopNav />
-      </div>
-    </ToolbarDockProvider>
-  );
+  return <ConditionalSiteChrome>{children}</ConditionalSiteChrome>;
 }

--- a/apps/chat/app/(site)/life/[project]/page.tsx
+++ b/apps/chat/app/(site)/life/[project]/page.tsx
@@ -37,6 +37,9 @@ export default async function LifeProjectPage({
       displayName={info.displayName}
       eyebrow={info.eyebrow}
       liveStream={info.liveStream}
+      emptyTitle={info.emptyTitle}
+      emptyHint={info.emptyHint}
+      suggestions={info.suggestions}
     />
   );
 }

--- a/apps/chat/app/(site)/life/_components/ChatColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/ChatColumn.tsx
@@ -19,6 +19,11 @@ interface Props {
   sourceLabel?: "mock" | "live";
   /** Model identifier to display in the Composer footer. */
   modelLabel?: string;
+  /** Hint lines for the empty state — swapped per project. */
+  emptyStateTitle?: string;
+  emptyStateHint?: string;
+  /** Suggested first-turn prompts shown below the empty-state title. */
+  suggestions?: Array<{ label: string; prompt: string }>;
 }
 
 export function ChatColumn({
@@ -30,6 +35,9 @@ export function ChatColumn({
   onSendMessage,
   sourceLabel = "mock",
   modelLabel,
+  emptyStateTitle,
+  emptyStateHint,
+  suggestions,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -91,7 +99,7 @@ export function ChatColumn({
         {state.messages.length === 0 && (
           <div
             style={{
-              padding: "80px 12px",
+              padding: "60px 20px",
               textAlign: "center",
               color: "var(--ag-text-muted)",
               fontSize: 12,
@@ -104,18 +112,47 @@ export function ChatColumn({
             <div
               style={{
                 fontFamily: "var(--ag-font-heading)",
-                fontSize: 18,
+                fontSize: 20,
                 color: "var(--ag-text-primary)",
                 letterSpacing: "-0.01em",
                 marginBottom: 10,
               }}
             >
-              What are we making today?
+              {emptyStateTitle ?? "What are we making today?"}
             </div>
-            <div>
-              Arcan is wired to your workspace — filesystem, Lago journal, Nous,
-              Autonomic, Haima.
+            <div style={{ marginBottom: 18 }}>
+              {emptyStateHint ??
+                "Arcan is wired to your workspace — filesystem, Lago journal, Nous, Autonomic, Haima."}
             </div>
+            {suggestions && suggestions.length > 0 && onSendMessage && (
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 6,
+                  maxWidth: 320,
+                  margin: "0 auto",
+                  textAlign: "left",
+                }}
+              >
+                {suggestions.map((s) => (
+                  <button
+                    key={s.prompt}
+                    type="button"
+                    className="btn btn--ghost"
+                    onClick={() => onSendMessage(s.prompt)}
+                    style={{
+                      justifyContent: "flex-start",
+                      fontSize: 12,
+                      padding: "10px 12px",
+                      border: "1px solid var(--ag-border-subtle)",
+                    }}
+                  >
+                    {s.label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         )}
         {state.messages.map((m) => (

--- a/apps/chat/app/(site)/life/_components/LifeShell.tsx
+++ b/apps/chat/app/(site)/life/_components/LifeShell.tsx
@@ -27,11 +27,14 @@ interface Props {
   eyebrow: string;
   /**
    * When true, the shell reads events from /api/life/run/<slug> over SSE
-   * instead of replaying the local scenario clock. Phase 2 enables it for
-   * Sentinel; Materiales stays on local replay until the live pipeline with
-   * web_search lands in a follow-up PR.
+   * instead of replaying the local scenario clock. Live projects start
+   * with an empty chat; the user's first message begins the first run.
    */
   liveStream?: boolean;
+  /** Empty-state title for the chat column (project-aware copy). */
+  emptyTitle?: string;
+  emptyHint?: string;
+  suggestions?: Array<{ label: string; prompt: string }>;
 }
 
 function usePersistedTweaks(initialScenario: ScenarioId): {
@@ -71,6 +74,9 @@ export function LifeShell({
   displayName,
   eyebrow,
   liveStream = false,
+  emptyTitle,
+  emptyHint,
+  suggestions,
 }: Props) {
   const { tweaks, setTweaks } = usePersistedTweaks(scenarioId);
   const [tweaksOpen, setTweaksOpen] = useState(false);
@@ -96,9 +102,14 @@ export function LifeShell({
   // fall back to the local replay clock so the Tweaks panel keeps working.
   const liveEnabled =
     liveStream && playing && tweaks.scenario === scenarioId;
+  // Live projects start EMPTY — the user's first message is the first run.
+  // No server-side scenario auto-play (that was a Phase 2 / early-Phase-3
+  // crutch that made the UI look scripted). The empty state now invites
+  // the user to type; sendMessage() kicks off the first real turn.
   const [liveState, setLiveState, liveMeta] = useLiveRun({
     projectSlug,
     enabled: liveEnabled,
+    autoStart: false,
   });
 
   // The downstream UI is agnostic to which source drove state — it only
@@ -192,6 +203,9 @@ export function LifeShell({
               onSendMessage={liveEnabled ? liveMeta.sendMessage : undefined}
               sourceLabel={liveEnabled ? "live" : "mock"}
               modelLabel={liveEnabled ? "openai/gpt-5-mini" : undefined}
+              emptyStateTitle={emptyTitle}
+              emptyStateHint={emptyHint}
+              suggestions={suggestions}
             />
             <MiddleColumn
               mode={tweaks.middleMode}

--- a/apps/chat/app/(site)/life/_lib/project-map.ts
+++ b/apps/chat/app/(site)/life/_lib/project-map.ts
@@ -13,11 +13,15 @@ export interface LifeProjectInfo {
   chipColor: ProjectChipColor;
   /**
    * When true, the shell hits /api/life/run/<slug> over SSE instead of
-   * running the in-browser scenario replay clock. Phase 2 flips this on for
-   * Sentinel (mock-replay server-side — no Claude cost); Materiales stays
-   * client-replay until the OAuth shim migration lands in the next PR.
+   * running the in-browser scenario replay clock.
    */
   liveStream: boolean;
+  /** Empty-state title above the composer prompt. */
+  emptyTitle?: string;
+  /** Empty-state hint describing what the project does. */
+  emptyHint?: string;
+  /** First-turn suggestions shown as clickable chips. */
+  suggestions?: Array<{ label: string; prompt: string }>;
 }
 
 export const PROJECTS: Record<string, LifeProjectInfo> = {
@@ -27,6 +31,25 @@ export const PROJECTS: Record<string, LifeProjectInfo> = {
     eyebrow: "sentinel-property-ops · exclusive-rentals",
     chipColor: "emerald",
     liveStream: true,
+    emptyTitle: "What should Sentinel audit?",
+    emptyHint:
+      "Describe a work order, a vendor pattern, or a portfolio you want reviewed. Sentinel flags duplicates, weak closures, follow-up risk, and missing evidence.",
+    suggestions: [
+      {
+        label: "What's a weak closure?",
+        prompt:
+          "In one sentence, what's a weak closure in property management and how should I spot one?",
+      },
+      {
+        label: "List 3 signs of follow-up risk",
+        prompt: "List 3 signs of follow-up risk on a closed work order. Be brief.",
+      },
+      {
+        label: "Draft an audit checklist",
+        prompt:
+          "Draft a short checklist (5 items) I can run on any closed work order to decide if it needs follow-up.",
+      },
+    ],
   },
   materiales: {
     scenarioId: "research",
@@ -34,6 +57,9 @@ export const PROJECTS: Record<string, LifeProjectInfo> = {
     eyebrow: "materiales-intel · _pending-constructora",
     chipColor: "amber",
     liveStream: false,
+    emptyTitle: "¿Qué material investigamos?",
+    emptyHint:
+      "Describe el material (familia, unidad, región) y el agente consulta proveedores colombianos en vivo, con precios citados.",
   },
   "sentinel-paid": {
     scenarioId: "refactor",
@@ -41,6 +67,16 @@ export const PROJECTS: Record<string, LifeProjectInfo> = {
     eyebrow: "sentinel-property-ops · x402 @ $0.50/run",
     chipColor: "violet",
     liveStream: true,
+    emptyTitle: "Sentinel Pro — paid via x402",
+    emptyHint:
+      "Same audit engine as /life/sentinel. External callers settle $0.50/run via x402 — you'll see the payment approval flow.",
+    suggestions: [
+      {
+        label: "Kick off an audit",
+        prompt:
+          "Audit the last quarter of closed work orders for a 50-unit property and flag top 3 risks.",
+      },
+    ],
   },
 };
 

--- a/apps/chat/app/(site)/life/life-styles.css
+++ b/apps/chat/app/(site)/life/life-styles.css
@@ -11,7 +11,10 @@
   color: var(--ag-text-primary);
   font-family: var(--ag-font-body);
   overflow: hidden;
-  z-index: 0;
+  /* Sit above any site chrome that slipped through the layout filter, so the
+     composer is always reachable. The `.ag-payment-overlay` at z:80 and the
+     Tweaks panel at z:70 stack above the shell via their own rules. */
+  z-index: 50;
 }
 
 .life-shell-root.life-shell-root--orbs {

--- a/apps/chat/components/site/conditional-footer.tsx
+++ b/apps/chat/components/site/conditional-footer.tsx
@@ -3,7 +3,7 @@
 import { usePathname } from "next/navigation";
 import { FlickeringFooter } from "@/components/ui/flickering-footer";
 
-const FOOTER_HIDDEN_PATHS = ["/graph"];
+const FOOTER_HIDDEN_PATHS = ["/graph", "/life"];
 
 export function ConditionalFooter() {
   const pathname = usePathname();

--- a/apps/chat/components/site/conditional-site-chrome.tsx
+++ b/apps/chat/components/site/conditional-site-chrome.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+import { ToolbarDockProvider } from "@/components/site/toolbar-dock-context";
+import { SiteHeader } from "@/components/site/site-header";
+import { TopNav } from "@/components/site/top-nav";
+import { ConditionalFooter } from "@/components/site/conditional-footer";
+
+/**
+ * Paths that opt OUT of the standard site chrome (header / top-nav / footer /
+ * padding) and run in their own full-viewport shell. These are full-surface
+ * experiences — e.g. /life/[project]'s three-column agent workspace — that
+ * need every pixel and can't coexist with the site's header/footer overlays.
+ */
+const BARE_PATHS = ["/life"];
+
+function isBarePath(pathname: string): boolean {
+  return BARE_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+/**
+ * Renders either the standard site layout (header + top-nav + footer +
+ * responsive padding) OR a bare pass-through for experiences that need the
+ * full viewport. Server-rendered parent layouts can compose this client
+ * wrapper without themselves needing to be client components.
+ */
+export function ConditionalSiteChrome({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  if (isBarePath(pathname)) {
+    // Bare mode: no header, no footer, no dock, no padding. The child is
+    // responsible for filling the viewport (usually via position: fixed).
+    return <>{children}</>;
+  }
+
+  return (
+    <ToolbarDockProvider>
+      <div className="flex min-h-screen flex-col bg-bg-deep pt-16 text-text-primary">
+        <SiteHeader />
+        <main className="flex-1 pb-24">{children}</main>
+        <ConditionalFooter />
+        <TopNav />
+      </div>
+    </ToolbarDockProvider>
+  );
+}


### PR DESCRIPTION
User-reported: composer was unreachable on /life/sentinel because the site footer was catching pointer events under the Life shell, and the landing auto-played the server-side scenario replay so users saw scripted output before typing. Fixes: (1) ConditionalSiteChrome wrapper skips site header/footer/top-nav for /life/*; (2) autoStart:false on useLiveRun so live projects start empty; (3) per-project empty-state title+hint+suggestions on the chat column. The reference design stays as a pattern, the mock content goes.