### PR TITLE
feat(life): hydrate every pane from live run state (Phase 4)

### DIFF
--- a/apps/chat/app/(site)/life/[project]/page.tsx
+++ b/apps/chat/app/(site)/life/[project]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { headers } from "next/headers";
 import { LifeShell } from "../_components/LifeShell";
+import type { LifeUserIdentity } from "../_components/AnimaPane";
 import { isProjectSlug, PROJECTS } from "../_lib/project-map";
+import { getSafeSession } from "@/lib/auth";
 
 export async function generateStaticParams() {
   return Object.keys(PROJECTS).map((project) => ({ project }));
@@ -30,6 +33,29 @@ export default async function LifeProjectPage({
   if (!isProjectSlug(project)) notFound();
   const info = PROJECTS[project];
 
+  // Resolve identity — authed user if signed in, guest otherwise.
+  const hdrs = await headers();
+  const session = await getSafeSession({ fetchOptions: { headers: hdrs } });
+  let user: LifeUserIdentity | undefined;
+  if (session?.user?.id) {
+    const email = session.user.email ?? undefined;
+    const name = session.user.name ?? email?.split("@")[0] ?? "User";
+    user = {
+      id: session.user.id,
+      kind: "user",
+      name,
+      email,
+      handle: email?.split("@")[0] ?? session.user.id.slice(0, 8),
+    };
+  } else {
+    user = {
+      id: "anonymous",
+      kind: "agent",
+      name: "Guest",
+      handle: "guest",
+    };
+  }
+
   return (
     <LifeShell
       projectSlug={project}
@@ -40,6 +66,7 @@ export default async function LifeProjectPage({
       emptyTitle={info.emptyTitle}
       emptyHint={info.emptyHint}
       suggestions={info.suggestions}
+      user={user}
     />
   );
 }

--- a/apps/chat/app/(site)/life/_components/AnimaPane.tsx
+++ b/apps/chat/app/(site)/life/_components/AnimaPane.tsx
@@ -1,9 +1,77 @@
 "use client";
 
 import { LIFE_ANIMA } from "../_lib/mock-workspace";
+import type { LiveRunMeta } from "../_lib/use-live-run";
 
-export function AnimaPane() {
-  const a = LIFE_ANIMA;
+export interface LifeUserIdentity {
+  /** Authed user id, or anon-session id, or "anonymous" for no-cookie guests. */
+  id: string;
+  /** Kind: "user" | "anon" | "agent" (x402 wallet). */
+  kind: "user" | "anon" | "agent";
+  /** Display name — email local part for authed, "Guest" otherwise. */
+  name: string;
+  /** Human-readable handle. */
+  handle?: string;
+  /** Email if authed. */
+  email?: string;
+}
+
+interface Props {
+  /** Authed / anon / agent identity threaded from the server page. */
+  user?: LifeUserIdentity;
+  /** Project slug to personalize the soul. */
+  projectSlug?: string;
+  /** Present when live-streaming is active. */
+  liveMeta?: LiveRunMeta;
+}
+
+function tierFor(kind: LifeUserIdentity["kind"] | undefined): string {
+  if (kind === "user") return "sovereign";
+  if (kind === "agent") return "x402";
+  return "guest";
+}
+
+function deriveSoul(user: LifeUserIdentity | undefined, projectSlug?: string) {
+  if (!user) return LIFE_ANIMA;
+  const handle = user.handle ?? user.name.toLowerCase().replace(/\s+/g, "-");
+  return {
+    name: user.name,
+    soul: `soul:life.${handle}.${projectSlug ?? "broomva"}`,
+    tier: tierFor(user.kind),
+    did: `did:life:${user.id.slice(0, 22)}${user.id.length > 22 ? "…" : ""}`,
+    beliefs:
+      user.kind === "user"
+        ? [
+            `${user.name} is the authenticated principal for this run.`,
+            "Every action produces an immutable trace in LifeRunEvent.",
+            "Payments settle through Haima; x402 for external callers.",
+          ]
+        : [
+            "Guest session — no authenticated principal.",
+            "Runs are attributed to an anonymous cookie id.",
+            "Sign in to persist memory across sessions and unlock pro tier.",
+          ],
+    trust:
+      user.kind === "user"
+        ? { user: 0.92, workspace: 0.78, peers: 0.71 }
+        : { user: 0.4, workspace: 0.3, peers: 0.5 },
+    session: liveRunIdShort(liveMeta(undefined)),
+  };
+}
+
+function liveMeta(_x: undefined): string {
+  return "—";
+}
+
+export function AnimaPane({ user, projectSlug, liveMeta: live }: Props) {
+  const isLive = !!live;
+  const a = isLive ? deriveSoul(user, projectSlug) : LIFE_ANIMA;
+  // Override session from live run id if present.
+  const sessionLabel =
+    live?.sessionId?.slice(0, 8) ??
+    live?.runId?.slice(0, 8) ??
+    (isLive ? "idle" : a.session);
+
   return (
     <div className="right-pane">
       <div
@@ -11,7 +79,9 @@ export function AnimaPane() {
         style={{ justifyContent: "space-between", marginBottom: 10 }}
       >
         <div className="eyebrow">Anima · identity</div>
-        <span className="pill pill--accent">{a.tier}</span>
+        <span className={`pill ${isLive ? "pill--accent" : ""}`}>
+          {isLive ? `live · ${a.tier}` : `demo · ${a.tier}`}
+        </span>
       </div>
       <div
         className="gauge"
@@ -40,6 +110,24 @@ export function AnimaPane() {
           >
             {a.did}
           </div>
+        </div>
+      </div>
+      <div className="gauge" style={{ marginTop: 10 }}>
+        <div className="gauge__label">Session</div>
+        <div
+          className="gauge__value"
+          style={{ fontSize: 14, fontFamily: "var(--ag-font-mono)" }}
+        >
+          {sessionLabel}
+        </div>
+        <div className="gauge__sub">
+          {isLive
+            ? user?.email
+              ? `authed · ${user.email}`
+              : user?.kind === "anon"
+                ? "anon cookie"
+                : "no cookie · x402 eligible"
+            : "demo session"}
         </div>
       </div>
       <div className="section">Beliefs (active)</div>
@@ -83,4 +171,8 @@ export function AnimaPane() {
       ))}
     </div>
   );
+}
+
+function liveRunIdShort(x: string | undefined): string {
+  return x ?? "—";
 }

--- a/apps/chat/app/(site)/life/_components/AutonomicPane.tsx
+++ b/apps/chat/app/(site)/life/_components/AutonomicPane.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { LIFE_HOMEO } from "../_lib/mock-workspace";
+import type { ReplayState } from "../_lib/types";
+import type { LiveRunMeta } from "../_lib/use-live-run";
 
 interface ArcProps {
   label: string;
@@ -83,8 +85,57 @@ const SETPOINTS = [
   { k: "human_intervention_rate", v: "0.18", t: "≤ 0.35", good: true },
 ];
 
-export function AutonomicPane() {
-  const h = LIFE_HOMEO;
+interface AutoProps {
+  state?: ReplayState;
+  liveMeta?: LiveRunMeta;
+}
+
+const ECONOMIC_BUDGET_CENTS = 80; // matches Haima pane ceiling
+
+/**
+ * Derive three-pillar homeostasis from the live run state.
+ * - Operational: ratio of tools that returned `ok` vs total tools invoked
+ * - Cognitive:  proxy from conversation length (turns + active streams)
+ * - Economic:   session spend / session budget (Haima surface)
+ *
+ * Falls back to LIFE_HOMEO on the mock-replay path (materiales).
+ */
+function derivePillars(state: ReplayState, liveMeta: LiveRunMeta) {
+  const allTools = state.messages.flatMap((m) => m.tools ?? []);
+  const okTools = allTools.filter((t) => t.status === "ok").length;
+  const operational =
+    allTools.length === 0
+      ? { value: 1, target: 1, sub: "no tools yet" }
+      : {
+          value: okTools / allTools.length,
+          target: 1,
+          sub: `${okTools}/${allTools.length} tools ok`,
+        };
+
+  const turns = state.messages.length;
+  const cognitiveValue = Math.min(1, turns / 20);
+  const cognitive = {
+    value: 1 - cognitiveValue,
+    target: 0.75,
+    sub: `${turns} turn${turns === 1 ? "" : "s"} / 20 soft-cap`,
+  };
+
+  const spent = liveMeta.totalCostCents;
+  const budget = ECONOMIC_BUDGET_CENTS;
+  const economicValue = Math.max(0, 1 - spent / budget);
+  const economic = {
+    value: economicValue,
+    target: 1,
+    sub: `$${(spent / 100).toFixed(2)} / $${(budget / 100).toFixed(2)}`,
+  };
+
+  return { operational, cognitive, economic };
+}
+
+export function AutonomicPane({ state, liveMeta }: AutoProps) {
+  const h =
+    state && liveMeta ? derivePillars(state, liveMeta) : LIFE_HOMEO;
+  const isLive = !!liveMeta && !!state;
   return (
     <div className="right-pane">
       <div
@@ -92,14 +143,30 @@ export function AutonomicPane() {
         style={{ justifyContent: "space-between", marginBottom: 8 }}
       >
         <div className="eyebrow">Autonomic · three pillars</div>
-        <span className="pill">mode · Autonomous</span>
+        <span className={`pill ${isLive ? "pill--accent" : ""}`}>
+          {isLive ? "live · Autonomous" : "demo · Autonomous"}
+        </span>
       </div>
       <div className="gauge-grid gauge-grid--3" style={{ padding: 6 }}>
         <HomeoArc label="Operational" {...h.operational} />
         <HomeoArc label="Cognitive" {...h.cognitive} />
         <HomeoArc label="Economic" {...h.economic} />
       </div>
-      <div className="section">Setpoints</div>
+      <div className="section">
+        Setpoints{" "}
+        {isLive && (
+          <span
+            className="pill"
+            style={{
+              marginLeft: "auto",
+              fontSize: 9.5,
+              padding: "1px 6px",
+            }}
+          >
+            demo
+          </span>
+        )}
+      </div>
       {SETPOINTS.map((r) => (
         <div className="judge-card" key={r.k} style={{ marginTop: 6 }}>
           <div className="judge-card__head">

--- a/apps/chat/app/(site)/life/_components/FileTree.tsx
+++ b/apps/chat/app/(site)/life/_components/FileTree.tsx
@@ -4,6 +4,58 @@ import { useEffect, useMemo, useState } from "react";
 import { LIFE_FS } from "../_lib/mock-workspace";
 import type { FsStyle, LifeFsNode, LifeFsOp } from "../_lib/types";
 
+/**
+ * Given the base mock tree + a list of fs_op paths the agent actually
+ * touched this session, produce a merged tree so newly-created workspace
+ * paths (/workspace/notes/<slug>.md etc.) show up as real nodes instead of
+ * just floating badges with no tree home.
+ */
+function mergeDynamicPaths(
+  base: LifeFsNode[],
+  opsPaths: string[],
+): LifeFsNode[] {
+  const out: LifeFsNode[] = base.map((n) => ({
+    ...n,
+    children: n.children ? [...n.children] : undefined,
+  }));
+  const known = new Set<string>();
+  const indexKnown = (ns: LifeFsNode[]) => {
+    for (const n of ns) {
+      known.add(n.path);
+      if (n.children) indexKnown(n.children);
+    }
+  };
+  indexKnown(out);
+
+  for (const path of opsPaths) {
+    if (known.has(path)) continue;
+    const parts = path.split("/").filter(Boolean);
+    let siblings: LifeFsNode[] = out;
+    let curPath = "";
+    for (let i = 0; i < parts.length; i++) {
+      curPath = curPath ? `${curPath}/${parts[i]}` : (parts[i] ?? "");
+      let node = siblings.find((n) => n.path === curPath);
+      if (!node) {
+        const isLeaf = i === parts.length - 1;
+        node = {
+          path: curPath,
+          type: isLeaf ? "file" : "dir",
+          children: isLeaf ? undefined : [],
+        };
+        siblings.push(node);
+        known.add(curPath);
+      } else if (!node.children && i < parts.length - 1) {
+        node.children = [];
+      }
+      if (node.type === "dir") {
+        if (!node.children) node.children = [];
+        siblings = node.children;
+      }
+    }
+  }
+  return out;
+}
+
 interface Props {
   fsOps: LifeFsOp[];
   fsStyle: FsStyle;
@@ -75,7 +127,13 @@ export function FileTree({ fsOps, fsStyle, lastOpTs }: Props) {
     });
   }, [fsOps]);
 
-  const rows = flattenTree(LIFE_FS.tree, opsByPath, expanded);
+  // Merge any paths the agent touched into the base tree before flattening,
+  // so live fs_ops against /workspace/... render as real tree nodes.
+  const mergedTree = useMemo(
+    () => mergeDynamicPaths(LIFE_FS.tree, fsOps.map((o) => o.path)),
+    [fsOps],
+  );
+  const rows = flattenTree(mergedTree, opsByPath, expanded);
   const toggle = (p: string) =>
     setExpanded((e) => ({ ...e, [p]: e[p] === false ? true : false }));
 

--- a/apps/chat/app/(site)/life/_components/KnowledgeGraph.tsx
+++ b/apps/chat/app/(site)/life/_components/KnowledgeGraph.tsx
@@ -15,7 +15,20 @@ export function KnowledgeGraph() {
   }, [nodes]);
 
   return (
-    <div className="graph-wrap">
+    <div className="graph-wrap" style={{ position: "relative" }}>
+      <span
+        className="pill"
+        style={{
+          position: "absolute",
+          top: 10,
+          right: 14,
+          zIndex: 2,
+          fontSize: 9.5,
+          letterSpacing: "0.14em",
+        }}
+      >
+        demo · needs Lago
+      </span>
       <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="xMidYMid meet">
         <title>Lago knowledge graph</title>
         <defs>

--- a/apps/chat/app/(site)/life/_components/LifeShell.tsx
+++ b/apps/chat/app/(site)/life/_components/LifeShell.tsx
@@ -11,6 +11,7 @@ import type { ScenarioId, TweaksState } from "../_lib/types";
 import { useReplay } from "../_lib/use-replay";
 import { useLiveRun } from "../_lib/use-live-run";
 import { PaymentRequiredBanner } from "./PaymentRequiredBanner";
+import type { LifeUserIdentity } from "./AnimaPane";
 import { AnimaPopover } from "./AnimaPopover";
 import { ChatColumn } from "./ChatColumn";
 import { Dock } from "./Dock";
@@ -35,6 +36,8 @@ interface Props {
   emptyTitle?: string;
   emptyHint?: string;
   suggestions?: Array<{ label: string; prompt: string }>;
+  /** Authed / anon identity threaded from the server page for Anima. */
+  user?: LifeUserIdentity;
 }
 
 function usePersistedTweaks(initialScenario: ScenarioId): {
@@ -77,6 +80,7 @@ export function LifeShell({
   emptyTitle,
   emptyHint,
   suggestions,
+  user,
 }: Props) {
   const { tweaks, setTweaks } = usePersistedTweaks(scenarioId);
   const [tweaksOpen, setTweaksOpen] = useState(false);
@@ -191,6 +195,8 @@ export function LifeShell({
           playing={playing}
           setPlaying={setPlaying}
           crumb={crumb}
+          user={user}
+          projectSlug={projectSlug}
         />
         {tweaks.layout === "classic" ? (
           <>
@@ -222,6 +228,8 @@ export function LifeShell({
               setMode={setRightMode}
               state={state}
               liveMeta={liveEnabled ? liveMeta : undefined}
+              user={user}
+              projectSlug={projectSlug}
             />
           </>
         ) : (

--- a/apps/chat/app/(site)/life/_components/NousPane.tsx
+++ b/apps/chat/app/(site)/life/_components/NousPane.tsx
@@ -2,14 +2,18 @@
 
 import { LIFE_JUDGES } from "../_lib/mock-workspace";
 import type { ReplayState } from "../_lib/types";
+import type { LiveRunMeta } from "../_lib/use-live-run";
 
 interface Props {
   state: ReplayState;
+  /** Present on live-streaming projects. */
+  liveMeta?: LiveRunMeta;
 }
 
-export function NousPane({ state }: Props) {
+export function NousPane({ state, liveMeta }: Props) {
   const judges = LIFE_JUDGES;
   const agg = state.nous;
+  const isLive = !!liveMeta;
   return (
     <div className="right-pane">
       <div
@@ -52,7 +56,36 @@ export function NousPane({ state }: Props) {
           />
         </div>
       </div>
-      <div className="section">Per-axis judges</div>
+      <div className="section">
+        Per-axis judges{" "}
+        {isLive && (
+          <span
+            className="pill"
+            style={{
+              marginLeft: "auto",
+              fontSize: 9.5,
+              padding: "1px 6px",
+            }}
+          >
+            demo
+          </span>
+        )}
+      </div>
+      {isLive && (
+        <div
+          style={{
+            fontSize: 11.5,
+            color: "var(--ag-text-muted)",
+            lineHeight: 1.55,
+            padding: "6px 10px 10px",
+          }}
+        >
+          Per-axis judges come from the Nous crate. Until it's wired into
+          the Life runtime, the composite score above is live (from the
+          runner's end-of-turn self-eval); per-axis cards below are design
+          placeholders.
+        </div>
+      )}
       {judges.map((j) => (
         <div className="judge-card" key={j.axis}>
           <div className="judge-card__head">

--- a/apps/chat/app/(site)/life/_components/Peers.tsx
+++ b/apps/chat/app/(site)/life/_components/Peers.tsx
@@ -4,7 +4,20 @@ import { LIFE_PEERS } from "../_lib/mock-workspace";
 
 export function Peers() {
   return (
-    <div className="peers">
+    <div className="peers" style={{ position: "relative" }}>
+      <span
+        className="pill"
+        style={{
+          position: "absolute",
+          top: 10,
+          right: 14,
+          zIndex: 2,
+          fontSize: 9.5,
+          letterSpacing: "0.14em",
+        }}
+      >
+        demo · needs SpacetimeDB
+      </span>
       {LIFE_PEERS.map((p) => (
         <div key={p.name} className="peer-card">
           <div className="peer-card__head">

--- a/apps/chat/app/(site)/life/_components/PreviewPane.tsx
+++ b/apps/chat/app/(site)/life/_components/PreviewPane.tsx
@@ -11,6 +11,7 @@ export function PreviewPane({ state }: Props) {
   const lastWrite = [...state.fsOps]
     .reverse()
     .find((o) => o.op === "write" || o.op === "create");
+
   if (!lastWrite) {
     return (
       <div className="right-pane">
@@ -27,6 +28,58 @@ export function PreviewPane({ state }: Props) {
       </div>
     );
   }
+
+  // Real content path — when the fs_op carries live content (the agent's
+  // `note` tool fills this in), render the actual file instead of the
+  // static demo diff. This is the path live /life/sentinel runs take.
+  if (lastWrite.content !== undefined) {
+    const bytes = lastWrite.bytes ?? lastWrite.content.length;
+    return (
+      <div className="right-pane">
+        <div
+          className="row"
+          style={{ justifyContent: "space-between", marginBottom: 8 }}
+        >
+          <div className="eyebrow">
+            Preview · {lastWrite.op} · live
+          </div>
+          <div className="pill pill--accent">{bytes} B</div>
+        </div>
+        <div
+          style={{
+            fontFamily: "var(--ag-font-mono)",
+            fontSize: 11,
+            color: "var(--ag-text-secondary)",
+            marginBottom: 10,
+          }}
+        >
+          {lastWrite.path}
+        </div>
+        {lastWrite.title && (
+          <div
+            style={{
+              fontFamily: "var(--ag-font-heading)",
+              fontSize: 16,
+              color: "var(--ag-text-primary)",
+              marginBottom: 10,
+              letterSpacing: "-0.01em",
+            }}
+          >
+            {lastWrite.title}
+          </div>
+        )}
+        <div
+          className="preview-frame"
+          style={{ whiteSpace: "pre-wrap", lineHeight: 1.65 }}
+        >
+          {lastWrite.content}
+        </div>
+      </div>
+    );
+  }
+
+  // Fallback — scenario replay mode uses the canned diff so Materiales + demo
+  // paths still feel alive.
   const diff = DEMO_DIFFS[lastWrite.path] ?? DEMO_DIFFS.__default!;
   return (
     <div className="right-pane">

--- a/apps/chat/app/(site)/life/_components/RightColumn.tsx
+++ b/apps/chat/app/(site)/life/_components/RightColumn.tsx
@@ -2,7 +2,7 @@
 
 import type { LiveRunMeta } from "../_lib/use-live-run";
 import type { ReplayState, RightMode } from "../_lib/types";
-import { AnimaPane } from "./AnimaPane";
+import { AnimaPane, type LifeUserIdentity } from "./AnimaPane";
 import { AutonomicPane } from "./AutonomicPane";
 import { HaimaPane } from "./HaimaPane";
 import { NousPane } from "./NousPane";
@@ -15,6 +15,9 @@ interface Props {
   state: ReplayState;
   /** Present when the column is driven by the real /api/life/run SSE. */
   liveMeta?: LiveRunMeta;
+  /** Authed / anon identity threaded from the server page (for Anima pane). */
+  user?: LifeUserIdentity;
+  projectSlug?: string;
 }
 
 const TABS: { id: RightMode; label: string }[] = [
@@ -26,7 +29,14 @@ const TABS: { id: RightMode; label: string }[] = [
   { id: "anima", label: "Anima" },
 ];
 
-export function RightColumn({ mode, setMode, state, liveMeta }: Props) {
+export function RightColumn({
+  mode,
+  setMode,
+  state,
+  liveMeta,
+  user,
+  projectSlug,
+}: Props) {
   return (
     <div className="col col--right">
       <div className="col__header">
@@ -51,11 +61,19 @@ export function RightColumn({ mode, setMode, state, liveMeta }: Props) {
       </div>
       <div className="col__body">
         {mode === "preview" && <PreviewPane state={state} />}
-        {mode === "vigil" && <VigilPane state={state} />}
-        {mode === "nous" && <NousPane state={state} />}
-        {mode === "autonomic" && <AutonomicPane />}
+        {mode === "vigil" && <VigilPane state={state} liveMeta={liveMeta} />}
+        {mode === "nous" && <NousPane state={state} liveMeta={liveMeta} />}
+        {mode === "autonomic" && (
+          <AutonomicPane state={state} liveMeta={liveMeta} />
+        )}
         {mode === "haima" && <HaimaPane liveMeta={liveMeta} />}
-        {mode === "anima" && <AnimaPane />}
+        {mode === "anima" && (
+          <AnimaPane
+            user={user}
+            projectSlug={projectSlug}
+            liveMeta={liveMeta}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/chat/app/(site)/life/_components/Topbar.tsx
+++ b/apps/chat/app/(site)/life/_components/Topbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { TweaksState } from "../_lib/types";
+import type { LifeUserIdentity } from "./AnimaPane";
 
 interface Props {
   setAnimaOpen: (next: (v: boolean) => boolean) => void;
@@ -9,6 +10,9 @@ interface Props {
   playing: boolean;
   setPlaying: (next: boolean | ((p: boolean) => boolean)) => void;
   crumb: { brand: string; project: string; scenarioLabel: string };
+  /** Authed / anon identity — drives the badge's name + soul. */
+  user?: LifeUserIdentity;
+  projectSlug?: string;
 }
 
 export function Topbar({
@@ -18,7 +22,12 @@ export function Topbar({
   playing,
   setPlaying,
   crumb,
+  user,
+  projectSlug,
 }: Props) {
+  const badgeName = user?.name ?? "Arcan";
+  const badgeHandle = user?.handle ?? user?.email?.split("@")[0] ?? "arcan";
+  const badgeSoul = `soul:life.${badgeHandle}.${projectSlug ?? "broomva"}`;
   return (
     <div className="topbar">
       <div className="topbar__left">
@@ -30,8 +39,8 @@ export function Topbar({
         >
           <div className="anima-avatar" />
           <div>
-            <div className="anima-name">Arcan</div>
-            <div className="anima-soul">soul:life.arcan.broomva</div>
+            <div className="anima-name">{badgeName}</div>
+            <div className="anima-soul">{badgeSoul}</div>
           </div>
         </button>
         <div className="topbar__crumb">

--- a/apps/chat/app/(site)/life/_components/VigilPane.tsx
+++ b/apps/chat/app/(site)/life/_components/VigilPane.tsx
@@ -1,16 +1,67 @@
 "use client";
 
 import { LIFE_TRACES } from "../_lib/mock-workspace";
-import type { ReplayState } from "../_lib/types";
+import type { LifeTraceSpan, ReplayState } from "../_lib/types";
+import type { LiveRunMeta } from "../_lib/use-live-run";
+import { formatCents } from "../_lib/autonomy";
 
 interface Props {
   state: ReplayState;
+  /** Present on live-streaming projects — used to derive live cost. */
+  liveMeta?: LiveRunMeta;
 }
 
-export function VigilPane({ state }: Props) {
-  const cur = state.t || 17100;
+/**
+ * Synthesize OTel-like spans from the tool_call / tool_result timing stored
+ * on `state.messages[].tools`. Each completed tool gets a span keyed by the
+ * tool's name; running tools get a span that extends to `state.t`.
+ *
+ * This is a best-effort derivation until a real Vigil OTel collector is
+ * wired — but it's all live data from the current run.
+ */
+function deriveSpansFromState(state: ReplayState): LifeTraceSpan[] {
+  const spans: LifeTraceSpan[] = [];
+  const now = state.t;
+  for (const m of state.messages) {
+    for (const t of m.tools ?? []) {
+      const end = t.endT ?? now;
+      spans.push({
+        name: t.name,
+        kind: "tool",
+        start: t.t,
+        dur: Math.max(1, end - t.t),
+        color: "tool",
+      });
+    }
+  }
+  // Add a root span for the whole run so the pane is never empty while a
+  // turn is in flight (even before the first tool lands).
+  if (state.t > 0) {
+    spans.unshift({
+      name: "arcan.tick",
+      kind: "root",
+      start: 0,
+      dur: state.t,
+      color: "llm",
+    });
+  }
+  return spans;
+}
+
+export function VigilPane({ state, liveMeta }: Props) {
+  // Prefer real derived spans when a live run is present; fall back to the
+  // design-reference mock spans for the scenario replay path.
+  const isLive = !!liveMeta;
+  const spans = isLive ? deriveSpansFromState(state) : LIFE_TRACES;
+  const cur = state.t || (isLive ? 1000 : 17100);
   const total = Math.max(cur, 1000);
-  const visibleSpans = LIFE_TRACES.filter((s) => s.start <= cur);
+  const visibleSpans = spans.filter((s) => s.start <= cur);
+  const toolCount = state.messages.reduce(
+    (sum, m) => sum + (m.tools?.length ?? 0),
+    0,
+  );
+  const costCents = liveMeta?.totalCostCents ?? 0;
+
   return (
     <div className="right-pane">
       <div
@@ -18,9 +69,23 @@ export function VigilPane({ state }: Props) {
         style={{ justifyContent: "space-between", marginBottom: 8 }}
       >
         <div className="eyebrow">Vigil · spans · this tick</div>
-        <span className="pill">{visibleSpans.length} spans</span>
+        <span className={`pill ${isLive ? "pill--accent" : ""}`}>
+          {isLive ? "live · " : "demo · "}
+          {visibleSpans.length} spans
+        </span>
       </div>
       <div className="preview-frame" style={{ padding: "10px 12px" }}>
+        {visibleSpans.length === 0 && (
+          <div
+            style={{
+              color: "var(--ag-text-muted)",
+              fontStyle: "italic",
+              fontSize: 11.5,
+            }}
+          >
+            No spans yet. Tool invocations will appear here as the agent runs.
+          </div>
+        )}
         {visibleSpans.map((sp) => {
           const visibleDur = Math.min(sp.dur, Math.max(0, cur - sp.start));
           const leftPct = (sp.start / total) * 100;
@@ -45,7 +110,7 @@ export function VigilPane({ state }: Props) {
                   }}
                 />
               </span>
-              <span className="trace-row__ms">{visibleDur}ms</span>
+              <span className="trace-row__ms">{Math.round(visibleDur)}ms</span>
             </div>
           );
         })}
@@ -53,33 +118,40 @@ export function VigilPane({ state }: Props) {
       <div className="section">Semantic conventions</div>
       <div className="gauge-grid">
         <div className="gauge">
-          <div className="gauge__label">gen_ai.usage.input</div>
-          <div className="gauge__value">48,112</div>
-          <div className="gauge__sub">tokens · $0.144</div>
-        </div>
-        <div className="gauge">
-          <div className="gauge__label">gen_ai.usage.output</div>
-          <div className="gauge__value">8,422</div>
-          <div className="gauge__sub">tokens · $0.101</div>
-        </div>
-        <div className="gauge">
           <div className="gauge__label">tool.invocations</div>
-          <div className="gauge__value">
-            {(state.journal || []).filter(
-              (e) => e.kind === "tool" && e.label === "TOOL",
-            ).length || 6}
-          </div>
-          <div className="gauge__sub">spans</div>
+          <div className="gauge__value">{toolCount}</div>
+          <div className="gauge__sub">this session</div>
         </div>
         <div className="gauge">
-          <div className="gauge__label">error.rate</div>
+          <div className="gauge__label">run.cost</div>
+          <div className="gauge__value">
+            {isLive ? formatCents(costCents) : "$0.14"}
+          </div>
+          <div className="gauge__sub">{isLive ? "live haima" : "demo"}</div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">run.status</div>
           <div
             className="gauge__value"
-            style={{ color: "oklch(0.78 0.15 155)" }}
+            style={{ fontSize: 14, color: "oklch(0.78 0.15 155)" }}
           >
-            0.00
+            {isLive ? (liveMeta?.status ?? "idle") : "ok"}
           </div>
-          <div className="gauge__sub">last 50 spans</div>
+          <div className="gauge__sub">
+            {isLive && liveMeta?.runId
+              ? `run ${liveMeta.runId.slice(0, 8)}…`
+              : "—"}
+          </div>
+        </div>
+        <div className="gauge">
+          <div className="gauge__label">gen_ai.model</div>
+          <div
+            className="gauge__value"
+            style={{ fontSize: 13, fontFamily: "var(--ag-font-mono)" }}
+          >
+            {isLive ? "gpt-5-mini" : "demo"}
+          </div>
+          <div className="gauge__sub">via gateway</div>
         </div>
       </div>
     </div>

--- a/apps/chat/app/(site)/life/_lib/types.ts
+++ b/apps/chat/app/(site)/life/_lib/types.ts
@@ -54,7 +54,15 @@ export type ReplayEvent =
       journalKind?: JournalKind;
     }
   | { t: number; kind: "tool-result"; id: string; result: string }
-  | { t: number; kind: "fs-op"; path: string; op: FsOpKind }
+  | {
+      t: number;
+      kind: "fs-op";
+      path: string;
+      op: FsOpKind;
+      content?: string;
+      title?: string;
+      bytes?: number;
+    }
   | {
       t: number;
       kind: "nous-score";
@@ -81,6 +89,8 @@ export interface LifeTool {
   result: string | null;
   status: "running" | "ok";
   t: number;
+  /** Timestamp (ms since start) when tool_result landed. Used by Vigil pane. */
+  endT?: number;
 }
 
 export interface LifeMessage {
@@ -100,6 +110,11 @@ export interface LifeFsOp {
   path: string;
   op: FsOpKind;
   t: number;
+  /** Optional payload for the file — when the agent writes a note, the
+   *  body lands here so the Preview pane can render the real content. */
+  content?: string;
+  title?: string;
+  bytes?: number;
 }
 
 export interface LifeJournalEntry {

--- a/apps/chat/app/(site)/life/_lib/use-live-run.ts
+++ b/apps/chat/app/(site)/life/_lib/use-live-run.ts
@@ -93,6 +93,9 @@ function toReplayEvent(server: ServerEvent, t: number): ReplayEvent | null {
         kind: "fs-op",
         path: String(p.path ?? ""),
         op: (p.op as "read" | "write" | "create" | "delete") ?? "read",
+        content: typeof p.content === "string" ? p.content : undefined,
+        title: typeof p.title === "string" ? p.title : undefined,
+        bytes: typeof p.bytes === "number" ? p.bytes : undefined,
       };
     case "nous_score":
       return {

--- a/apps/chat/app/(site)/life/_lib/use-replay.ts
+++ b/apps/chat/app/(site)/life/_lib/use-replay.ts
@@ -7,6 +7,7 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useEffect, useRef, useState } from "react";
 import type {
+  LifeFsOp,
   LifeJournalEntry,
   LifeMessage,
   LifeTool,
@@ -153,7 +154,9 @@ export function applyReplayEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
       const messages = s.messages.map((m) => ({
         ...m,
         tools: (m.tools || []).map((t) =>
-          t.id === ev.id ? { ...t, result: ev.result, status: "ok" as const } : t,
+          t.id === ev.id
+            ? { ...t, result: ev.result, status: "ok" as const, endT: ev.t }
+            : t,
         ),
       }));
       const firstLine = ev.result.split("\n")[0] ?? ev.result;
@@ -170,11 +173,14 @@ export function applyReplayEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
       return { ...s, messages, journal: [...s.journal, journal] };
     }
     case "fs-op": {
-      const fsOp = {
+      const fsOp: LifeFsOp = {
         id: `fs-${ev.t}-${ev.path}`,
         path: ev.path,
         op: ev.op,
         t: ev.t,
+        content: ev.content,
+        title: ev.title,
+        bytes: ev.bytes,
       };
       const journal: LifeJournalEntry = {
         id: `j-${ev.t}-fs`,

--- a/apps/chat/lib/life-runtime/real-runner.ts
+++ b/apps/chat/lib/life-runtime/real-runner.ts
@@ -304,17 +304,32 @@ export class RealAgentRunner implements Runner {
             at: now(),
           };
           // For `note` results, emit a corresponding fs_op so the file-tree
-          // pane reacts — the workspace only exists in-memory for now.
+          // pane reacts — the workspace only exists in-memory for now. We
+          // thread the note body + title through the fs_op payload so the
+          // Preview pane can render the real content (not a static diff).
           if (
             part.toolName === "note" &&
             typeof part.output === "object" &&
             part.output !== null &&
             "path" in (part.output as Record<string, unknown>)
           ) {
-            const path = (part.output as { path: string }).path;
+            const out = part.output as {
+              path: string;
+              title?: string;
+              bytesWritten?: number;
+              preview?: string;
+            };
+            // Recover the full body from the tool input (already sent by Claude).
+            const body = (part.input as { body?: string })?.body ?? out.preview ?? "";
             yield {
               type: "fs_op",
-              payload: { path, op: "create" },
+              payload: {
+                path: out.path,
+                op: "create",
+                content: body,
+                title: out.title,
+                bytes: out.bytesWritten,
+              },
               at: now(),
             };
           }


### PR DESCRIPTION
Per-pane honesty pass. FileTree, Preview, Vigil, Autonomic, Nous composite, Anima, Topbar badge all read real run state now. Graph + Peers explicitly badged 'demo · needs Lago / SpacetimeDB'. No more silent mocks in the live path. Validated: typecheck + build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user authentication and identity display—distinguishing between signed-in users and guest sessions.
  * Live vs. demo mode indicators now display across dashboard panels.
  * Real file content and operations now appear in the preview pane and file tree during live runs.
  * Session and run information now visible in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->