### PR TITLE
feat(life+prosopon): TS bindings + Prosopon-native /api/life/run endpoint

### DIFF
--- a/apps/chat/app/api/life/run/[project]/prosopon/route.ts
+++ b/apps/chat/app/api/life/run/[project]/prosopon/route.ts
@@ -1,0 +1,418 @@
+/**
+ * POST /api/life/run/[project]/prosopon
+ *
+ * Prosopon-native variant of /api/life/run/[project]. Emits
+ * `Envelope<ProsoponEvent>` frames over SSE — one envelope per `data:` line.
+ * The canonical wire format aligning broomva.tech/life with the Prosopon
+ * display server.
+ *
+ * The legacy endpoint at /api/life/run/[project] (without /prosopon) still
+ * exists for the current UI. It will be removed in PR C once the UI is
+ * migrated to consume envelopes.
+ *
+ * Transport: SSE for now. A WS upgrade path lands when we deploy
+ * prosopon-daemon and switch to its /ws fanout; for a single Next.js
+ * process SSE is sufficient and CDN-friendly.
+ */
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { headers } from "next/headers";
+
+import {
+  type Envelope,
+  encode as encodeEnvelope,
+  makeEnvelope,
+  type ProsoponEvent,
+  ProsoponSession,
+} from "@broomva/prosopon";
+import { getSafeSession } from "@/lib/auth";
+import { getAnonymousSession } from "@/lib/anonymous-session-server";
+import {
+  appendRunEvent,
+  bumpProjectStats,
+  createRun,
+  finishRun,
+  getCurrentRulesVersion,
+  getOrCreateSession,
+  getProjectBySlug,
+  getSessionHistory,
+} from "@/lib/life-runtime/queries";
+import {
+  pickPaymentMode,
+  settleCreditsDebit,
+  userHasCreditsFor,
+} from "@/lib/life-runtime/billing";
+import { RealAgentRunner } from "@/lib/life-runtime/real-runner";
+import {
+  ProsoponEmitter,
+  makeInitialScene,
+  SCENE_ROOT_ID,
+} from "@/lib/life-runtime/prosopon-emitter";
+import {
+  RunRequestSchema,
+  type ConsumerIdentity,
+} from "@/lib/life-runtime/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonError(
+  status: number,
+  message: string,
+  extra: Record<string, unknown> = {},
+) {
+  return NextResponse.json({ error: message, ...extra }, { status });
+}
+
+function sseHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+  };
+}
+
+function sseFrame(envelope: Envelope): string {
+  // SSE: one envelope per "data:" block; event name = "envelope" so clients
+  // can addEventListener("envelope") just like prosopon-daemon's fanout.
+  const json = JSON.stringify(envelope);
+  return `event: envelope\ndata: ${json}\n\n`;
+}
+
+async function resolveConsumer(): Promise<ConsumerIdentity | null> {
+  const hdrs = await headers();
+  const session = await getSafeSession({ fetchOptions: { headers: hdrs } });
+  if (session?.user?.id) {
+    return { kind: "user", id: session.user.id };
+  }
+  const anon = await getAnonymousSession();
+  if (anon) return { kind: "anon", id: anon.id };
+  if (
+    hdrs.get("x-payment") ||
+    hdrs.get("authorization")?.startsWith("x402 ")
+  ) {
+    return {
+      kind: "agent",
+      id: hdrs.get("x-payment-sender") ?? "unknown-wallet",
+    };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+const ParamsSchema = z.object({ project: z.string().min(1).max(128) });
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ project: string }> },
+) {
+  try {
+    return await handlePost(request, params);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[life/run/prosopon] uncaught error:", err);
+    return NextResponse.json(
+      {
+        error: "Internal error while starting Prosopon run.",
+        detail:
+          process.env.VERCEL_ENV === "production"
+            ? "See function logs for trace."
+            : message,
+      },
+      { status: 500 },
+    );
+  }
+}
+
+async function handlePost(
+  request: Request,
+  params: Promise<{ project: string }>,
+) {
+  const resolvedParams = await params;
+  const parsedParams = ParamsSchema.safeParse(resolvedParams);
+  if (!parsedParams.success) {
+    return jsonError(400, "Invalid project slug.");
+  }
+  const { project: slug } = parsedParams.data;
+
+  const project = await getProjectBySlug(slug);
+  if (!project) return jsonError(404, "Project not found.");
+  if (project.status !== "active") {
+    return jsonError(403, `Project is ${project.status}.`);
+  }
+
+  let consumer = await resolveConsumer();
+  if (!consumer) {
+    consumer = { kind: "agent", id: "anonymous" };
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const parsedBody = RunRequestSchema.safeParse(body);
+  if (!parsedBody.success) {
+    return jsonError(400, "Invalid body.", { issues: parsedBody.error.issues });
+  }
+  const {
+    input = {},
+    byokKeyId,
+    sessionId: lifeSessionIdHint,
+    message,
+  } = parsedBody.data;
+  const userMessage = typeof message === "string" ? message.trim() : "";
+
+  const decision = pickPaymentMode({ project, consumer, byokKeyId });
+
+  // 402 Payment Required — return as a plain JSON response with the quote;
+  // the client retries with X-PAYMENT header. Does not use Prosopon envelope
+  // shape because this happens before the session has begun.
+  if (decision.mode === "x402") {
+    return NextResponse.json(
+      {
+        error: "Payment Required",
+        quote: decision.paymentQuote,
+        retryWithHeader: "X-PAYMENT",
+        projectSlug: slug,
+      },
+      {
+        status: 402,
+        headers: {
+          "WWW-Authenticate": `x402 nonce="${decision.paymentQuote?.nonce}"`,
+        },
+      },
+    );
+  }
+
+  if (decision.mode === "credits" && consumer.kind === "user") {
+    const ok = await userHasCreditsFor(consumer.id, decision.quotedCents);
+    if (!ok) {
+      return jsonError(402, "Insufficient credits.", {
+        quotedCents: decision.quotedCents,
+        rationale: decision.rationale,
+      });
+    }
+  }
+
+  // Sessions (LifeSession on our side, separate from ProsoponSession id).
+  const isLiveTurn = userMessage.length > 0;
+  const sessionConsumerKind: "user" | "anon" =
+    consumer.kind === "user" ? "user" : "anon";
+  const lifeSession =
+    isLiveTurn && consumer.kind !== "agent"
+      ? await getOrCreateSession({
+          projectId: project.id,
+          sessionId: lifeSessionIdHint,
+          consumerKind: sessionConsumerKind,
+          consumerId: consumer.id,
+          organizationId: consumer.organizationId,
+        })
+      : null;
+  const history = lifeSession ? await getSessionHistory(lifeSession.id) : [];
+
+  const rulesVersion = await getCurrentRulesVersion(project);
+  const run = await createRun({
+    projectId: project.id,
+    rulesVersionId: rulesVersion?.id ?? null,
+    sessionId: lifeSession?.id,
+    inputText: isLiveTurn ? userMessage : undefined,
+    consumerKind: consumer.kind,
+    consumerId: consumer.id,
+    organizationId: consumer.organizationId,
+    input,
+    paymentMode: decision.mode,
+  });
+
+  // Prosopon session id — when we have a LifeSession, reuse its id so the
+  // Prosopon stream and LifeRun table share a stable handle. Otherwise mint
+  // a random one scoped to this run.
+  const prosoponSessionId = lifeSession?.id ?? run.id;
+
+  // Scenario replay path is NOT supported on the Prosopon endpoint — this is
+  // intentionally "live only". Scenario demos continue to work on the legacy
+  // endpoint (without /prosopon) until PR D removes it.
+  if (!isLiveTurn) {
+    return jsonError(
+      400,
+      "Prosopon endpoint requires a `message` in the request body. " +
+        "Scenario-replay demos still work on /api/life/run/[project] until PR D.",
+    );
+  }
+
+  const runner = new RealAgentRunner({
+    projectSlug: slug,
+    moduleTypeId: project.moduleTypeId,
+    input,
+    maxCostCents: decision.maxCostCents,
+    project,
+    history,
+    userMessage,
+    paymentMode: decision.mode,
+  });
+
+  let finalCostCents = 0;
+  let model: string | undefined;
+  let provider: string | undefined;
+  let assistantTextAccum = "";
+
+  const emitter = new ProsoponEmitter({
+    sessionId: prosoponSessionId,
+    projectSlug: slug,
+    displayName: project.displayName,
+    paymentMode: decision.mode,
+    priorCostCents: 0,
+  });
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const enc = new TextEncoder();
+      let frameSeq = 0;
+
+      const write = async (envelope: Envelope) => {
+        controller.enqueue(enc.encode(sseFrame(envelope)));
+        // Persist the envelope JSON into LifeRunEvent so reruns can be
+        // reconstructed — Prosopon's "journal" on our substrate.
+        await appendRunEvent(run.id, frameSeq++, envelope.event.type, {
+          envelope: envelope as unknown as Record<string, unknown>,
+        });
+      };
+
+      try {
+        // Envelope 1..N: scene_reset + initial signals.
+        for (const env of emitter.runStarted()) {
+          await write(env);
+        }
+
+        // Attach the onFinish hook so we capture llm cost + model.
+        runner["opts"].onFinish = (cost) => {
+          finalCostCents = cost.llmCents;
+          model = cost.model;
+          provider = cost.provider;
+        };
+
+        for await (const ev of runner.run()) {
+          if (ev.type === "text_delta") {
+            const t = (ev.payload as { text?: string }).text ?? "";
+            assistantTextAccum += t;
+          }
+          for (const env of emitter.translate(ev)) {
+            await write(env);
+          }
+        }
+
+        await finishRun({
+          runId: run.id,
+          status: "succeeded",
+          output: assistantTextAccum ? { text: assistantTextAccum } : undefined,
+          llmCostCents: finalCostCents,
+          consumerPaidCents: decision.quotedCents,
+          model,
+          provider,
+        });
+        if (decision.mode === "credits" && consumer.kind === "user") {
+          await settleCreditsDebit({
+            userId: consumer.id,
+            mode: decision.mode,
+            amountCents: decision.quotedCents,
+          });
+        }
+        try {
+          await bumpProjectStats(project.id, finalCostCents);
+        } catch (statsErr) {
+          console.warn(
+            "[life/run/prosopon] bumpProjectStats failed (non-fatal):",
+            statsErr,
+          );
+        }
+
+        // Final heartbeat so clients flush timers.
+        await write(emitter.heartbeat());
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        const errorEnv = makeEnvelope({
+          session_id: prosoponSessionId,
+          seq: frameSeq + 1,
+          event: {
+            type: "node_added",
+            parent: SCENE_ROOT_ID,
+            node: {
+              id: `err-${Date.now().toString(36)}`,
+              intent: {
+                type: "confirm",
+                message: msg,
+                severity: "danger",
+              },
+              children: [],
+              bindings: [],
+              actions: [],
+              attrs: {},
+              lifecycle: { created_at: new Date().toISOString() },
+            },
+          } as ProsoponEvent,
+        });
+        try {
+          await write(errorEnv);
+        } catch {
+          /* ignore */
+        }
+        await finishRun({
+          runId: run.id,
+          status: "failed",
+          errorReason: msg,
+        });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, { headers: sseHeaders() });
+}
+
+/**
+ * GET /api/life/run/[project]/prosopon
+ * Diagnostic — returns the initial Scene that POST would emit as its
+ * scene_reset. Lets clients render a skeleton UI before the first turn.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ project: string }> },
+) {
+  try {
+    const { project: slug } = await params;
+    const project = await getProjectBySlug(slug);
+    if (!project) {
+      return NextResponse.json(
+        { ok: false, reason: "project-not-found", slug },
+        { status: 404 },
+      );
+    }
+    const scene = makeInitialScene({
+      projectSlug: slug,
+      displayName: project.displayName,
+    });
+    return NextResponse.json({
+      ok: true,
+      project: {
+        slug: project.slug,
+        displayName: project.displayName,
+        moduleTypeId: project.moduleTypeId,
+      },
+      scene,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, reason: "internal", detail: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/chat/lib/life-runtime/prosopon-emitter.ts
+++ b/apps/chat/lib/life-runtime/prosopon-emitter.ts
@@ -1,0 +1,485 @@
+/**
+ * Prosopon emitter — translates the `RealAgentRunner`'s internal `RunEvent`
+ * stream into Prosopon envelopes. Server-only.
+ *
+ * Scene scaffold on run start:
+ *
+ *   root (Section: "Life Runtime")
+ *   ├─ chat       (Section: "Chat")
+ *   ├─ workspace  (Section: "Workspace")
+ *   └─ inspector  (Section: "Inspector")
+ *
+ * As the agent runs:
+ *   - Each assistant turn → a Stream{kind:text} child of chat
+ *   - Each text_delta     → StreamChunk on that stream
+ *   - Each tool call      → a ToolCall child of chat, patched to ToolResult
+ *                           when the result lands
+ *   - Each fs_op          → a Custom{kind:"fs.write"} child of workspace
+ *                           carrying {path, content, title, bytes} payload
+ *   - nous_score / autonomic_event / cost → SignalChanged on topics
+ *     nous.composite / autonomic.<pillar> / haima.spend.cents
+ *   - Heartbeat every 5s between events so long-running turns don't look
+ *     disconnected.
+ *
+ * Live cost signals are also emitted as a SignalChanged on every delta so
+ * the Haima pane animates during streaming — not just at turn end.
+ *
+ * This module depends on @broomva/prosopon purely for types + helpers;
+ * there's no runtime coupling to the Rust daemon today. When we deploy
+ * prosopon-daemon, callers pipe these envelopes into its fanout instead of
+ * writing them directly into SSE frames.
+ */
+
+import "server-only";
+import {
+  makeEnvelope,
+  type Envelope,
+  type ProsoponEvent,
+  type Scene,
+  type SceneNode,
+  ProsoponSession,
+} from "@broomva/prosopon";
+import type { RunEvent } from "./types";
+
+// Stable node ids so downstream patches and callers can reference them.
+export const SCENE_ROOT_ID = "root";
+export const CHAT_NODE_ID = "chat";
+export const WORKSPACE_NODE_ID = "workspace";
+export const INSPECTOR_NODE_ID = "inspector";
+
+const nowIso = (): string => new Date().toISOString();
+
+function freshNode(id: string, intent: SceneNode["intent"]): SceneNode {
+  return {
+    id,
+    intent,
+    children: [],
+    bindings: [],
+    actions: [],
+    attrs: {},
+    lifecycle: { created_at: nowIso() },
+  };
+}
+
+/**
+ * Build the initial Scene sent on a scene_reset at run start.
+ * The three Section children are permanent targets for NodeAdded events.
+ */
+export function makeInitialScene(args: {
+  projectSlug: string;
+  displayName: string;
+  sceneId?: string;
+}): Scene {
+  const chat = freshNode(CHAT_NODE_ID, {
+    type: "section",
+    title: "Chat",
+    collapsible: false,
+  });
+  const workspace = freshNode(WORKSPACE_NODE_ID, {
+    type: "section",
+    title: "Workspace",
+    collapsible: false,
+  });
+  const inspector = freshNode(INSPECTOR_NODE_ID, {
+    type: "section",
+    title: "Inspector",
+    collapsible: false,
+  });
+  const root = freshNode(SCENE_ROOT_ID, {
+    type: "section",
+    title: args.displayName,
+    collapsible: false,
+  });
+  root.children = [chat, workspace, inspector];
+  root.attrs = { project: args.projectSlug };
+  return {
+    id: args.sceneId ?? `scene-${args.projectSlug}-${Date.now().toString(36)}`,
+    root,
+    signals: {},
+    hints: { density: "comfortable", intent_profile: "conversational" },
+  };
+}
+
+export interface EmitterOptions {
+  sessionId: string;
+  projectSlug: string;
+  displayName: string;
+  paymentMode: string;
+  /** Cumulative cost at turn-start, so we can emit live deltas on top. */
+  priorCostCents?: number;
+}
+
+/**
+ * Stateful translator. Each agent turn produces one instance; it tracks the
+ * current stream + tool ids so Updated/StreamChunk events reference the right
+ * nodes.
+ */
+export class ProsoponEmitter {
+  readonly session: ProsoponSession;
+  readonly opts: EmitterOptions;
+  private currentMessageId: string | null = null;
+  private streamSeqByMessage = new Map<string, number>();
+  private toolNodeIdByCallId = new Map<string, string>();
+  private fsNodeCounter = 0;
+
+  constructor(opts: EmitterOptions) {
+    this.session = new ProsoponSession({ sessionId: opts.sessionId });
+    this.opts = opts;
+  }
+
+  /**
+   * Emit the initial envelopes for a new run — scene reset, run metadata
+   * signals, starting cost.
+   */
+  *runStarted(): Generator<Envelope> {
+    const scene = makeInitialScene({
+      projectSlug: this.opts.projectSlug,
+      displayName: this.opts.displayName,
+    });
+    yield this.session.emit({ type: "scene_reset", scene });
+
+    // Static-for-this-turn signals — projectSlug, paymentMode — broadcast once.
+    yield this.session.emit({
+      type: "signal_changed",
+      topic: "life.project.slug",
+      value: { Scalar: this.opts.projectSlug } as unknown as Record<
+        string,
+        unknown
+      >,
+      ts: nowIso(),
+    } as ProsoponEvent);
+
+    yield this.session.emit({
+      type: "signal_changed",
+      topic: "haima.payment_mode",
+      value: { Scalar: this.opts.paymentMode } as unknown as Record<
+        string,
+        unknown
+      >,
+      ts: nowIso(),
+    } as ProsoponEvent);
+
+    if (typeof this.opts.priorCostCents === "number") {
+      yield this.session.emit({
+        type: "signal_changed",
+        topic: "haima.spend.cents",
+        value: { Scalar: this.opts.priorCostCents } as unknown as Record<
+          string,
+          unknown
+        >,
+        ts: nowIso(),
+      } as ProsoponEvent);
+    }
+  }
+
+  /**
+   * Translate one RunEvent into one-or-more Envelopes. Yields envelopes in
+   * the order they should hit the wire.
+   */
+  *translate(event: RunEvent): Generator<Envelope> {
+    switch (event.type) {
+      case "run_started":
+        // Internal; scene reset already emitted.
+        return;
+
+      case "thinking_start": {
+        const id = payloadString(event, "id") ?? this.nextMessageId();
+        this.currentMessageId = id;
+        const msgNode = freshNode(`msg-${id}`, {
+          type: "section",
+          title: "Reasoning",
+          collapsible: true,
+        });
+        msgNode.lifecycle = {
+          created_at: nowIso(),
+          status: { kind: "pending" },
+        };
+        yield this.session.emit({
+          type: "node_added",
+          parent: CHAT_NODE_ID,
+          node: msgNode,
+        });
+        return;
+      }
+
+      case "thinking_delta": {
+        const id = payloadString(event, "id");
+        if (!id) return;
+        yield this.session.emit({
+          type: "node_updated",
+          id: `msg-${id}`,
+          patch: {
+            attrs: { thinking: payloadString(event, "text") ?? "" },
+          },
+        });
+        return;
+      }
+
+      case "thinking_end": {
+        const id = payloadString(event, "id");
+        if (!id) return;
+        yield this.session.emit({
+          type: "node_updated",
+          id: `msg-${id}`,
+          patch: {
+            lifecycle: {
+              created_at: nowIso(),
+              status: { kind: "resolved" },
+            },
+          },
+        });
+        return;
+      }
+
+      case "text_start": {
+        const id = payloadString(event, "id") ?? this.nextMessageId();
+        this.currentMessageId = id;
+        const streamNodeId = `stream-${id}`;
+        const streamNode = freshNode(streamNodeId, {
+          type: "stream",
+          id: streamNodeId,
+          kind: "text",
+        });
+        yield this.session.emit({
+          type: "node_added",
+          parent: CHAT_NODE_ID,
+          node: streamNode,
+        });
+        this.streamSeqByMessage.set(id, 0);
+        return;
+      }
+
+      case "text_delta": {
+        const id = payloadString(event, "id");
+        const text = payloadString(event, "text") ?? "";
+        if (!id) return;
+        const seq = (this.streamSeqByMessage.get(id) ?? 0) + 1;
+        this.streamSeqByMessage.set(id, seq);
+        yield this.session.emit({
+          type: "stream_chunk",
+          id: `stream-${id}`,
+          chunk: {
+            seq,
+            payload: { encoding: "text", text },
+            final_: false,
+          },
+        });
+        return;
+      }
+
+      case "text_end": {
+        const id = payloadString(event, "id");
+        if (!id) return;
+        const seq = (this.streamSeqByMessage.get(id) ?? 0) + 1;
+        this.streamSeqByMessage.set(id, seq);
+        yield this.session.emit({
+          type: "stream_chunk",
+          id: `stream-${id}`,
+          chunk: {
+            seq,
+            payload: { encoding: "text", text: "" },
+            final_: true,
+          },
+        });
+        return;
+      }
+
+      case "tool_call": {
+        const callId = payloadString(event, "id") ?? `tc-${Date.now()}`;
+        const name = payloadString(event, "name") ?? "unknown";
+        const target = payloadString(event, "target") ?? "";
+        const nodeId = `tool-${callId}`;
+        this.toolNodeIdByCallId.set(callId, nodeId);
+        let parsedArgs: unknown;
+        try {
+          parsedArgs = JSON.parse(payloadString(event, "args") ?? "{}");
+        } catch {
+          parsedArgs = { raw: payloadString(event, "args") ?? "" };
+        }
+        const toolNode = freshNode(nodeId, {
+          type: "tool_call",
+          name: target ? `${name}:${target}` : name,
+          args: parsedArgs as Record<string, unknown>,
+        });
+        toolNode.lifecycle = {
+          created_at: nowIso(),
+          status: { kind: "pending" },
+        };
+        yield this.session.emit({
+          type: "node_added",
+          parent: CHAT_NODE_ID,
+          node: toolNode,
+        });
+        return;
+      }
+
+      case "tool_result": {
+        const callId = payloadString(event, "id") ?? "";
+        const nodeId = this.toolNodeIdByCallId.get(callId);
+        if (!nodeId) return;
+        const result = payloadString(event, "result") ?? "";
+        yield this.session.emit({
+          type: "node_updated",
+          id: nodeId,
+          patch: {
+            intent: {
+              type: "tool_result",
+              success: true,
+              payload: { text: result } as Record<string, unknown>,
+            },
+            lifecycle: {
+              created_at: nowIso(),
+              status: { kind: "resolved" },
+            },
+          },
+        });
+        return;
+      }
+
+      case "fs_op": {
+        const path = payloadString(event, "path") ?? "";
+        const op = payloadString(event, "op") ?? "write";
+        const content = payloadString(event, "content") ?? "";
+        const title = payloadString(event, "title") ?? "";
+        const bytes = payloadNumber(event, "bytes") ?? content.length;
+        const id = `fs-${++this.fsNodeCounter}`;
+        const fsNode = freshNode(id, {
+          type: "custom",
+          kind: "fs.op",
+          payload: {
+            path,
+            op,
+            content,
+            title,
+            bytes,
+          } as Record<string, unknown>,
+        });
+        yield this.session.emit({
+          type: "node_added",
+          parent: WORKSPACE_NODE_ID,
+          node: fsNode,
+        });
+        return;
+      }
+
+      case "nous_score": {
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "nous.composite",
+          value: {
+            Scalar: payloadNumber(event, "score") ?? 0,
+          } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "nous.band",
+          value: {
+            Scalar: payloadString(event, "band") ?? "unknown",
+          } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        return;
+      }
+
+      case "autonomic_event": {
+        const pillar = payloadString(event, "pillar") ?? "unknown";
+        const text = payloadString(event, "text") ?? "";
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: `autonomic.${pillar}.note`,
+          value: { Scalar: text } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        return;
+      }
+
+      case "done": {
+        const costCents = payloadNumber(event, "costCents") ?? 0;
+        const inputTokens = payloadNumber(event, "inputTokens") ?? 0;
+        const outputTokens = payloadNumber(event, "outputTokens") ?? 0;
+        const elapsedMs = payloadNumber(event, "elapsedMs") ?? 0;
+        const total =
+          (this.opts.priorCostCents ?? 0) + costCents;
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "haima.spend.cents",
+          value: { Scalar: total } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "haima.last_turn.cents",
+          value: { Scalar: costCents } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "vigil.tokens.input",
+          value: { Scalar: inputTokens } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "vigil.tokens.output",
+          value: { Scalar: outputTokens } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        yield this.session.emit({
+          type: "signal_changed",
+          topic: "vigil.duration.ms",
+          value: { Scalar: elapsedMs } as unknown as Record<string, unknown>,
+          ts: nowIso(),
+        } as ProsoponEvent);
+        return;
+      }
+
+      case "error": {
+        // Surface as a Confirm intent with danger severity under chat —
+        // compositors decide whether to render a toast, modal, inline block.
+        const message = payloadString(event, "message") ?? "unknown error";
+        const errNode = freshNode(`err-${Date.now().toString(36)}`, {
+          type: "confirm",
+          message,
+          severity: "danger",
+        });
+        yield this.session.emit({
+          type: "node_added",
+          parent: CHAT_NODE_ID,
+          node: errNode,
+        });
+        return;
+      }
+
+      default:
+        // Unknown RunEvent — ignore (forward-compat).
+        return;
+    }
+  }
+
+  /** Emit a heartbeat. Callers may send every ~5s to indicate liveness. */
+  heartbeat(): Envelope {
+    return this.session.emit({
+      type: "heartbeat",
+      ts: nowIso(),
+    });
+  }
+
+  private nextMessageId(): string {
+    return `m-${Date.now().toString(36)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function payloadString(ev: RunEvent, key: string): string | undefined {
+  const v = (ev.payload as Record<string, unknown> | undefined)?.[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+function payloadNumber(ev: RunEvent, key: string): number | undefined {
+  const v = (ev.payload as Record<string, unknown> | undefined)?.[key];
+  return typeof v === "number" ? v : undefined;
+}

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -182,7 +182,8 @@
     "uuid": "^11.1.0",
     "vaul": "^1.1.2",
     "zod": "^4.3.6",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "@broomva/prosopon": "workspace:*"
   },
   "overrides": {
     "commander": "^14.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@ai-sdk/react": "3.0.143",
         "@auth/agent": "^0.4.3",
         "@better-auth/agent-auth": "^0.4.0",
+        "@broomva/prosopon": "workspace:*",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-python": "^6.1.6",
         "@codemirror/state": "^6.5.0",
@@ -226,6 +227,15 @@
         "typescript": "^5.8.0",
       },
     },
+    "packages/prosopon-ts": {
+      "name": "@broomva/prosopon",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "json-schema-to-typescript": "^15.0.4",
+        "typescript": "^5.8.0",
+      },
+    },
     "packages/sentinel-property-ops": {
       "name": "@broomva/sentinel-property-ops",
       "version": "0.1.0",
@@ -269,6 +279,8 @@
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.68.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-SMYAmbbiprG8k1EjEPMTwaTqssDT7Ae+jxcR5kWXiqTlbwMR2AthXtscEVWOHkRfyAV5+y3PFYTJRNa3OJWIEw=="],
+
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
     "@auth/agent": ["@auth/agent@0.4.3", "", { "dependencies": { "jose": "^6.0.0" }, "peerDependencies": { "ai": ">=3.0.0" }, "optionalPeers": ["ai"] }, "sha512-8eauR5ilnVboQjlbRuuClNZXFQUvm7J6otvLaYesnH5E6h3mXjqhN64AQbKMYfe2NJieliFbbNNw5KtXRNpogQ=="],
 
@@ -357,6 +369,8 @@
     "@broomva/life-modules-core": ["@broomva/life-modules-core@workspace:packages/life-modules-core"],
 
     "@broomva/materiales-intel": ["@broomva/materiales-intel@workspace:packages/materiales-intel"],
+
+    "@broomva/prosopon": ["@broomva/prosopon@workspace:packages/prosopon-ts"],
 
     "@broomva/sentinel-property-ops": ["@broomva/sentinel-property-ops@workspace:packages/sentinel-property-ops"],
 
@@ -601,6 +615,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
 
     "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
@@ -1350,6 +1366,8 @@
 
     "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
@@ -2056,7 +2074,11 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
@@ -2107,6 +2129,8 @@
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-to-typescript": ["json-schema-to-typescript@15.0.4", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^11.5.5", "@types/json-schema": "^7.0.15", "@types/lodash": "^4.17.7", "is-glob": "^4.0.3", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "minimist": "^1.2.8", "prettier": "^3.2.5", "tinyglobby": "^0.2.9" }, "bin": { "json2ts": "dist/src/cli.js" } }, "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -2988,6 +3012,8 @@
 
     "@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@apidevtools/json-schema-ref-parser/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -3220,6 +3246,8 @@
 
     "jest-worker/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
+    "json-schema-to-typescript/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "light-my-request/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
@@ -3277,6 +3305,8 @@
     "@ai-sdk-tools/store/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
 
     "@ai-sdk-tools/store/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.22", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw=="],
+
+    "@apidevtools/json-schema-ref-parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -3491,6 +3521,8 @@
     "fumadocs-mdx/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "jest-worker/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "json-schema-to-typescript/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/packages/prosopon-ts/README.md
+++ b/packages/prosopon-ts/README.md
@@ -1,0 +1,76 @@
+# @broomva/prosopon
+
+TypeScript bindings for [Prosopon](../../../core/prosopon) — the Life Agent OS display server. Wire-compatible with `prosopon-protocol` v1.
+
+## What this package provides
+
+| Module | Purpose |
+|---|---|
+| `.` (default) | Re-exports of IR types + runtime helpers |
+| `./codec` | JSON/JSONL envelope encode/decode |
+| `./apply-event` | Pure reducer: `applyEvent(scene, event) → scene` |
+| `./client` | Browser client — WS primary, SSE fallback |
+| `./session` | Server-side session emitter |
+| `./ids` | ID factories (NodeId, SceneId, StreamId, Topic) |
+
+## Type layering
+
+```
+src/
+├── generated/
+│   ├── scene.json         ← snapshot of prosopon-core's JSON schema (Scene)
+│   ├── event.json         ← snapshot (ProsoponEvent)
+│   └── types.ts           ← json-schema-to-typescript output (generated)
+├── types.ts               ← re-exports + curated facade over generated types
+├── codec.ts               ← Envelope + Codec (JSON, JSONL) matching prosopon-protocol
+├── apply-event.ts         ← Pure reducer for all 8 ProsoponEvent variants
+├── client.ts              ← WS primary, SSE fallback, reconnect policy
+├── session.ts             ← Server emitter (used by broomva.tech API routes)
+├── ids.ts                 ← ID factory helpers
+└── index.ts
+```
+
+## Regenerating types from the Rust source of truth
+
+```bash
+cd ../../../core/prosopon
+cargo run -p prosopon-cli -- schema scene > /tmp/scene.json
+cargo run -p prosopon-cli -- schema event > /tmp/event.json
+cd -
+cp /tmp/scene.json src/generated/scene.json
+cp /tmp/event.json src/generated/event.json
+bun run generate
+```
+
+## Minimal example
+
+### Server (Node / Bun / edge)
+
+```ts
+import { ProsoponSession, makeEnvelope } from "@broomva/prosopon";
+
+const session = new ProsoponSession("session-123");
+yield session.sceneReset({ id: "scene-1", root: { ... } });
+yield session.nodeAdded("chat", { intent: { type: "stream", id: "m1", kind: "text" } });
+yield session.streamChunk("m1", { encoding: "text", text: "Hello" }, 1);
+```
+
+### Browser
+
+```ts
+import { ProsoponClient, applyEvent, type Scene } from "@broomva/prosopon";
+
+const client = new ProsoponClient("/api/life/run/sentinel/prosopon");
+let scene: Scene = { id: "init", root: { id: "root", intent: { type: "empty" }, children: [], bindings: [], actions: [], attrs: {}, lifecycle: { created_at: new Date().toISOString() } } };
+
+client.onEnvelope((envelope) => {
+  scene = applyEvent(scene, envelope.event);
+  render(scene);
+});
+
+client.connect();
+```
+
+## Forward-compat
+
+When Mission Control / Prompter / third parties adopt Prosopon, this package migrates into `core/prosopon/bindings/typescript/` and publishes to npm. Imports don't change.

--- a/packages/prosopon-ts/package.json
+++ b/packages/prosopon-ts/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@broomva/prosopon",
+  "version": "0.1.0",
+  "description": "TypeScript bindings for Prosopon (the Life Agent OS display server). IR types auto-generated from prosopon-core's JSON schemas; runtime helpers (codecs, reducer, WS/SSE client) hand-written. Wire-compatible with prosopon-protocol v1.",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./codec": "./src/codec.ts",
+    "./apply-event": "./src/apply-event.ts",
+    "./client": "./src/client.ts",
+    "./session": "./src/session.ts",
+    "./ids": "./src/ids.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "generate": "bun run scripts/generate-types.ts",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "json-schema-to-typescript": "^15.0.4",
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/prosopon-ts/scripts/generate-types.ts
+++ b/packages/prosopon-ts/scripts/generate-types.ts
@@ -1,0 +1,112 @@
+/**
+ * Auto-generate TypeScript types from the JSON schemas published by
+ * `prosopon-core::scene_schema_json` + `event_schema_json`.
+ *
+ * Usage:
+ *   bun run scripts/generate-types.ts
+ *
+ * Input:  src/generated/{scene,event}.json (committed snapshots)
+ * Output: src/generated/types.ts
+ *
+ * To refresh the snapshots from the canonical Rust source:
+ *   cd ../../../core/prosopon
+ *   cargo run -p prosopon-cli -- schema scene > $(pwd)/src/generated/scene.json
+ *   cargo run -p prosopon-cli -- schema event > $(pwd)/src/generated/event.json
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { compile } from "json-schema-to-typescript";
+
+const ROOT = path.resolve(new URL("..", import.meta.url).pathname);
+const GEN = path.join(ROOT, "src", "generated");
+
+const BANNER = `/**
+ * AUTO-GENERATED — do not edit by hand.
+ *
+ * Source of truth: core/prosopon/crates/prosopon-core (Rust).
+ * Regenerate with \`bun run generate\` from packages/prosopon-ts/.
+ *
+ * Generated on: ${new Date().toISOString()}
+ */
+/* eslint-disable */
+/* biome-ignore-all */
+`;
+
+/**
+ * Merge the two published schemas into a single composite schema whose root
+ * has two properties: `scene` (Scene) and `event` (ProsoponEvent). Shared
+ * definitions (Node, Intent, Lifecycle, etc.) appear once in the merged
+ * `definitions` block, so json-schema-to-typescript emits each type exactly
+ * once. We then post-process the output to drop the synthetic root wrapper.
+ */
+async function main(): Promise<void> {
+  const [sceneSrc, eventSrc] = await Promise.all([
+    readFile(path.join(GEN, "scene.json"), "utf-8"),
+    readFile(path.join(GEN, "event.json"), "utf-8"),
+  ]);
+  const scene = JSON.parse(sceneSrc) as SchemaShape;
+  const event = JSON.parse(eventSrc) as SchemaShape;
+
+  const sceneDefs = scene.definitions ?? {};
+  const eventDefs = event.definitions ?? {};
+
+  // The top-level schemas (Scene / ProsoponEvent) go into `definitions` so
+  // they become named exports alongside shared types. We peel the root-level
+  // `oneOf` off the event schema and keep it as the ProsoponEvent definition.
+  const stripRoot = (s: SchemaShape): SchemaShape => {
+    const { definitions: _d, ...root } = s;
+    void _d;
+    return root;
+  };
+
+  const combined = {
+    $schema: "http://json-schema.org/draft-07/schema#",
+    title: "Prosopon",
+    description: "Combined Scene + ProsoponEvent schema for TS code-gen.",
+    type: "object",
+    required: ["scene", "event"],
+    properties: {
+      scene: { $ref: "#/definitions/Scene" },
+      event: { $ref: "#/definitions/ProsoponEvent" },
+    },
+    definitions: {
+      Scene: stripRoot(scene),
+      ProsoponEvent: stripRoot(event),
+      ...sceneDefs,
+      ...eventDefs,
+    },
+  };
+
+  const compiled = await compile(
+    combined as Parameters<typeof compile>[0],
+    "Prosopon",
+    {
+      bannerComment: "",
+      declareExternallyReferenced: true,
+      strictIndexSignatures: true,
+      additionalProperties: false,
+    },
+  );
+
+  // Drop the synthetic `export interface Prosopon { scene, event }` wrapper —
+  // callers import Scene + ProsoponEvent directly. Everything else stays.
+  const cleaned = compiled.replace(
+    /export interface Prosopon \{[\s\S]*?scene: Scene;[\s\S]*?event: ProsoponEvent;[\s\S]*?\}\n+/,
+    "",
+  );
+
+  const out = `${BANNER}\n${cleaned}\n`;
+  await writeFile(path.join(GEN, "types.ts"), out);
+  console.log(`✓ wrote src/generated/types.ts (${out.length} bytes)`);
+}
+
+interface SchemaShape {
+  definitions?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/prosopon-ts/src/apply-event.ts
+++ b/packages/prosopon-ts/src/apply-event.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure reducer — `applyEvent(scene, event) → scene`.
+ *
+ * Mirrors the semantics of `prosopon_runtime::SceneStore` in Rust. Given a
+ * current scene and an incoming ProsoponEvent, returns the updated scene.
+ * Never mutates its inputs. Unknown / future event variants are passed
+ * through as no-ops (forward-compat).
+ *
+ * This is intentionally tiny and dependency-free so it runs identically in
+ * the browser, Node, Bun, and edge runtimes.
+ */
+
+import type {
+  ChildrenPatch,
+  NodePatch,
+  ProsoponEvent,
+  Scene,
+  SceneNode,
+  SignalValue,
+} from "./types";
+
+/**
+ * Core reducer. Returns a fresh Scene on change; returns the input reference
+ * on no-op so React + Zustand users can cheaply detect "nothing happened".
+ */
+export function applyEvent(scene: Scene, event: ProsoponEvent): Scene {
+  // ProsoponEvent is tagged by `type` (snake_case). This dispatch matches
+  // the Rust enum variants exactly.
+  const ev = event as ProsoponEventNarrowed;
+  switch (ev.type) {
+    case "scene_reset":
+      return ev.scene;
+
+    case "node_added":
+      return replaceNodeById(scene, ev.parent, (node) => ({
+        ...node,
+        children: [...(node.children ?? []), ev.node],
+      }));
+
+    case "node_updated":
+      return replaceNodeById(scene, ev.id, (node) =>
+        applyPatch(node, ev.patch),
+      );
+
+    case "node_removed":
+      return removeNodeById(scene, ev.id);
+
+    case "signal_changed":
+      return {
+        ...scene,
+        signals: {
+          ...(scene.signals ?? {}),
+          [ev.topic]: ev.value,
+        },
+      };
+
+    case "stream_chunk":
+      // Stream chunks are handled by callers (typically: append to a text
+      // buffer keyed by ev.id). The reducer itself can't know which node
+      // owns the stream without additional bookkeeping, so we pass-through.
+      // Callers should use `subscribeStream` in client.ts to get a stream
+      // of chunks + their fanout target.
+      return scene;
+
+    case "action_emitted":
+      // compositor → agent flow; not a scene update
+      return scene;
+
+    case "heartbeat":
+      return scene;
+
+    default:
+      // Unknown event — forward-compat: ignore.
+      return scene;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+type ProsoponEventNarrowed = ProsoponEvent & { type: string };
+
+function applyPatch(node: SceneNode, patch: NodePatch): SceneNode {
+  let next = node;
+  if (patch.intent !== undefined && patch.intent !== null) {
+    next = { ...next, intent: patch.intent };
+  }
+  if (patch.attrs) {
+    const attrs = { ...(next.attrs ?? {}) };
+    for (const [k, v] of Object.entries(patch.attrs)) {
+      if (v === null || v === undefined) {
+        delete attrs[k];
+      } else {
+        attrs[k] = v;
+      }
+    }
+    next = { ...next, attrs };
+  }
+  if (patch.lifecycle !== undefined && patch.lifecycle !== null) {
+    next = { ...next, lifecycle: patch.lifecycle };
+  }
+  if (patch.children !== undefined && patch.children !== null) {
+    next = {
+      ...next,
+      children: applyChildrenPatch(next.children ?? [], patch.children),
+    };
+  }
+  return next;
+}
+
+function applyChildrenPatch(
+  current: SceneNode[],
+  patch: ChildrenPatch,
+): SceneNode[] {
+  const p = patch as ChildrenPatchNarrowed;
+  switch (p.op) {
+    case "replace":
+      return p.children;
+    case "append":
+      return [...current, ...p.children];
+    case "remove": {
+      const removeSet = new Set(p.ids);
+      return current.filter((c) => !removeSet.has(c.id));
+    }
+    case "reorder": {
+      const byId = new Map(current.map((c) => [c.id, c]));
+      return p.order
+        .map((id) => byId.get(id))
+        .filter((c): c is SceneNode => c !== undefined);
+    }
+    default:
+      return current;
+  }
+}
+
+type ChildrenPatchNarrowed =
+  | { op: "replace"; children: SceneNode[] }
+  | { op: "append"; children: SceneNode[] }
+  | { op: "remove"; ids: string[] }
+  | { op: "reorder"; order: string[] };
+
+function replaceNodeById(
+  scene: Scene,
+  id: string,
+  transform: (node: SceneNode) => SceneNode,
+): Scene {
+  const newRoot = replaceInTree(scene.root, id, transform);
+  if (newRoot === scene.root) return scene;
+  return { ...scene, root: newRoot };
+}
+
+function replaceInTree(
+  node: SceneNode,
+  id: string,
+  transform: (node: SceneNode) => SceneNode,
+): SceneNode {
+  if (node.id === id) return transform(node);
+  const children = node.children ?? [];
+  let changed = false;
+  const next: SceneNode[] = new Array(children.length);
+  for (let i = 0; i < children.length; i++) {
+    const c = children[i] as SceneNode;
+    const nc = replaceInTree(c, id, transform);
+    if (nc !== c) changed = true;
+    next[i] = nc;
+  }
+  return changed ? { ...node, children: next } : node;
+}
+
+function removeNodeById(scene: Scene, id: string): Scene {
+  if (scene.root.id === id) {
+    // Removing the root leaves a scene with no content; mirror Rust behaviour
+    // by returning the scene unchanged and logging a warning.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[prosopon] ignoring node_removed for root id=${id} — not permitted`,
+    );
+    return scene;
+  }
+  const newRoot = filterTree(scene.root, id);
+  if (newRoot === scene.root) return scene;
+  return { ...scene, root: newRoot };
+}
+
+function filterTree(node: SceneNode, removeId: string): SceneNode {
+  const children = node.children ?? [];
+  const kept: SceneNode[] = [];
+  let changed = false;
+  for (const c of children) {
+    if (c.id === removeId) {
+      changed = true;
+      continue;
+    }
+    const nc = filterTree(c, removeId);
+    if (nc !== c) changed = true;
+    kept.push(nc);
+  }
+  return changed ? { ...node, children: kept } : node;
+}
+
+/**
+ * Utility — pull the current value of a signal topic off a scene.
+ * Returns undefined if the signal has never been pushed.
+ */
+export function readSignal(scene: Scene, topic: string): SignalValue | undefined {
+  return scene.signals?.[topic];
+}

--- a/packages/prosopon-ts/src/client.ts
+++ b/packages/prosopon-ts/src/client.ts
@@ -1,0 +1,255 @@
+/**
+ * Browser-side client — subscribes to a Prosopon envelope stream over
+ * WebSocket (primary) with SSE fallback for environments that can't
+ * upgrade.
+ *
+ * The client owns transport management (connect, reconnect, close); it does
+ * NOT fold envelopes into a Scene. Callers pipe into their state store via
+ * `applyEvent()` from `./apply-event`.
+ */
+
+import { decode, type Envelope, ProtocolVersionMismatch } from "./codec";
+
+export type ProsoponTransport = "ws" | "sse";
+
+export interface ProsoponClientOptions {
+  /** Base URL of the transport endpoint. For WS pass wss:/ws:; for SSE pass http(s):/events. */
+  url: string;
+  /** Which transport to try first. Default: `ws`. */
+  preferred?: ProsoponTransport;
+  /**
+   * When true (default), if the preferred transport fails to open within
+   * `fallbackAfterMs` or errors immediately, the other transport is tried.
+   * Set false to disable automatic fallback.
+   */
+  autoFallback?: boolean;
+  fallbackAfterMs?: number;
+  /** Maximum reconnect attempts before giving up. Default: infinite. */
+  maxReconnects?: number;
+  /** Base backoff (ms) — actual backoff is exponential with jitter. Default 500. */
+  reconnectBaseMs?: number;
+}
+
+export type EnvelopeHandler = (envelope: Envelope) => void;
+export type ErrorHandler = (err: Error) => void;
+export type StateHandler = (state: ProsoponClientState) => void;
+
+export type ProsoponClientState =
+  | "idle"
+  | "connecting"
+  | "open"
+  | "reconnecting"
+  | "closed"
+  | "error";
+
+export class ProsoponClient {
+  private readonly opts: Required<ProsoponClientOptions>;
+  private handlers: EnvelopeHandler[] = [];
+  private errorHandlers: ErrorHandler[] = [];
+  private stateHandlers: StateHandler[] = [];
+  private ws: WebSocket | null = null;
+  private sse: EventSource | null = null;
+  private currentTransport: ProsoponTransport | null = null;
+  private reconnects = 0;
+  private state: ProsoponClientState = "idle";
+  private closed = false;
+
+  constructor(options: ProsoponClientOptions) {
+    this.opts = {
+      url: options.url,
+      preferred: options.preferred ?? "ws",
+      autoFallback: options.autoFallback ?? true,
+      fallbackAfterMs: options.fallbackAfterMs ?? 3000,
+      maxReconnects: options.maxReconnects ?? Number.POSITIVE_INFINITY,
+      reconnectBaseMs: options.reconnectBaseMs ?? 500,
+    };
+  }
+
+  onEnvelope(handler: EnvelopeHandler): () => void {
+    this.handlers.push(handler);
+    return () => {
+      this.handlers = this.handlers.filter((h) => h !== handler);
+    };
+  }
+
+  onError(handler: ErrorHandler): () => void {
+    this.errorHandlers.push(handler);
+    return () => {
+      this.errorHandlers = this.errorHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  onState(handler: StateHandler): () => void {
+    this.stateHandlers.push(handler);
+    handler(this.state);
+    return () => {
+      this.stateHandlers = this.stateHandlers.filter((h) => h !== handler);
+    };
+  }
+
+  connect(): void {
+    this.closed = false;
+    this.open(this.opts.preferred);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.teardown();
+    this.setState("closed");
+  }
+
+  // ------------------------------------------------------------------ private
+
+  private open(transport: ProsoponTransport): void {
+    if (this.closed) return;
+    this.teardown();
+    this.currentTransport = transport;
+    this.setState(this.reconnects === 0 ? "connecting" : "reconnecting");
+
+    if (transport === "ws") {
+      this.openWs();
+    } else {
+      this.openSse();
+    }
+  }
+
+  private openWs(): void {
+    try {
+      const ws = new WebSocket(this.toWsUrl(this.opts.url));
+      this.ws = ws;
+      let opened = false;
+
+      const fallbackTimer = setTimeout(() => {
+        if (!opened && this.opts.autoFallback) {
+          ws.close();
+          this.open("sse");
+        }
+      }, this.opts.fallbackAfterMs);
+
+      ws.addEventListener("open", () => {
+        opened = true;
+        clearTimeout(fallbackTimer);
+        this.reconnects = 0;
+        this.setState("open");
+      });
+
+      ws.addEventListener("message", (ev) => {
+        this.ingest(typeof ev.data === "string" ? ev.data : "");
+      });
+
+      ws.addEventListener("error", (ev) => {
+        clearTimeout(fallbackTimer);
+        this.emitError(new Error(`WebSocket error: ${String(ev)}`));
+      });
+
+      ws.addEventListener("close", () => {
+        clearTimeout(fallbackTimer);
+        if (!opened && this.opts.autoFallback) {
+          this.open("sse");
+        } else {
+          this.scheduleReconnect();
+        }
+      });
+    } catch (err) {
+      if (this.opts.autoFallback) {
+        this.open("sse");
+      } else {
+        this.emitError(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
+  }
+
+  private openSse(): void {
+    try {
+      const sse = new EventSource(this.opts.url);
+      this.sse = sse;
+
+      sse.addEventListener("open", () => {
+        this.reconnects = 0;
+        this.setState("open");
+      });
+
+      // The Rust daemon emits envelopes under the `envelope` event name;
+      // we also subscribe to the default `message` event for broader compat.
+      const onMessage = (ev: MessageEvent): void => {
+        this.ingest(ev.data);
+      };
+      sse.addEventListener("envelope", onMessage as EventListener);
+      sse.addEventListener("message", onMessage as EventListener);
+
+      sse.addEventListener("error", () => {
+        // EventSource auto-reconnects; we just surface the state change.
+        this.setState("reconnecting");
+      });
+    } catch (err) {
+      this.emitError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  private ingest(payload: string): void {
+    if (!payload) return;
+    try {
+      const env = decode("json", payload);
+      for (const h of this.handlers) h(env);
+    } catch (err) {
+      if (err instanceof ProtocolVersionMismatch) {
+        this.emitError(err);
+        this.close();
+        return;
+      }
+      this.emitError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed) return;
+    if (this.reconnects >= this.opts.maxReconnects) {
+      this.setState("closed");
+      return;
+    }
+    const delay = Math.min(
+      30_000,
+      this.opts.reconnectBaseMs * 2 ** this.reconnects,
+    );
+    const jitter = Math.random() * 250;
+    this.reconnects += 1;
+    setTimeout(() => {
+      this.open(this.currentTransport ?? this.opts.preferred);
+    }, delay + jitter);
+  }
+
+  private teardown(): void {
+    if (this.ws) {
+      try {
+        this.ws.close();
+      } catch {
+        /* ignore */
+      }
+      this.ws = null;
+    }
+    if (this.sse) {
+      try {
+        this.sse.close();
+      } catch {
+        /* ignore */
+      }
+      this.sse = null;
+    }
+  }
+
+  private setState(state: ProsoponClientState): void {
+    this.state = state;
+    for (const h of this.stateHandlers) h(state);
+  }
+
+  private emitError(err: Error): void {
+    this.setState("error");
+    for (const h of this.errorHandlers) h(err);
+  }
+
+  private toWsUrl(url: string): string {
+    if (url.startsWith("http://")) return `ws://${url.slice(7)}`;
+    if (url.startsWith("https://")) return `wss://${url.slice(8)}`;
+    return url;
+  }
+}

--- a/packages/prosopon-ts/src/codec.ts
+++ b/packages/prosopon-ts/src/codec.ts
@@ -1,0 +1,83 @@
+/**
+ * Wire codec — mirrors `prosopon-protocol::Envelope` + `Codec`.
+ *
+ * Protocol version is pinned to 1. Bump in lockstep with `prosopon-protocol`.
+ */
+
+import type { ProsoponEvent } from "./types";
+
+/** Current wire version — MUST equal `prosopon_protocol::PROTOCOL_VERSION`. */
+export const PROTOCOL_VERSION = 1 as const;
+
+/**
+ * One envelope — wraps a single `ProsoponEvent` with session metadata.
+ * Deliberately structurally identical to the Rust `Envelope` so the same JSON
+ * round-trips between implementations losslessly.
+ */
+export interface Envelope {
+  version: number;
+  session_id: string;
+  seq: number;
+  ts: string; // RFC3339 / ISO8601 — Rust emits chrono::DateTime<Utc> in this format
+  event: ProsoponEvent;
+}
+
+export interface NewEnvelopeArgs {
+  session_id: string;
+  seq: number;
+  event: ProsoponEvent;
+  ts?: string;
+}
+
+export function makeEnvelope(args: NewEnvelopeArgs): Envelope {
+  return {
+    version: PROTOCOL_VERSION,
+    session_id: args.session_id,
+    seq: args.seq,
+    ts: args.ts ?? new Date().toISOString(),
+    event: args.event,
+  };
+}
+
+export type Codec = "json" | "jsonl";
+
+export function encode(codec: Codec, envelope: Envelope): string {
+  const json = JSON.stringify(envelope);
+  return codec === "jsonl" ? `${json}\n` : json;
+}
+
+/**
+ * Decode a single envelope. For `jsonl`, tolerates trailing whitespace /
+ * newlines.
+ */
+export function decode(codec: Codec, payload: string): Envelope {
+  const trimmed = codec === "jsonl" ? payload.replace(/\s+$/g, "") : payload;
+  const parsed = JSON.parse(trimmed) as Envelope;
+  if (parsed.version !== PROTOCOL_VERSION) {
+    throw new ProtocolVersionMismatch(PROTOCOL_VERSION, parsed.version);
+  }
+  return parsed;
+}
+
+export class ProtocolVersionMismatch extends Error {
+  constructor(
+    public readonly expected: number,
+    public readonly actual: number,
+  ) {
+    super(`protocol version mismatch: expected ${expected}, got ${actual}`);
+    this.name = "ProtocolVersionMismatch";
+  }
+}
+
+/** `Hello` handshake frame — used by agents and compositors to declare role + capabilities. */
+export interface Hello {
+  max_version: number;
+  agent: string;
+  role: "agent" | "compositor";
+  capabilities: {
+    surfaces?: string[];
+    codecs?: Codec[];
+    supports_signal_push?: boolean;
+    supports_streaming?: boolean;
+  };
+}

--- a/packages/prosopon-ts/src/generated/event.json
+++ b/packages/prosopon-ts/src/generated/event.json
@@ -1,0 +1,2290 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ProsoponEvent",
+  "description": "A single event in the Prosopon stream.",
+  "oneOf": [
+    {
+      "description": "Full scene reset. Compositors SHOULD clear state and re-render.",
+      "type": "object",
+      "required": [
+        "scene",
+        "type"
+      ],
+      "properties": {
+        "scene": {
+          "$ref": "#/definitions/Scene"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "scene_reset"
+          ]
+        }
+      }
+    },
+    {
+      "description": "New node attached under a parent. If the parent does not exist, compositors MAY buffer or drop; implementations SHOULD log.",
+      "type": "object",
+      "required": [
+        "node",
+        "parent",
+        "type"
+      ],
+      "properties": {
+        "node": {
+          "$ref": "#/definitions/Node"
+        },
+        "parent": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "node_added"
+          ]
+        }
+      }
+    },
+    {
+      "description": "Incremental patch to an existing node.",
+      "type": "object",
+      "required": [
+        "id",
+        "patch",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "patch": {
+          "$ref": "#/definitions/NodePatch"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "node_updated"
+          ]
+        }
+      }
+    },
+    {
+      "description": "Remove a node and its subtree.",
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "node_removed"
+          ]
+        }
+      }
+    },
+    {
+      "description": "A signal's current value changed.",
+      "type": "object",
+      "required": [
+        "topic",
+        "ts",
+        "type",
+        "value"
+      ],
+      "properties": {
+        "topic": {
+          "type": "string"
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "signal_changed"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/SignalValue"
+        }
+      }
+    },
+    {
+      "description": "A chunk of streaming output for a `Stream` intent.",
+      "type": "object",
+      "required": [
+        "chunk",
+        "id",
+        "type"
+      ],
+      "properties": {
+        "chunk": {
+          "$ref": "#/definitions/StreamChunk"
+        },
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "stream_chunk"
+          ]
+        }
+      }
+    },
+    {
+      "description": "The user (via a compositor) invoked an action slot. Flow direction: compositor -> agent.",
+      "type": "object",
+      "required": [
+        "kind",
+        "slot",
+        "source",
+        "type"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ActionKind"
+        },
+        "slot": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "action_emitted"
+          ]
+        }
+      }
+    },
+    {
+      "description": "Periodic liveness. Compositors MAY use this for \"last-heard-from\" timeouts.",
+      "type": "object",
+      "required": [
+        "ts",
+        "type"
+      ],
+      "properties": {
+        "ts": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "heartbeat"
+          ]
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "ActionKind": {
+      "description": "What the action *means*. Compositors choose representation; agents react by semantics.",
+      "oneOf": [
+        {
+          "description": "Submit a payload back to the agent — the most generic action.",
+          "type": "object",
+          "required": [
+            "kind",
+            "payload"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "submit"
+              ]
+            },
+            "payload": true
+          }
+        },
+        {
+          "description": "Request the agent inspect another node (drill-down, \"tell me more\").",
+          "type": "object",
+          "required": [
+            "kind",
+            "target"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "inspect"
+              ]
+            },
+            "target": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Move focus to another node without side effects.",
+          "type": "object",
+          "required": [
+            "kind",
+            "target"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "focus"
+              ]
+            },
+            "target": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Invoke a named command on the agent (e.g. \"rerun\", \"cancel\").",
+          "type": "object",
+          "required": [
+            "command",
+            "kind"
+          ],
+          "properties": {
+            "args": {
+              "default": null
+            },
+            "command": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "invoke"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Record human feedback on a result — thumb-up/down plus optional comment.",
+          "type": "object",
+          "required": [
+            "kind",
+            "valence"
+          ],
+          "properties": {
+            "comment": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "feedback"
+              ]
+            },
+            "valence": {
+              "$ref": "#/definitions/Valence"
+            }
+          }
+        },
+        {
+          "description": "Pick one of the options declared by a `Choice` intent.",
+          "type": "object",
+          "required": [
+            "kind",
+            "option_id"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "choose"
+              ]
+            },
+            "option_id": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Fill an `Input` intent's value.",
+          "type": "object",
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "input"
+              ]
+            },
+            "value": true
+          }
+        },
+        {
+          "description": "Confirm a `Confirm` intent.",
+          "type": "object",
+          "required": [
+            "accepted",
+            "kind"
+          ],
+          "properties": {
+            "accepted": {
+              "type": "boolean"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "confirm"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ActionSlot": {
+      "description": "An interactive slot attached to a node.\n\nSlots are *declarative* — the node says \"this action is available,\" the compositor decides how to present it (button, keybind, voice command, gesture), and the agent reacts to the emitted `ActionEvent`.",
+      "type": "object",
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/ActionKind"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "visibility": {
+          "default": "visible",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Visibility"
+            }
+          ]
+        }
+      }
+    },
+    "BindTarget": {
+      "description": "What part of a node a binding updates.",
+      "oneOf": [
+        {
+          "description": "Update a named attribute on the node (e.g. `\"pct\"`, `\"label\"`).",
+          "type": "object",
+          "required": [
+            "key",
+            "kind"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "attr"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Update a named slot inside the node's `Intent` payload (e.g. `\"progress.pct\"`).",
+          "type": "object",
+          "required": [
+            "kind",
+            "path"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "intent_slot"
+              ]
+            },
+            "path": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Replace the content of a child node entirely.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "child_content"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Binding": {
+      "description": "Binds a live signal to a rendering slot on a node.\n\nThe compositor is responsible for subscribing to the signal and applying the (optional) transform before updating the target.",
+      "type": "object",
+      "required": [
+        "source",
+        "target"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/SignalRef"
+        },
+        "target": {
+          "$ref": "#/definitions/BindTarget"
+        },
+        "transform": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Transform"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ChildrenPatch": {
+      "description": "How a patch modifies a node's children.",
+      "oneOf": [
+        {
+          "description": "Replace the entire children list.",
+          "type": "object",
+          "required": [
+            "children",
+            "op"
+          ],
+          "properties": {
+            "children": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Node"
+              }
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "replace"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Append new children to the end.",
+          "type": "object",
+          "required": [
+            "children",
+            "op"
+          ],
+          "properties": {
+            "children": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Node"
+              }
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "append"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Remove children by id.",
+          "type": "object",
+          "required": [
+            "ids",
+            "op"
+          ],
+          "properties": {
+            "ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "op": {
+              "type": "string",
+              "enum": [
+                "remove"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Reorder children to match `order`. Any ids not present are dropped.",
+          "type": "object",
+          "required": [
+            "op",
+            "order"
+          ],
+          "properties": {
+            "op": {
+              "type": "string",
+              "enum": [
+                "reorder"
+              ]
+            },
+            "order": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "ChoiceOption": {
+      "description": "One of the options presented by a `Choice` intent.",
+      "type": "object",
+      "required": [
+        "id",
+        "label"
+      ],
+      "properties": {
+        "default": {
+          "default": false,
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Stable identifier used in the corresponding `ActionKind::Choose`.",
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "ChunkPayload": {
+      "description": "Payload variants carried in a stream chunk.",
+      "oneOf": [
+        {
+          "description": "UTF-8 text fragment — append to the rendered stream.",
+          "type": "object",
+          "required": [
+            "encoding",
+            "text"
+          ],
+          "properties": {
+            "encoding": {
+              "type": "string",
+              "enum": [
+                "text"
+              ]
+            },
+            "text": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Base64-encoded bytes (audio frames, binary data).",
+          "type": "object",
+          "required": [
+            "data",
+            "encoding"
+          ],
+          "properties": {
+            "data": {
+              "type": "string"
+            },
+            "encoding": {
+              "type": "string",
+              "enum": [
+                "b64"
+              ]
+            },
+            "mime": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A JSON value — for JSONL streams.",
+          "type": "object",
+          "required": [
+            "encoding",
+            "value"
+          ],
+          "properties": {
+            "encoding": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            },
+            "value": true
+          }
+        }
+      ]
+    },
+    "Density": {
+      "description": "Visual density preference. Compositors interpret this per-surface.",
+      "type": "string",
+      "enum": [
+        "compact",
+        "comfortable",
+        "spacious"
+      ]
+    },
+    "FormationKind": {
+      "description": "A coherent grouping of agents — renders as a cluster, swarm, or quorum.",
+      "oneOf": [
+        {
+          "description": "Threshold-reached consensus.",
+          "type": "string",
+          "enum": [
+            "quorum"
+          ]
+        },
+        {
+          "description": "Moving coordinated group.",
+          "type": "string",
+          "enum": [
+            "swarm"
+          ]
+        },
+        {
+          "description": "Static ring, line, or geometric arrangement.",
+          "type": "string",
+          "enum": [
+            "geometric"
+          ]
+        },
+        {
+          "description": "Leftover scent traces (stigmergic).",
+          "type": "string",
+          "enum": [
+            "stigmergy"
+          ]
+        }
+      ]
+    },
+    "GroupKind": {
+      "description": "How a `Group` lays out its children.",
+      "oneOf": [
+        {
+          "description": "Top-to-bottom list.",
+          "type": "string",
+          "enum": [
+            "list"
+          ]
+        },
+        {
+          "description": "Gridded layout — compositors decide column count.",
+          "type": "string",
+          "enum": [
+            "grid"
+          ]
+        },
+        {
+          "description": "Strictly ordered sequence — render as a process or timeline.",
+          "type": "string",
+          "enum": [
+            "sequence"
+          ]
+        },
+        {
+          "description": "Concurrent/parallel items — render side-by-side or overlapped.",
+          "type": "string",
+          "enum": [
+            "parallel"
+          ]
+        },
+        {
+          "description": "A stack — only the top child is fully visible.",
+          "type": "string",
+          "enum": [
+            "stack"
+          ]
+        }
+      ]
+    },
+    "InputKind": {
+      "description": "Shape of an `Input` intent.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "text"
+              ]
+            },
+            "multiline": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "number"
+              ]
+            },
+            "max": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "double"
+            },
+            "min": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "double"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "boolean"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "date"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Intent": {
+      "description": "The semantic type of a node.\n\nSee module docs for the design philosophy. Compositors SHOULD handle every variant gracefully; falling back to rendering via `Intent::Prose` of the variant's `Display` is acceptable when no better representation is available.",
+      "oneOf": [
+        {
+          "description": "Plain semantic prose. Inline markup is NOT interpreted — compositors format according to the surrounding node's attributes.",
+          "type": "object",
+          "required": [
+            "text",
+            "type"
+          ],
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "prose"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Source code in a named language. Compositors MAY syntax-highlight.",
+          "type": "object",
+          "required": [
+            "lang",
+            "source",
+            "type"
+          ],
+          "properties": {
+            "lang": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "code"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Mathematical expression in LaTeX or MathML. Optional; text compositors fall back to raw source.",
+          "type": "object",
+          "required": [
+            "source",
+            "type"
+          ],
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "math"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A pointer to a known entity in the agent's knowledge graph. Compositors MAY render as a clickable reference.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "entity_ref"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A hyperlink to an external resource.",
+          "type": "object",
+          "required": [
+            "href",
+            "type"
+          ],
+          "properties": {
+            "href": {
+              "type": "string"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "link"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A citation reference — source + optional anchor/page.",
+          "type": "object",
+          "required": [
+            "source",
+            "type"
+          ],
+          "properties": {
+            "anchor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "citation"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Displays the current value of a reactive signal.",
+          "type": "object",
+          "required": [
+            "topic",
+            "type"
+          ],
+          "properties": {
+            "display": {
+              "default": "inline",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/SignalDisplay"
+                }
+              ]
+            },
+            "topic": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "signal"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A streaming output channel (token stream, audio stream, etc.).",
+          "type": "object",
+          "required": [
+            "id",
+            "kind",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/definitions/StreamKind"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "stream"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Present a choice between mutually exclusive options.",
+          "type": "object",
+          "required": [
+            "options",
+            "prompt",
+            "type"
+          ],
+          "properties": {
+            "options": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ChoiceOption"
+              }
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "choice"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Request yes/no confirmation before the agent proceeds.",
+          "type": "object",
+          "required": [
+            "message",
+            "type"
+          ],
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "severity": {
+              "default": "notice",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Severity"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "confirm"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Request typed input from the human.",
+          "type": "object",
+          "required": [
+            "input",
+            "prompt",
+            "type"
+          ],
+          "properties": {
+            "default": true,
+            "input": {
+              "$ref": "#/definitions/InputKind"
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "input"
+              ]
+            }
+          }
+        },
+        {
+          "description": "An in-flight or completed tool invocation.",
+          "type": "object",
+          "required": [
+            "args",
+            "name",
+            "type"
+          ],
+          "properties": {
+            "args": true,
+            "name": {
+              "type": "string"
+            },
+            "stream": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "tool_call"
+              ]
+            }
+          }
+        },
+        {
+          "description": "The outcome of a tool call.",
+          "type": "object",
+          "required": [
+            "payload",
+            "success",
+            "type"
+          ],
+          "properties": {
+            "payload": true,
+            "success": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "tool_result"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Bounded progress — optional percentage + optional label.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pct": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "float"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "progress"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A container whose `GroupKind` tells the compositor how to lay out children.",
+          "type": "object",
+          "required": [
+            "layout",
+            "type"
+          ],
+          "properties": {
+            "layout": {
+              "$ref": "#/definitions/GroupKind"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "group"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A named section — compositors MAY render a heading; children are the body.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "collapsible": {
+              "default": false,
+              "type": "boolean"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "section"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A visual break between siblings.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "divider"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A scalar or vector field, indexed by coordinate, projected for the chosen surface.",
+          "type": "object",
+          "required": [
+            "projection",
+            "topic",
+            "type"
+          ],
+          "properties": {
+            "projection": {
+              "$ref": "#/definitions/Projection"
+            },
+            "topic": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "field"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A named spatial anchor in the given frame of reference.",
+          "type": "object",
+          "required": [
+            "frame",
+            "position",
+            "type"
+          ],
+          "properties": {
+            "frame": {
+              "$ref": "#/definitions/SpatialFrame"
+            },
+            "position": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "float"
+              },
+              "maxItems": 3,
+              "minItems": 3
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "locus"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A coherent arrangement of agents (quorum, swarm, formation).",
+          "type": "object",
+          "required": [
+            "kind",
+            "topic",
+            "type"
+          ],
+          "properties": {
+            "kind": {
+              "$ref": "#/definitions/FormationKind"
+            },
+            "topic": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "formation"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A bitmap or vector image.",
+          "type": "object",
+          "required": [
+            "type",
+            "uri"
+          ],
+          "properties": {
+            "alt": {
+              "default": "",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "image"
+              ]
+            },
+            "uri": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "An audio source. Either a pre-rendered URI, a live stream, or a TTS voice.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "stream": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "audio"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "voice": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A video source.",
+          "type": "object",
+          "required": [
+            "type",
+            "uri"
+          ],
+          "properties": {
+            "poster": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "video"
+              ]
+            },
+            "uri": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Intentionally empty (useful as a container whose content will stream in).",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "empty"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Compositor-specific or experimental intents. Compositors that don't know `kind` SHOULD fall back to rendering a generic placeholder with the payload preview.",
+          "type": "object",
+          "required": [
+            "kind",
+            "payload",
+            "type"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "payload": true,
+            "type": {
+              "type": "string",
+              "enum": [
+                "custom"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "IntentProfile": {
+      "description": "Overall presentation bias for a scene.",
+      "oneOf": [
+        {
+          "description": "Default — balanced density and ambience.",
+          "type": "string",
+          "enum": [
+            "balanced"
+          ]
+        },
+        {
+          "description": "Dense technical output — maximize information per unit surface.",
+          "type": "string",
+          "enum": [
+            "dense_technical"
+          ]
+        },
+        {
+          "description": "Ambient monitor — minimize intrusion, prefer peripheral rendering.",
+          "type": "string",
+          "enum": [
+            "ambient_monitor"
+          ]
+        },
+        {
+          "description": "Cinematic — long-form narrative, one idea per frame.",
+          "type": "string",
+          "enum": [
+            "cinematic"
+          ]
+        },
+        {
+          "description": "Conversational — paced for human back-and-forth.",
+          "type": "string",
+          "enum": [
+            "conversational"
+          ]
+        }
+      ]
+    },
+    "Lifecycle": {
+      "description": "Temporal and attentional state of a node.",
+      "type": "object",
+      "required": [
+        "created_at"
+      ],
+      "properties": {
+        "created_at": {
+          "description": "When this node was first emitted by the agent.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "description": "Optional expiration. Compositors SHOULD remove or fade past this time.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "priority": {
+          "description": "Attention priority — shapes placement, color, and notification behavior.",
+          "default": "normal",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Priority"
+            }
+          ]
+        },
+        "status": {
+          "description": "Current status in the node's lifecycle.",
+          "default": {
+            "kind": "active"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/NodeStatus"
+            }
+          ]
+        }
+      }
+    },
+    "Node": {
+      "description": "A node in the Prosopon IR tree.",
+      "type": "object",
+      "required": [
+        "id",
+        "intent"
+      ],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionSlot"
+          }
+        },
+        "attrs": {
+          "description": "Free-form attribute bag for hints the compositor MAY use. Well-known keys: `emphasis` (`\"low\" | \"normal\" | \"high\"`), `semantic_role` (e.g. `\"error\"`, `\"success\"`), `width_hint` (fraction 0..=1), `voice` (TTS voice id).",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Binding"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Node"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/definitions/Intent"
+        },
+        "lifecycle": {
+          "default": {
+            "created_at": "2026-04-23T20:28:10.606342Z",
+            "priority": "normal",
+            "status": {
+              "kind": "active"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Lifecycle"
+            }
+          ]
+        }
+      }
+    },
+    "NodePatch": {
+      "description": "An incremental update to a node — used by `ProsoponEvent::NodeUpdated`.\n\nAll fields are optional; unset fields leave existing values untouched.",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "description": "Attribute updates. `None` values remove the key.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "children": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ChildrenPatch"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "intent": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Intent"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "lifecycle": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Lifecycle"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "NodeStatus": {
+      "description": "Discrete lifecycle state of a node.",
+      "oneOf": [
+        {
+          "description": "Node is live and interactive.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "active"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Node is waiting on an upstream process (tool call, user response).",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "pending"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Node's intent has been satisfied — useful for collapsing completed items.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "resolved"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Node failed — `reason` is human-readable and SHOULD be surfaced in the UI.",
+          "type": "object",
+          "required": [
+            "kind",
+            "reason"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "failed"
+              ]
+            },
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Node is fading out according to a decay curve (0.0 = fresh, 1.0 = gone).",
+          "type": "object",
+          "required": [
+            "kind",
+            "progress"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "decaying"
+              ]
+            },
+            "progress": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        }
+      ]
+    },
+    "Priority": {
+      "description": "Attention priority of a node.",
+      "oneOf": [
+        {
+          "description": "Background presence — persistent but non-demanding (e.g. a live metric).",
+          "type": "string",
+          "enum": [
+            "ambient"
+          ]
+        },
+        {
+          "description": "Default rendering priority.",
+          "type": "string",
+          "enum": [
+            "normal"
+          ]
+        },
+        {
+          "description": "Requires user attention soon but does not block other flows.",
+          "type": "string",
+          "enum": [
+            "urgent"
+          ]
+        },
+        {
+          "description": "Halts dependent flows until resolved (e.g. a destructive-action confirm).",
+          "type": "string",
+          "enum": [
+            "blocking"
+          ]
+        }
+      ]
+    },
+    "Projection": {
+      "description": "How a field is projected into the compositor's surface.",
+      "oneOf": [
+        {
+          "description": "Flat 2D heatmap.",
+          "type": "string",
+          "enum": [
+            "heatmap"
+          ]
+        },
+        {
+          "description": "Contour lines.",
+          "type": "string",
+          "enum": [
+            "contour"
+          ]
+        },
+        {
+          "description": "3D volume rendering — only honored by 3D compositors.",
+          "type": "string",
+          "enum": [
+            "volume"
+          ]
+        },
+        {
+          "description": "Reduced to a scalar summary (min/mean/max) by the compositor.",
+          "type": "string",
+          "enum": [
+            "summary"
+          ]
+        }
+      ]
+    },
+    "Scene": {
+      "description": "A complete snapshot of \"what to render.\"",
+      "type": "object",
+      "required": [
+        "id",
+        "root"
+      ],
+      "properties": {
+        "hints": {
+          "default": {
+            "density": "comfortable",
+            "intent_profile": "balanced"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/SceneHints"
+            }
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "root": {
+          "$ref": "#/definitions/Node"
+        },
+        "signals": {
+          "description": "Last-known value for each referenced signal topic. Compositors that support push-based updates MAY subscribe and ignore this cache; compositors that only pull SHOULD treat this as the authoritative initial value.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SignalValue"
+          }
+        }
+      }
+    },
+    "SceneHints": {
+      "description": "Compositor-steering hints carried with every scene.",
+      "type": "object",
+      "properties": {
+        "density": {
+          "description": "Visual density preference.",
+          "default": "comfortable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Density"
+            }
+          ]
+        },
+        "intent_profile": {
+          "description": "Overall intent profile — tells compositors whether to bias dense+technical or sparse+ambient presentations.",
+          "default": "balanced",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IntentProfile"
+            }
+          ]
+        },
+        "locale": {
+          "description": "BCP-47 locale (e.g. `\"en-US\"`, `\"es-CO\"`). Compositors localize formatting.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preferred_surfaces": {
+          "description": "Ordered preferred surfaces, most preferred first. A compositor MAY skip a scene if its surface is not listed; compositors SHOULD respect the first match.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SurfaceKind"
+          }
+        },
+        "viewport": {
+          "description": "Rough viewport budget — hints for truncation/layout. `None` = unbounded.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Viewport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Severity": {
+      "description": "Severity level for confirmation dialogs, warnings, and alerts.",
+      "type": "string",
+      "enum": [
+        "info",
+        "notice",
+        "warning",
+        "danger"
+      ]
+    },
+    "SignalDisplay": {
+      "description": "How a `Signal` intent is surfaced.",
+      "oneOf": [
+        {
+          "description": "Just the current value, formatted by the compositor.",
+          "type": "string",
+          "enum": [
+            "inline"
+          ]
+        },
+        {
+          "description": "A miniature plot (sparkline, bar).",
+          "type": "string",
+          "enum": [
+            "sparkline"
+          ]
+        },
+        {
+          "description": "A badge (colored chip with value).",
+          "type": "string",
+          "enum": [
+            "badge"
+          ]
+        }
+      ]
+    },
+    "SignalRef": {
+      "description": "A reference to a live value. Supports nested paths for structured signals: `SignalRef { topic: \"plexus.state\", path: [\"quorum\", \"ratio\"] }` addresses the `ratio` field inside the `quorum` object inside the `plexus.state` signal.",
+      "type": "object",
+      "required": [
+        "topic"
+      ],
+      "properties": {
+        "path": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topic": {
+          "type": "string"
+        }
+      }
+    },
+    "SignalValue": {
+      "description": "A concrete signal value pushed onto the bus at a given instant.\n\nCompositors MAY cache last-known values to render bindings when a signal has not yet emitted.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "scalar"
+              ]
+            }
+          }
+        },
+        {
+          "type": [
+            "object",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/TimePoint"
+          },
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "time_series"
+              ]
+            }
+          }
+        },
+        {
+          "type": [
+            "object",
+            "array"
+          ],
+          "items": {
+            "type": "number",
+            "format": "float"
+          },
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "vector"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "payload"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "event"
+              ]
+            },
+            "payload": true
+          }
+        }
+      ]
+    },
+    "SpatialFrame": {
+      "description": "Frame of reference for a spatial locus.",
+      "oneOf": [
+        {
+          "description": "Viewer-centric — `position` is in the compositor's viewport space.",
+          "type": "string",
+          "enum": [
+            "viewer"
+          ]
+        },
+        {
+          "description": "Scene-world — `position` is in the shared world coordinate system.",
+          "type": "string",
+          "enum": [
+            "world"
+          ]
+        },
+        {
+          "description": "Earth-fixed — `position` is (lat, lon, alt).",
+          "type": "string",
+          "enum": [
+            "geo"
+          ]
+        }
+      ]
+    },
+    "StreamChunk": {
+      "description": "A chunk of streaming payload.",
+      "type": "object",
+      "required": [
+        "payload",
+        "seq"
+      ],
+      "properties": {
+        "final_": {
+          "description": "True if this is the last chunk of the stream.",
+          "default": false,
+          "type": "boolean"
+        },
+        "payload": {
+          "description": "Encoded payload. Interpretation depends on the `StreamKind` of the originating `Stream` intent.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ChunkPayload"
+            }
+          ]
+        },
+        "seq": {
+          "description": "Sequence number (monotonic per stream). Compositors drop out-of-order chunks.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "StreamKind": {
+      "description": "The content of a `Stream` channel.",
+      "oneOf": [
+        {
+          "description": "Token-by-token text (LLM generation, log tail).",
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        {
+          "description": "Audio PCM or encoded.",
+          "type": "string",
+          "enum": [
+            "audio"
+          ]
+        },
+        {
+          "description": "Arbitrary binary frames.",
+          "type": "string",
+          "enum": [
+            "binary"
+          ]
+        },
+        {
+          "description": "Structured JSON lines.",
+          "type": "string",
+          "enum": [
+            "jsonl"
+          ]
+        }
+      ]
+    },
+    "SurfaceKind": {
+      "description": "The shape of surface a compositor renders onto.",
+      "oneOf": [
+        {
+          "description": "Plain ANSI / text terminal or plain-text document.",
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        {
+          "description": "2D raster or vector canvas (browser DOM, native 2D).",
+          "type": "string",
+          "enum": [
+            "two_d"
+          ]
+        },
+        {
+          "description": "3D world (WebGPU, native 3D engines).",
+          "type": "string",
+          "enum": [
+            "three_d"
+          ]
+        },
+        {
+          "description": "GPU shader program — agents become field/material parameters.",
+          "type": "string",
+          "enum": [
+            "shader"
+          ]
+        },
+        {
+          "description": "Audio playback surface (speech, ambient music, sonification).",
+          "type": "string",
+          "enum": [
+            "audio"
+          ]
+        },
+        {
+          "description": "Spatial computing (Vision Pro / Quest / AR).",
+          "type": "string",
+          "enum": [
+            "spatial"
+          ]
+        },
+        {
+          "description": "Haptic / tactile feedback.",
+          "type": "string",
+          "enum": [
+            "tactile"
+          ]
+        }
+      ]
+    },
+    "TimePoint": {
+      "description": "Single point in a time-series signal.",
+      "type": "object",
+      "required": [
+        "t",
+        "v"
+      ],
+      "properties": {
+        "t": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "v": true
+      }
+    },
+    "Transform": {
+      "description": "Optional transformation applied to the signal value before binding.\n\nTransforms are intentionally limited to pure, deterministic functions so compositors can execute them safely without a scripting runtime.",
+      "oneOf": [
+        {
+          "description": "Pass the value through unchanged.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "identity"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Format the value into a template string. `{}` is replaced with the value.",
+          "type": "object",
+          "required": [
+            "kind",
+            "template"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "format"
+              ]
+            },
+            "template": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Clamp a numeric value into `[min, max]`.",
+          "type": "object",
+          "required": [
+            "kind",
+            "max",
+            "min"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "clamp"
+              ]
+            },
+            "max": {
+              "type": "number",
+              "format": "double"
+            },
+            "min": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "description": "Round a numeric value to `decimals` places.",
+          "type": "object",
+          "required": [
+            "decimals",
+            "kind"
+          ],
+          "properties": {
+            "decimals": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "round"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Multiply by 100 and append `\"%\"`.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "percent"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Valence": {
+      "description": "Qualitative feedback direction.",
+      "type": "string",
+      "enum": [
+        "positive",
+        "neutral",
+        "negative"
+      ]
+    },
+    "Viewport": {
+      "description": "Rough viewport budget. Compositors with bounded surfaces (terminals, small screens) SHOULD respect these; surfaces without a natural viewport (audio, spatial) MAY ignore.",
+      "type": "object",
+      "required": [
+        "cols",
+        "rows"
+      ],
+      "properties": {
+        "cols": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "rows": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Visibility": {
+      "description": "Whether this slot should be offered to the user right now.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "visible"
+          ]
+        },
+        {
+          "description": "Rendered but visually de-emphasized.",
+          "type": "string",
+          "enum": [
+            "muted"
+          ]
+        },
+        {
+          "description": "Not rendered; still in the IR for programmatic inspection.",
+          "type": "string",
+          "enum": [
+            "hidden"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/prosopon-ts/src/generated/scene.json
+++ b/packages/prosopon-ts/src/generated/scene.json
@@ -1,0 +1,1874 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Scene",
+  "description": "A complete snapshot of \"what to render.\"",
+  "type": "object",
+  "required": [
+    "id",
+    "root"
+  ],
+  "properties": {
+    "hints": {
+      "default": {
+        "density": "comfortable",
+        "intent_profile": "balanced"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SceneHints"
+        }
+      ]
+    },
+    "id": {
+      "type": "string"
+    },
+    "root": {
+      "$ref": "#/definitions/Node"
+    },
+    "signals": {
+      "description": "Last-known value for each referenced signal topic. Compositors that support push-based updates MAY subscribe and ignore this cache; compositors that only pull SHOULD treat this as the authoritative initial value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/SignalValue"
+      }
+    }
+  },
+  "definitions": {
+    "ActionKind": {
+      "description": "What the action *means*. Compositors choose representation; agents react by semantics.",
+      "oneOf": [
+        {
+          "description": "Submit a payload back to the agent — the most generic action.",
+          "type": "object",
+          "required": [
+            "kind",
+            "payload"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "submit"
+              ]
+            },
+            "payload": true
+          }
+        },
+        {
+          "description": "Request the agent inspect another node (drill-down, \"tell me more\").",
+          "type": "object",
+          "required": [
+            "kind",
+            "target"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "inspect"
+              ]
+            },
+            "target": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Move focus to another node without side effects.",
+          "type": "object",
+          "required": [
+            "kind",
+            "target"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "focus"
+              ]
+            },
+            "target": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Invoke a named command on the agent (e.g. \"rerun\", \"cancel\").",
+          "type": "object",
+          "required": [
+            "command",
+            "kind"
+          ],
+          "properties": {
+            "args": {
+              "default": null
+            },
+            "command": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "invoke"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Record human feedback on a result — thumb-up/down plus optional comment.",
+          "type": "object",
+          "required": [
+            "kind",
+            "valence"
+          ],
+          "properties": {
+            "comment": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "feedback"
+              ]
+            },
+            "valence": {
+              "$ref": "#/definitions/Valence"
+            }
+          }
+        },
+        {
+          "description": "Pick one of the options declared by a `Choice` intent.",
+          "type": "object",
+          "required": [
+            "kind",
+            "option_id"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "choose"
+              ]
+            },
+            "option_id": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Fill an `Input` intent's value.",
+          "type": "object",
+          "required": [
+            "kind",
+            "value"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "input"
+              ]
+            },
+            "value": true
+          }
+        },
+        {
+          "description": "Confirm a `Confirm` intent.",
+          "type": "object",
+          "required": [
+            "accepted",
+            "kind"
+          ],
+          "properties": {
+            "accepted": {
+              "type": "boolean"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "confirm"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "ActionSlot": {
+      "description": "An interactive slot attached to a node.\n\nSlots are *declarative* — the node says \"this action is available,\" the compositor decides how to present it (button, keybind, voice command, gesture), and the agent reacts to the emitted `ActionEvent`.",
+      "type": "object",
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "enabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/ActionKind"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "visibility": {
+          "default": "visible",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Visibility"
+            }
+          ]
+        }
+      }
+    },
+    "BindTarget": {
+      "description": "What part of a node a binding updates.",
+      "oneOf": [
+        {
+          "description": "Update a named attribute on the node (e.g. `\"pct\"`, `\"label\"`).",
+          "type": "object",
+          "required": [
+            "key",
+            "kind"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "attr"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Update a named slot inside the node's `Intent` payload (e.g. `\"progress.pct\"`).",
+          "type": "object",
+          "required": [
+            "kind",
+            "path"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "intent_slot"
+              ]
+            },
+            "path": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Replace the content of a child node entirely.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "child_content"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Binding": {
+      "description": "Binds a live signal to a rendering slot on a node.\n\nThe compositor is responsible for subscribing to the signal and applying the (optional) transform before updating the target.",
+      "type": "object",
+      "required": [
+        "source",
+        "target"
+      ],
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/SignalRef"
+        },
+        "target": {
+          "$ref": "#/definitions/BindTarget"
+        },
+        "transform": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Transform"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ChoiceOption": {
+      "description": "One of the options presented by a `Choice` intent.",
+      "type": "object",
+      "required": [
+        "id",
+        "label"
+      ],
+      "properties": {
+        "default": {
+          "default": false,
+          "type": "boolean"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "Stable identifier used in the corresponding `ActionKind::Choose`.",
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "Density": {
+      "description": "Visual density preference. Compositors interpret this per-surface.",
+      "type": "string",
+      "enum": [
+        "compact",
+        "comfortable",
+        "spacious"
+      ]
+    },
+    "FormationKind": {
+      "description": "A coherent grouping of agents — renders as a cluster, swarm, or quorum.",
+      "oneOf": [
+        {
+          "description": "Threshold-reached consensus.",
+          "type": "string",
+          "enum": [
+            "quorum"
+          ]
+        },
+        {
+          "description": "Moving coordinated group.",
+          "type": "string",
+          "enum": [
+            "swarm"
+          ]
+        },
+        {
+          "description": "Static ring, line, or geometric arrangement.",
+          "type": "string",
+          "enum": [
+            "geometric"
+          ]
+        },
+        {
+          "description": "Leftover scent traces (stigmergic).",
+          "type": "string",
+          "enum": [
+            "stigmergy"
+          ]
+        }
+      ]
+    },
+    "GroupKind": {
+      "description": "How a `Group` lays out its children.",
+      "oneOf": [
+        {
+          "description": "Top-to-bottom list.",
+          "type": "string",
+          "enum": [
+            "list"
+          ]
+        },
+        {
+          "description": "Gridded layout — compositors decide column count.",
+          "type": "string",
+          "enum": [
+            "grid"
+          ]
+        },
+        {
+          "description": "Strictly ordered sequence — render as a process or timeline.",
+          "type": "string",
+          "enum": [
+            "sequence"
+          ]
+        },
+        {
+          "description": "Concurrent/parallel items — render side-by-side or overlapped.",
+          "type": "string",
+          "enum": [
+            "parallel"
+          ]
+        },
+        {
+          "description": "A stack — only the top child is fully visible.",
+          "type": "string",
+          "enum": [
+            "stack"
+          ]
+        }
+      ]
+    },
+    "InputKind": {
+      "description": "Shape of an `Input` intent.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "text"
+              ]
+            },
+            "multiline": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "number"
+              ]
+            },
+            "max": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "double"
+            },
+            "min": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "double"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "boolean"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "date"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Intent": {
+      "description": "The semantic type of a node.\n\nSee module docs for the design philosophy. Compositors SHOULD handle every variant gracefully; falling back to rendering via `Intent::Prose` of the variant's `Display` is acceptable when no better representation is available.",
+      "oneOf": [
+        {
+          "description": "Plain semantic prose. Inline markup is NOT interpreted — compositors format according to the surrounding node's attributes.",
+          "type": "object",
+          "required": [
+            "text",
+            "type"
+          ],
+          "properties": {
+            "text": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "prose"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Source code in a named language. Compositors MAY syntax-highlight.",
+          "type": "object",
+          "required": [
+            "lang",
+            "source",
+            "type"
+          ],
+          "properties": {
+            "lang": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "code"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Mathematical expression in LaTeX or MathML. Optional; text compositors fall back to raw source.",
+          "type": "object",
+          "required": [
+            "source",
+            "type"
+          ],
+          "properties": {
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "math"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A pointer to a known entity in the agent's knowledge graph. Compositors MAY render as a clickable reference.",
+          "type": "object",
+          "required": [
+            "id",
+            "kind",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "entity_ref"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A hyperlink to an external resource.",
+          "type": "object",
+          "required": [
+            "href",
+            "type"
+          ],
+          "properties": {
+            "href": {
+              "type": "string"
+            },
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "link"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A citation reference — source + optional anchor/page.",
+          "type": "object",
+          "required": [
+            "source",
+            "type"
+          ],
+          "properties": {
+            "anchor": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "citation"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Displays the current value of a reactive signal.",
+          "type": "object",
+          "required": [
+            "topic",
+            "type"
+          ],
+          "properties": {
+            "display": {
+              "default": "inline",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/SignalDisplay"
+                }
+              ]
+            },
+            "topic": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "signal"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A streaming output channel (token stream, audio stream, etc.).",
+          "type": "object",
+          "required": [
+            "id",
+            "kind",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "kind": {
+              "$ref": "#/definitions/StreamKind"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "stream"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Present a choice between mutually exclusive options.",
+          "type": "object",
+          "required": [
+            "options",
+            "prompt",
+            "type"
+          ],
+          "properties": {
+            "options": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ChoiceOption"
+              }
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "choice"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Request yes/no confirmation before the agent proceeds.",
+          "type": "object",
+          "required": [
+            "message",
+            "type"
+          ],
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "severity": {
+              "default": "notice",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Severity"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "confirm"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Request typed input from the human.",
+          "type": "object",
+          "required": [
+            "input",
+            "prompt",
+            "type"
+          ],
+          "properties": {
+            "default": true,
+            "input": {
+              "$ref": "#/definitions/InputKind"
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "input"
+              ]
+            }
+          }
+        },
+        {
+          "description": "An in-flight or completed tool invocation.",
+          "type": "object",
+          "required": [
+            "args",
+            "name",
+            "type"
+          ],
+          "properties": {
+            "args": true,
+            "name": {
+              "type": "string"
+            },
+            "stream": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "tool_call"
+              ]
+            }
+          }
+        },
+        {
+          "description": "The outcome of a tool call.",
+          "type": "object",
+          "required": [
+            "payload",
+            "success",
+            "type"
+          ],
+          "properties": {
+            "payload": true,
+            "success": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "tool_result"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Bounded progress — optional percentage + optional label.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pct": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "float"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "progress"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A container whose `GroupKind` tells the compositor how to lay out children.",
+          "type": "object",
+          "required": [
+            "layout",
+            "type"
+          ],
+          "properties": {
+            "layout": {
+              "$ref": "#/definitions/GroupKind"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "group"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A named section — compositors MAY render a heading; children are the body.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "collapsible": {
+              "default": false,
+              "type": "boolean"
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "section"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A visual break between siblings.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "divider"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A scalar or vector field, indexed by coordinate, projected for the chosen surface.",
+          "type": "object",
+          "required": [
+            "projection",
+            "topic",
+            "type"
+          ],
+          "properties": {
+            "projection": {
+              "$ref": "#/definitions/Projection"
+            },
+            "topic": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "field"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A named spatial anchor in the given frame of reference.",
+          "type": "object",
+          "required": [
+            "frame",
+            "position",
+            "type"
+          ],
+          "properties": {
+            "frame": {
+              "$ref": "#/definitions/SpatialFrame"
+            },
+            "position": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "float"
+              },
+              "maxItems": 3,
+              "minItems": 3
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "locus"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A coherent arrangement of agents (quorum, swarm, formation).",
+          "type": "object",
+          "required": [
+            "kind",
+            "topic",
+            "type"
+          ],
+          "properties": {
+            "kind": {
+              "$ref": "#/definitions/FormationKind"
+            },
+            "topic": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "formation"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A bitmap or vector image.",
+          "type": "object",
+          "required": [
+            "type",
+            "uri"
+          ],
+          "properties": {
+            "alt": {
+              "default": "",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "image"
+              ]
+            },
+            "uri": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "An audio source. Either a pre-rendered URI, a live stream, or a TTS voice.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "stream": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "audio"
+              ]
+            },
+            "uri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "voice": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A video source.",
+          "type": "object",
+          "required": [
+            "type",
+            "uri"
+          ],
+          "properties": {
+            "poster": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "video"
+              ]
+            },
+            "uri": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Intentionally empty (useful as a container whose content will stream in).",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "empty"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Compositor-specific or experimental intents. Compositors that don't know `kind` SHOULD fall back to rendering a generic placeholder with the payload preview.",
+          "type": "object",
+          "required": [
+            "kind",
+            "payload",
+            "type"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "payload": true,
+            "type": {
+              "type": "string",
+              "enum": [
+                "custom"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "IntentProfile": {
+      "description": "Overall presentation bias for a scene.",
+      "oneOf": [
+        {
+          "description": "Default — balanced density and ambience.",
+          "type": "string",
+          "enum": [
+            "balanced"
+          ]
+        },
+        {
+          "description": "Dense technical output — maximize information per unit surface.",
+          "type": "string",
+          "enum": [
+            "dense_technical"
+          ]
+        },
+        {
+          "description": "Ambient monitor — minimize intrusion, prefer peripheral rendering.",
+          "type": "string",
+          "enum": [
+            "ambient_monitor"
+          ]
+        },
+        {
+          "description": "Cinematic — long-form narrative, one idea per frame.",
+          "type": "string",
+          "enum": [
+            "cinematic"
+          ]
+        },
+        {
+          "description": "Conversational — paced for human back-and-forth.",
+          "type": "string",
+          "enum": [
+            "conversational"
+          ]
+        }
+      ]
+    },
+    "Lifecycle": {
+      "description": "Temporal and attentional state of a node.",
+      "type": "object",
+      "required": [
+        "created_at"
+      ],
+      "properties": {
+        "created_at": {
+          "description": "When this node was first emitted by the agent.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "description": "Optional expiration. Compositors SHOULD remove or fade past this time.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "priority": {
+          "description": "Attention priority — shapes placement, color, and notification behavior.",
+          "default": "normal",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Priority"
+            }
+          ]
+        },
+        "status": {
+          "description": "Current status in the node's lifecycle.",
+          "default": {
+            "kind": "active"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/NodeStatus"
+            }
+          ]
+        }
+      }
+    },
+    "Node": {
+      "description": "A node in the Prosopon IR tree.",
+      "type": "object",
+      "required": [
+        "id",
+        "intent"
+      ],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ActionSlot"
+          }
+        },
+        "attrs": {
+          "description": "Free-form attribute bag for hints the compositor MAY use. Well-known keys: `emphasis` (`\"low\" | \"normal\" | \"high\"`), `semantic_role` (e.g. `\"error\"`, `\"success\"`), `width_hint` (fraction 0..=1), `voice` (TTS voice id).",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "bindings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Binding"
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Node"
+          }
+        },
+        "id": {
+          "type": "string"
+        },
+        "intent": {
+          "$ref": "#/definitions/Intent"
+        },
+        "lifecycle": {
+          "default": {
+            "created_at": "2026-04-23T20:28:10.200826Z",
+            "priority": "normal",
+            "status": {
+              "kind": "active"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Lifecycle"
+            }
+          ]
+        }
+      }
+    },
+    "NodeStatus": {
+      "description": "Discrete lifecycle state of a node.",
+      "oneOf": [
+        {
+          "description": "Node is live and interactive.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "active"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Node is waiting on an upstream process (tool call, user response).",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "pending"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Node's intent has been satisfied — useful for collapsing completed items.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "resolved"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Node failed — `reason` is human-readable and SHOULD be surfaced in the UI.",
+          "type": "object",
+          "required": [
+            "kind",
+            "reason"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "failed"
+              ]
+            },
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Node is fading out according to a decay curve (0.0 = fresh, 1.0 = gone).",
+          "type": "object",
+          "required": [
+            "kind",
+            "progress"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "decaying"
+              ]
+            },
+            "progress": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        }
+      ]
+    },
+    "Priority": {
+      "description": "Attention priority of a node.",
+      "oneOf": [
+        {
+          "description": "Background presence — persistent but non-demanding (e.g. a live metric).",
+          "type": "string",
+          "enum": [
+            "ambient"
+          ]
+        },
+        {
+          "description": "Default rendering priority.",
+          "type": "string",
+          "enum": [
+            "normal"
+          ]
+        },
+        {
+          "description": "Requires user attention soon but does not block other flows.",
+          "type": "string",
+          "enum": [
+            "urgent"
+          ]
+        },
+        {
+          "description": "Halts dependent flows until resolved (e.g. a destructive-action confirm).",
+          "type": "string",
+          "enum": [
+            "blocking"
+          ]
+        }
+      ]
+    },
+    "Projection": {
+      "description": "How a field is projected into the compositor's surface.",
+      "oneOf": [
+        {
+          "description": "Flat 2D heatmap.",
+          "type": "string",
+          "enum": [
+            "heatmap"
+          ]
+        },
+        {
+          "description": "Contour lines.",
+          "type": "string",
+          "enum": [
+            "contour"
+          ]
+        },
+        {
+          "description": "3D volume rendering — only honored by 3D compositors.",
+          "type": "string",
+          "enum": [
+            "volume"
+          ]
+        },
+        {
+          "description": "Reduced to a scalar summary (min/mean/max) by the compositor.",
+          "type": "string",
+          "enum": [
+            "summary"
+          ]
+        }
+      ]
+    },
+    "SceneHints": {
+      "description": "Compositor-steering hints carried with every scene.",
+      "type": "object",
+      "properties": {
+        "density": {
+          "description": "Visual density preference.",
+          "default": "comfortable",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Density"
+            }
+          ]
+        },
+        "intent_profile": {
+          "description": "Overall intent profile — tells compositors whether to bias dense+technical or sparse+ambient presentations.",
+          "default": "balanced",
+          "allOf": [
+            {
+              "$ref": "#/definitions/IntentProfile"
+            }
+          ]
+        },
+        "locale": {
+          "description": "BCP-47 locale (e.g. `\"en-US\"`, `\"es-CO\"`). Compositors localize formatting.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preferred_surfaces": {
+          "description": "Ordered preferred surfaces, most preferred first. A compositor MAY skip a scene if its surface is not listed; compositors SHOULD respect the first match.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SurfaceKind"
+          }
+        },
+        "viewport": {
+          "description": "Rough viewport budget — hints for truncation/layout. `None` = unbounded.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Viewport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "Severity": {
+      "description": "Severity level for confirmation dialogs, warnings, and alerts.",
+      "type": "string",
+      "enum": [
+        "info",
+        "notice",
+        "warning",
+        "danger"
+      ]
+    },
+    "SignalDisplay": {
+      "description": "How a `Signal` intent is surfaced.",
+      "oneOf": [
+        {
+          "description": "Just the current value, formatted by the compositor.",
+          "type": "string",
+          "enum": [
+            "inline"
+          ]
+        },
+        {
+          "description": "A miniature plot (sparkline, bar).",
+          "type": "string",
+          "enum": [
+            "sparkline"
+          ]
+        },
+        {
+          "description": "A badge (colored chip with value).",
+          "type": "string",
+          "enum": [
+            "badge"
+          ]
+        }
+      ]
+    },
+    "SignalRef": {
+      "description": "A reference to a live value. Supports nested paths for structured signals: `SignalRef { topic: \"plexus.state\", path: [\"quorum\", \"ratio\"] }` addresses the `ratio` field inside the `quorum` object inside the `plexus.state` signal.",
+      "type": "object",
+      "required": [
+        "topic"
+      ],
+      "properties": {
+        "path": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topic": {
+          "type": "string"
+        }
+      }
+    },
+    "SignalValue": {
+      "description": "A concrete signal value pushed onto the bus at a given instant.\n\nCompositors MAY cache last-known values to render bindings when a signal has not yet emitted.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "scalar"
+              ]
+            }
+          }
+        },
+        {
+          "type": [
+            "object",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/TimePoint"
+          },
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "time_series"
+              ]
+            }
+          }
+        },
+        {
+          "type": [
+            "object",
+            "array"
+          ],
+          "items": {
+            "type": "number",
+            "format": "float"
+          },
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "vector"
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "kind",
+            "payload"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "event"
+              ]
+            },
+            "payload": true
+          }
+        }
+      ]
+    },
+    "SpatialFrame": {
+      "description": "Frame of reference for a spatial locus.",
+      "oneOf": [
+        {
+          "description": "Viewer-centric — `position` is in the compositor's viewport space.",
+          "type": "string",
+          "enum": [
+            "viewer"
+          ]
+        },
+        {
+          "description": "Scene-world — `position` is in the shared world coordinate system.",
+          "type": "string",
+          "enum": [
+            "world"
+          ]
+        },
+        {
+          "description": "Earth-fixed — `position` is (lat, lon, alt).",
+          "type": "string",
+          "enum": [
+            "geo"
+          ]
+        }
+      ]
+    },
+    "StreamKind": {
+      "description": "The content of a `Stream` channel.",
+      "oneOf": [
+        {
+          "description": "Token-by-token text (LLM generation, log tail).",
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        {
+          "description": "Audio PCM or encoded.",
+          "type": "string",
+          "enum": [
+            "audio"
+          ]
+        },
+        {
+          "description": "Arbitrary binary frames.",
+          "type": "string",
+          "enum": [
+            "binary"
+          ]
+        },
+        {
+          "description": "Structured JSON lines.",
+          "type": "string",
+          "enum": [
+            "jsonl"
+          ]
+        }
+      ]
+    },
+    "SurfaceKind": {
+      "description": "The shape of surface a compositor renders onto.",
+      "oneOf": [
+        {
+          "description": "Plain ANSI / text terminal or plain-text document.",
+          "type": "string",
+          "enum": [
+            "text"
+          ]
+        },
+        {
+          "description": "2D raster or vector canvas (browser DOM, native 2D).",
+          "type": "string",
+          "enum": [
+            "two_d"
+          ]
+        },
+        {
+          "description": "3D world (WebGPU, native 3D engines).",
+          "type": "string",
+          "enum": [
+            "three_d"
+          ]
+        },
+        {
+          "description": "GPU shader program — agents become field/material parameters.",
+          "type": "string",
+          "enum": [
+            "shader"
+          ]
+        },
+        {
+          "description": "Audio playback surface (speech, ambient music, sonification).",
+          "type": "string",
+          "enum": [
+            "audio"
+          ]
+        },
+        {
+          "description": "Spatial computing (Vision Pro / Quest / AR).",
+          "type": "string",
+          "enum": [
+            "spatial"
+          ]
+        },
+        {
+          "description": "Haptic / tactile feedback.",
+          "type": "string",
+          "enum": [
+            "tactile"
+          ]
+        }
+      ]
+    },
+    "TimePoint": {
+      "description": "Single point in a time-series signal.",
+      "type": "object",
+      "required": [
+        "t",
+        "v"
+      ],
+      "properties": {
+        "t": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "v": true
+      }
+    },
+    "Transform": {
+      "description": "Optional transformation applied to the signal value before binding.\n\nTransforms are intentionally limited to pure, deterministic functions so compositors can execute them safely without a scripting runtime.",
+      "oneOf": [
+        {
+          "description": "Pass the value through unchanged.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "identity"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Format the value into a template string. `{}` is replaced with the value.",
+          "type": "object",
+          "required": [
+            "kind",
+            "template"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "format"
+              ]
+            },
+            "template": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "Clamp a numeric value into `[min, max]`.",
+          "type": "object",
+          "required": [
+            "kind",
+            "max",
+            "min"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "clamp"
+              ]
+            },
+            "max": {
+              "type": "number",
+              "format": "double"
+            },
+            "min": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "description": "Round a numeric value to `decimals` places.",
+          "type": "object",
+          "required": [
+            "decimals",
+            "kind"
+          ],
+          "properties": {
+            "decimals": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "kind": {
+              "type": "string",
+              "enum": [
+                "round"
+              ]
+            }
+          }
+        },
+        {
+          "description": "Multiply by 100 and append `\"%\"`.",
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "percent"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Valence": {
+      "description": "Qualitative feedback direction.",
+      "type": "string",
+      "enum": [
+        "positive",
+        "neutral",
+        "negative"
+      ]
+    },
+    "Viewport": {
+      "description": "Rough viewport budget. Compositors with bounded surfaces (terminals, small screens) SHOULD respect these; surfaces without a natural viewport (audio, spatial) MAY ignore.",
+      "type": "object",
+      "required": [
+        "cols",
+        "rows"
+      ],
+      "properties": {
+        "cols": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "rows": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "Visibility": {
+      "description": "Whether this slot should be offered to the user right now.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "visible"
+          ]
+        },
+        {
+          "description": "Rendered but visually de-emphasized.",
+          "type": "string",
+          "enum": [
+            "muted"
+          ]
+        },
+        {
+          "description": "Not rendered; still in the IR for programmatic inspection.",
+          "type": "string",
+          "enum": [
+            "hidden"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/prosopon-ts/src/generated/types.ts
+++ b/packages/prosopon-ts/src/generated/types.ts
@@ -1,0 +1,597 @@
+/**
+ * AUTO-GENERATED — do not edit by hand.
+ *
+ * Source of truth: core/prosopon/crates/prosopon-core (Rust).
+ * Regenerate with `bun run generate` from packages/prosopon-ts/.
+ *
+ * Generated on: 2026-04-23T20:31:02.253Z
+ */
+/* eslint-disable */
+/* biome-ignore-all */
+
+/**
+ * Visual density preference. Compositors interpret this per-surface.
+ */
+export type Density = "compact" | "comfortable" | "spacious";
+/**
+ * Overall presentation bias for a scene.
+ */
+export type IntentProfile = "balanced" | "dense_technical" | "ambient_monitor" | "cinematic" | "conversational";
+/**
+ * The shape of surface a compositor renders onto.
+ */
+export type SurfaceKind = "text" | "two_d" | "three_d" | "shader" | "audio" | "spatial" | "tactile";
+/**
+ * What the action *means*. Compositors choose representation; agents react by semantics.
+ */
+export type ActionKind =
+  | {
+      kind: "submit";
+      payload: unknown;
+    }
+  | {
+      kind: "inspect";
+      target: string;
+    }
+  | {
+      kind: "focus";
+      target: string;
+    }
+  | {
+      args?: {
+        [k: string]: unknown | undefined;
+      };
+      command: string;
+      kind: "invoke";
+    }
+  | {
+      comment?: string | null;
+      kind: "feedback";
+      valence: Valence;
+    }
+  | {
+      kind: "choose";
+      option_id: string;
+    }
+  | {
+      kind: "input";
+      value: unknown;
+    }
+  | {
+      accepted: boolean;
+      kind: "confirm";
+    };
+/**
+ * Qualitative feedback direction.
+ */
+export type Valence = "positive" | "neutral" | "negative";
+/**
+ * Whether this slot should be offered to the user right now.
+ */
+export type Visibility = "visible" | "muted" | "hidden";
+/**
+ * What part of a node a binding updates.
+ */
+export type BindTarget =
+  | {
+      key: string;
+      kind: "attr";
+    }
+  | {
+      kind: "intent_slot";
+      path: string;
+    }
+  | {
+      id: string;
+      kind: "child_content";
+    };
+/**
+ * Optional transformation applied to the signal value before binding.
+ *
+ * Transforms are intentionally limited to pure, deterministic functions so compositors can execute them safely without a scripting runtime.
+ */
+export type Transform =
+  | {
+      kind: "identity";
+    }
+  | {
+      kind: "format";
+      template: string;
+    }
+  | {
+      kind: "clamp";
+      max: number;
+      min: number;
+    }
+  | {
+      decimals: number;
+      kind: "round";
+    }
+  | {
+      kind: "percent";
+    };
+/**
+ * The semantic type of a node.
+ *
+ * See module docs for the design philosophy. Compositors SHOULD handle every variant gracefully; falling back to rendering via `Intent::Prose` of the variant's `Display` is acceptable when no better representation is available.
+ */
+export type Intent =
+  | {
+      text: string;
+      type: "prose";
+    }
+  | {
+      lang: string;
+      source: string;
+      type: "code";
+    }
+  | {
+      source: string;
+      type: "math";
+    }
+  | {
+      id: string;
+      kind: string;
+      label?: string | null;
+      type: "entity_ref";
+    }
+  | {
+      href: string;
+      label?: string | null;
+      type: "link";
+    }
+  | {
+      anchor?: string | null;
+      source: string;
+      type: "citation";
+    }
+  | {
+      display?: SignalDisplay & string;
+      topic: string;
+      type: "signal";
+    }
+  | {
+      id: string;
+      kind: StreamKind;
+      type: "stream";
+    }
+  | {
+      options: ChoiceOption[];
+      prompt: string;
+      type: "choice";
+    }
+  | {
+      message: string;
+      severity?: Severity & string;
+      type: "confirm";
+    }
+  | {
+      default?: unknown;
+      input: InputKind;
+      prompt: string;
+      type: "input";
+    }
+  | {
+      args: unknown;
+      name: string;
+      stream?: string | null;
+      type: "tool_call";
+    }
+  | {
+      payload: unknown;
+      success: boolean;
+      type: "tool_result";
+    }
+  | {
+      label?: string | null;
+      pct?: number | null;
+      type: "progress";
+    }
+  | {
+      layout: GroupKind;
+      type: "group";
+    }
+  | {
+      collapsible?: boolean;
+      title?: string | null;
+      type: "section";
+    }
+  | {
+      type: "divider";
+    }
+  | {
+      projection: Projection;
+      topic: string;
+      type: "field";
+    }
+  | {
+      frame: SpatialFrame;
+      /**
+       * @minItems 3
+       * @maxItems 3
+       */
+      position: [number, number, number];
+      type: "locus";
+    }
+  | {
+      kind: FormationKind;
+      topic: string;
+      type: "formation";
+    }
+  | {
+      alt?: string;
+      type: "image";
+      uri: string;
+    }
+  | {
+      stream?: string | null;
+      type: "audio";
+      uri?: string | null;
+      voice?: string | null;
+    }
+  | {
+      poster?: string | null;
+      type: "video";
+      uri: string;
+    }
+  | {
+      type: "empty";
+    }
+  | {
+      kind: string;
+      payload: unknown;
+      type: "custom";
+    };
+/**
+ * How a `Signal` intent is surfaced.
+ */
+export type SignalDisplay = "inline" | "sparkline" | "badge";
+/**
+ * The content of a `Stream` channel.
+ */
+export type StreamKind = "text" | "audio" | "binary" | "jsonl";
+/**
+ * Severity level for confirmation dialogs, warnings, and alerts.
+ */
+export type Severity = "info" | "notice" | "warning" | "danger";
+/**
+ * Shape of an `Input` intent.
+ */
+export type InputKind =
+  | {
+      kind: "text";
+      multiline?: boolean;
+    }
+  | {
+      kind: "number";
+      max?: number | null;
+      min?: number | null;
+    }
+  | {
+      kind: "boolean";
+    }
+  | {
+      kind: "date";
+    }
+  | {
+      kind: "json";
+    };
+/**
+ * How a `Group` lays out its children.
+ */
+export type GroupKind = "list" | "grid" | "sequence" | "parallel" | "stack";
+/**
+ * How a field is projected into the compositor's surface.
+ */
+export type Projection = "heatmap" | "contour" | "volume" | "summary";
+/**
+ * Frame of reference for a spatial locus.
+ */
+export type SpatialFrame = "viewer" | "world" | "geo";
+/**
+ * A coherent grouping of agents — renders as a cluster, swarm, or quorum.
+ */
+export type FormationKind = "quorum" | "swarm" | "geometric" | "stigmergy";
+/**
+ * Attention priority of a node.
+ */
+export type Priority = "ambient" | "normal" | "urgent" | "blocking";
+/**
+ * Discrete lifecycle state of a node.
+ */
+export type NodeStatus =
+  | {
+      kind: "active";
+    }
+  | {
+      kind: "pending";
+    }
+  | {
+      kind: "resolved";
+    }
+  | {
+      kind: "failed";
+      reason: string;
+    }
+  | {
+      kind: "decaying";
+      progress: number;
+    };
+/**
+ * A concrete signal value pushed onto the bus at a given instant.
+ *
+ * Compositors MAY cache last-known values to render bindings when a signal has not yet emitted.
+ */
+export type SignalValue =
+  | (
+      | {
+          kind: "scalar";
+        }
+      | (
+          | {
+              kind: "time_series";
+            }
+          | TimePoint[]
+        )
+      | (
+          | {
+              kind: "vector";
+            }
+          | number[]
+        )
+      | {
+          kind: "event";
+          payload: unknown;
+        }
+    )
+  | undefined;
+/**
+ * A single event in the Prosopon stream.
+ */
+export type ProsoponEvent =
+  | {
+      scene: Scene;
+      type: "scene_reset";
+    }
+  | {
+      node: Node;
+      parent: string;
+      type: "node_added";
+    }
+  | {
+      id: string;
+      patch: NodePatch;
+      type: "node_updated";
+    }
+  | {
+      id: string;
+      type: "node_removed";
+    }
+  | {
+      topic: string;
+      ts: string;
+      type: "signal_changed";
+      value: SignalValue | undefined;
+    }
+  | {
+      chunk: StreamChunk;
+      id: string;
+      type: "stream_chunk";
+    }
+  | {
+      kind: ActionKind;
+      slot: string;
+      source: string;
+      type: "action_emitted";
+    }
+  | {
+      ts: string;
+      type: "heartbeat";
+    };
+/**
+ * How a patch modifies a node's children.
+ */
+export type ChildrenPatch =
+  | {
+      children: Node[];
+      op: "replace";
+    }
+  | {
+      children: Node[];
+      op: "append";
+    }
+  | {
+      ids: string[];
+      op: "remove";
+    }
+  | {
+      op: "reorder";
+      order: string[];
+    };
+/**
+ * Payload variants carried in a stream chunk.
+ */
+export type ChunkPayload =
+  | {
+      encoding: "text";
+      text: string;
+    }
+  | {
+      data: string;
+      encoding: "b64";
+      mime?: string | null;
+    }
+  | {
+      encoding: "json";
+      value: unknown;
+    };
+
+/**
+ * Combined Scene + ProsoponEvent schema for TS code-gen.
+ */
+/**
+ * A complete snapshot of "what to render."
+ */
+export interface Scene {
+  hints?: SceneHints;
+  id: string;
+  root: Node;
+  /**
+   * Last-known value for each referenced signal topic. Compositors that support push-based updates MAY subscribe and ignore this cache; compositors that only pull SHOULD treat this as the authoritative initial value.
+   */
+  signals?: {
+    [k: string]: SignalValue | undefined;
+  };
+}
+/**
+ * Compositor-steering hints carried with every scene.
+ */
+export interface SceneHints {
+  /**
+   * Visual density preference.
+   */
+  density?: Density & string;
+  /**
+   * Overall intent profile — tells compositors whether to bias dense+technical or sparse+ambient presentations.
+   */
+  intent_profile?: IntentProfile & string;
+  /**
+   * BCP-47 locale (e.g. `"en-US"`, `"es-CO"`). Compositors localize formatting.
+   */
+  locale?: string | null;
+  /**
+   * Ordered preferred surfaces, most preferred first. A compositor MAY skip a scene if its surface is not listed; compositors SHOULD respect the first match.
+   */
+  preferred_surfaces?: SurfaceKind[];
+  /**
+   * Rough viewport budget — hints for truncation/layout. `None` = unbounded.
+   */
+  viewport?: Viewport | null;
+}
+/**
+ * Rough viewport budget. Compositors with bounded surfaces (terminals, small screens) SHOULD respect these; surfaces without a natural viewport (audio, spatial) MAY ignore.
+ */
+export interface Viewport {
+  cols: number;
+  rows: number;
+}
+/**
+ * A node in the Prosopon IR tree.
+ */
+export interface Node {
+  actions?: ActionSlot[];
+  /**
+   * Free-form attribute bag for hints the compositor MAY use. Well-known keys: `emphasis` (`"low" | "normal" | "high"`), `semantic_role` (e.g. `"error"`, `"success"`), `width_hint` (fraction 0..=1), `voice` (TTS voice id).
+   */
+  attrs?: {
+    [k: string]: unknown | undefined;
+  };
+  bindings?: Binding[];
+  children?: Node[];
+  id: string;
+  intent: Intent;
+  lifecycle?: Lifecycle;
+}
+/**
+ * An interactive slot attached to a node.
+ *
+ * Slots are *declarative* — the node says "this action is available," the compositor decides how to present it (button, keybind, voice command, gesture), and the agent reacts to the emitted `ActionEvent`.
+ */
+export interface ActionSlot {
+  enabled?: boolean;
+  id: string;
+  kind: ActionKind;
+  label?: string | null;
+  visibility?: Visibility & string;
+}
+/**
+ * Binds a live signal to a rendering slot on a node.
+ *
+ * The compositor is responsible for subscribing to the signal and applying the (optional) transform before updating the target.
+ */
+export interface Binding {
+  source: SignalRef;
+  target: BindTarget;
+  transform?: Transform | null;
+}
+/**
+ * A reference to a live value. Supports nested paths for structured signals: `SignalRef { topic: "plexus.state", path: ["quorum", "ratio"] }` addresses the `ratio` field inside the `quorum` object inside the `plexus.state` signal.
+ */
+export interface SignalRef {
+  path?: string[];
+  topic: string;
+}
+/**
+ * One of the options presented by a `Choice` intent.
+ */
+export interface ChoiceOption {
+  default?: boolean;
+  description?: string | null;
+  /**
+   * Stable identifier used in the corresponding `ActionKind::Choose`.
+   */
+  id: string;
+  label: string;
+}
+/**
+ * Temporal and attentional state of a node.
+ */
+export interface Lifecycle {
+  /**
+   * When this node was first emitted by the agent.
+   */
+  created_at: string;
+  /**
+   * Optional expiration. Compositors SHOULD remove or fade past this time.
+   */
+  expires_at?: string | null;
+  /**
+   * Attention priority — shapes placement, color, and notification behavior.
+   */
+  priority?: Priority & string;
+  /**
+   * Current status in the node's lifecycle.
+   */
+  status?: NodeStatus;
+}
+/**
+ * Single point in a time-series signal.
+ */
+export interface TimePoint {
+  t: string;
+  v: unknown;
+}
+/**
+ * An incremental update to a node — used by `ProsoponEvent::NodeUpdated`.
+ *
+ * All fields are optional; unset fields leave existing values untouched.
+ */
+export interface NodePatch {
+  /**
+   * Attribute updates. `None` values remove the key.
+   */
+  attrs?: {
+    [k: string]: unknown | undefined;
+  };
+  children?: ChildrenPatch | null;
+  intent?: Intent | null;
+  lifecycle?: Lifecycle | null;
+}
+/**
+ * A chunk of streaming payload.
+ */
+export interface StreamChunk {
+  /**
+   * True if this is the last chunk of the stream.
+   */
+  final_?: boolean;
+  /**
+   * Encoded payload. Interpretation depends on the `StreamKind` of the originating `Stream` intent.
+   */
+  payload: ChunkPayload;
+  /**
+   * Sequence number (monotonic per stream). Compositors drop out-of-order chunks.
+   */
+  seq: number;
+}
+

--- a/packages/prosopon-ts/src/ids.ts
+++ b/packages/prosopon-ts/src/ids.ts
@@ -1,0 +1,51 @@
+/**
+ * Identifier helpers — Prosopon IDs are transparent UUID strings in the Rust
+ * core. We mirror the minting behaviour (v4 UUIDs by default) so hand-rolled
+ * TS agents produce IDs wire-compatible with Rust-emitted IDs.
+ */
+
+import { randomUUID } from "node:crypto";
+
+type Branded<K, Brand> = K & { readonly __brand: Brand };
+
+export type NodeId = Branded<string, "NodeId">;
+export type SceneId = Branded<string, "SceneId">;
+export type ActionId = Branded<string, "ActionId">;
+export type StreamId = Branded<string, "StreamId">;
+export type Topic = Branded<string, "Topic">;
+
+function mint<B>(): Branded<string, B> {
+  // Browsers expose crypto.randomUUID() globally; Node/Bun do too via the
+  // imported `randomUUID` above. This tries global first so the code works
+  // identically in edge runtimes without a `node:crypto` shim.
+  const g = (globalThis as { crypto?: { randomUUID?(): string } }).crypto;
+  if (g?.randomUUID) return g.randomUUID() as Branded<string, B>;
+  return randomUUID() as Branded<string, B>;
+}
+
+export function newNodeId(raw?: string): NodeId {
+  return (raw ?? mint<"NodeId">()) as NodeId;
+}
+
+export function newSceneId(raw?: string): SceneId {
+  return (raw ?? mint<"SceneId">()) as SceneId;
+}
+
+export function newActionId(raw?: string): ActionId {
+  return (raw ?? mint<"ActionId">()) as ActionId;
+}
+
+export function newStreamId(raw?: string): StreamId {
+  return (raw ?? mint<"StreamId">()) as StreamId;
+}
+
+export function topic(name: string): Topic {
+  return name as Topic;
+}
+
+/** Topic namespace-prefix matching (dot-aware), mirrors Rust `Topic::starts_with_namespace`. */
+export function topicStartsWith(t: Topic, prefix: string): boolean {
+  const s = t as unknown as string;
+  if (s === prefix) return true;
+  return s.startsWith(`${prefix}.`);
+}

--- a/packages/prosopon-ts/src/index.ts
+++ b/packages/prosopon-ts/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @broomva/prosopon — TypeScript bindings for the Prosopon display server.
+ *
+ * Wire-compatible with `prosopon-protocol` v1 (as implemented in
+ * `core/prosopon/crates/prosopon-protocol`).
+ */
+
+// IR types — re-exported from the facade over auto-generated output.
+export * from "./types";
+
+// Wire layer (envelope + codec)
+export {
+  type Envelope,
+  type Codec,
+  type Hello,
+  PROTOCOL_VERSION,
+  makeEnvelope,
+  encode,
+  decode,
+  ProtocolVersionMismatch,
+} from "./codec";
+
+// Pure reducer
+export { applyEvent, readSignal } from "./apply-event";
+
+// Browser client (WS primary, SSE fallback)
+export {
+  ProsoponClient,
+  type ProsoponClientOptions,
+  type ProsoponClientState,
+  type ProsoponTransport,
+  type EnvelopeHandler,
+  type ErrorHandler,
+  type StateHandler,
+} from "./client";
+
+// Server-side session emitter
+export { ProsoponSession, type ProsoponSessionOptions } from "./session";
+
+// ID helpers
+export {
+  type NodeId,
+  type SceneId,
+  type ActionId,
+  type StreamId,
+  type Topic,
+  newNodeId,
+  newSceneId,
+  newActionId,
+  newStreamId,
+  topic,
+  topicStartsWith,
+} from "./ids";

--- a/packages/prosopon-ts/src/session.ts
+++ b/packages/prosopon-ts/src/session.ts
@@ -1,0 +1,52 @@
+/**
+ * Server-side emitter — `ProsoponSession`. Helper for agent code running on
+ * Node / Bun / edge that needs to emit envelopes into a transport (SSE, WS,
+ * prosopon-daemon fanout, etc.).
+ *
+ * The session owns (sessionId, seq). Every `emit()` mints a new envelope with
+ * the next monotonic seq. Callers supply the event; we handle versioning,
+ * timestamps, and encoding.
+ */
+
+import { type Envelope, type Codec, encode, makeEnvelope } from "./codec";
+import type { ProsoponEvent } from "./types";
+
+export interface ProsoponSessionOptions {
+  /** Stable session identifier. Generate with crypto.randomUUID() if absent. */
+  sessionId: string;
+  /** Starting sequence number (default 1, matches Rust `seq` semantics). */
+  startSeq?: number;
+}
+
+export class ProsoponSession {
+  readonly sessionId: string;
+  private seq: number;
+
+  constructor(options: ProsoponSessionOptions) {
+    this.sessionId = options.sessionId;
+    this.seq = options.startSeq ?? 1;
+  }
+
+  /**
+   * Build the next envelope wrapping `event`. Increments the session's
+   * sequence counter. Does NOT send anything — callers pipe the returned
+   * envelope into their transport of choice.
+   */
+  emit(event: ProsoponEvent): Envelope {
+    const envelope = makeEnvelope({
+      session_id: this.sessionId,
+      seq: this.seq,
+      event,
+    });
+    this.seq += 1;
+    return envelope;
+  }
+
+  /**
+   * Emit + encode in one step. Convenience for SSE/JSONL writers.
+   * Returns the wire bytes ready to enqueue into a stream.
+   */
+  emitFrame(event: ProsoponEvent, codec: Codec = "jsonl"): string {
+    return encode(codec, this.emit(event));
+  }
+}

--- a/packages/prosopon-ts/src/types.ts
+++ b/packages/prosopon-ts/src/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Facade over the auto-generated types — re-exports with stable names and
+ * a couple of ergonomic helpers. If `src/generated/types.ts` is regenerated
+ * and an export name changes upstream, adjust here rather than at every
+ * call-site.
+ */
+
+export type {
+  // Scene root
+  Scene,
+  SceneHints,
+  Viewport,
+  Density,
+  IntentProfile,
+  SurfaceKind,
+  // Nodes
+  Node as SceneNode,
+  NodePatch,
+  ChildrenPatch,
+  // Intent — the IR's semantic layer
+  Intent,
+  GroupKind,
+  SignalDisplay,
+  StreamKind,
+  ChoiceOption,
+  InputKind,
+  Projection,
+  SpatialFrame,
+  FormationKind,
+  // Lifecycle
+  Lifecycle,
+  NodeStatus,
+  Priority,
+  Severity,
+  // Actions (compositor → agent)
+  ActionSlot,
+  ActionKind,
+  Valence,
+  Visibility,
+  // Signals (reactive)
+  Binding,
+  BindTarget,
+  Transform,
+  SignalRef,
+  SignalValue,
+  TimePoint,
+  // Events + stream payload
+  ProsoponEvent,
+  StreamChunk,
+  ChunkPayload,
+} from "./generated/types";

--- a/packages/prosopon-ts/tests/roundtrip.test.ts
+++ b/packages/prosopon-ts/tests/roundtrip.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Roundtrip tests — verify wire compatibility with the Rust core by folding
+ * each of the 8 ProsoponEvent variants against a scene and asserting
+ * invariants.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  applyEvent,
+  decode,
+  encode,
+  makeEnvelope,
+  PROTOCOL_VERSION,
+  ProsoponSession,
+  readSignal,
+  type Envelope,
+  type ProsoponEvent,
+  type Scene,
+  type SceneNode,
+} from "../src/index";
+
+const ROOT_ID = "root-1";
+const CHAT_ID = "chat";
+const MSG_ID = "m-1";
+
+function baseScene(): Scene {
+  const root: SceneNode = {
+    id: ROOT_ID,
+    intent: { type: "section", title: "Root", collapsible: false },
+    children: [
+      {
+        id: CHAT_ID,
+        intent: { type: "section", title: "Chat", collapsible: false },
+        children: [],
+        bindings: [],
+        actions: [],
+        attrs: {},
+        lifecycle: { created_at: new Date().toISOString() },
+      },
+    ],
+    bindings: [],
+    actions: [],
+    attrs: {},
+    lifecycle: { created_at: new Date().toISOString() },
+  };
+  return {
+    id: "scene-1",
+    root,
+    signals: {},
+    hints: { density: "comfortable", intent_profile: "balanced" },
+  };
+}
+
+describe("envelope codec", () => {
+  test("makeEnvelope + encode + decode (json) round-trips", () => {
+    const env = makeEnvelope({
+      session_id: "s1",
+      seq: 42,
+      event: { type: "heartbeat", ts: new Date().toISOString() },
+    });
+    const wire = encode("json", env);
+    const back = decode("json", wire);
+    expect(back.version).toBe(PROTOCOL_VERSION);
+    expect(back.seq).toBe(42);
+    expect(back.event).toEqual(env.event);
+  });
+
+  test("jsonl preserves trailing newline", () => {
+    const env = makeEnvelope({
+      session_id: "s2",
+      seq: 1,
+      event: { type: "heartbeat", ts: new Date().toISOString() },
+    });
+    const wire = encode("jsonl", env);
+    expect(wire.endsWith("\n")).toBe(true);
+    const back = decode("jsonl", wire);
+    expect(back.seq).toBe(1);
+  });
+
+  test("version mismatch throws", () => {
+    const bad = JSON.stringify({
+      version: 999,
+      session_id: "x",
+      seq: 1,
+      ts: new Date().toISOString(),
+      event: { type: "heartbeat", ts: new Date().toISOString() },
+    });
+    expect(() => decode("json", bad)).toThrow(
+      /protocol version mismatch/,
+    );
+  });
+});
+
+describe("applyEvent", () => {
+  test("scene_reset replaces scene wholesale", () => {
+    const s = baseScene();
+    const nextRoot: SceneNode = {
+      id: "new-root",
+      intent: { type: "prose", text: "fresh" },
+      children: [],
+      bindings: [],
+      actions: [],
+      attrs: {},
+      lifecycle: { created_at: new Date().toISOString() },
+    };
+    const ev: ProsoponEvent = {
+      type: "scene_reset",
+      scene: {
+        id: "scene-2",
+        root: nextRoot,
+        signals: {},
+        hints: { density: "comfortable", intent_profile: "balanced" },
+      },
+    };
+    const out = applyEvent(s, ev);
+    expect(out.id).toBe("scene-2");
+    expect(out.root.id).toBe("new-root");
+  });
+
+  test("node_added grafts under parent", () => {
+    const s = baseScene();
+    const newNode: SceneNode = {
+      id: MSG_ID,
+      intent: { type: "stream", id: MSG_ID, kind: "text" },
+      children: [],
+      bindings: [],
+      actions: [],
+      attrs: {},
+      lifecycle: { created_at: new Date().toISOString() },
+    };
+    const out = applyEvent(s, {
+      type: "node_added",
+      parent: CHAT_ID,
+      node: newNode,
+    });
+    const chat = findById(out, CHAT_ID);
+    expect(chat?.children?.map((c) => c.id)).toEqual([MSG_ID]);
+  });
+
+  test("node_updated applies attrs and intent patches", () => {
+    let s = baseScene();
+    s = applyEvent(s, {
+      type: "node_added",
+      parent: CHAT_ID,
+      node: {
+        id: MSG_ID,
+        intent: { type: "prose", text: "v1" },
+        children: [],
+        bindings: [],
+        actions: [],
+        attrs: {},
+        lifecycle: { created_at: new Date().toISOString() },
+      },
+    });
+    const out = applyEvent(s, {
+      type: "node_updated",
+      id: MSG_ID,
+      patch: {
+        intent: { type: "prose", text: "v2" },
+        attrs: { emphasis: "high" },
+      },
+    });
+    const node = findById(out, MSG_ID);
+    expect(node?.intent).toEqual({ type: "prose", text: "v2" });
+    expect(node?.attrs?.emphasis).toBe("high");
+  });
+
+  test("node_removed removes subtree", () => {
+    let s = baseScene();
+    s = applyEvent(s, {
+      type: "node_added",
+      parent: CHAT_ID,
+      node: {
+        id: MSG_ID,
+        intent: { type: "prose", text: "bye" },
+        children: [],
+        bindings: [],
+        actions: [],
+        attrs: {},
+        lifecycle: { created_at: new Date().toISOString() },
+      },
+    });
+    const out = applyEvent(s, { type: "node_removed", id: MSG_ID });
+    const chat = findById(out, CHAT_ID);
+    expect(chat?.children ?? []).toEqual([]);
+  });
+
+  test("signal_changed updates signals map", () => {
+    const s = baseScene();
+    const out = applyEvent(s, {
+      type: "signal_changed",
+      topic: "haima.spend.cents",
+      value: { kind: "scalar", Scalar: 42 } as unknown as ReturnType<
+        typeof readSignal
+      >,
+      ts: new Date().toISOString(),
+    } as ProsoponEvent);
+    expect(out.signals?.["haima.spend.cents"]).toBeDefined();
+  });
+
+  test("heartbeat is a no-op", () => {
+    const s = baseScene();
+    const out = applyEvent(s, {
+      type: "heartbeat",
+      ts: new Date().toISOString(),
+    });
+    expect(out).toBe(s);
+  });
+
+  test("unknown event type is forward-compat no-op", () => {
+    const s = baseScene();
+    const out = applyEvent(s, {
+      type: "future_variant",
+    } as unknown as ProsoponEvent);
+    expect(out).toBe(s);
+  });
+});
+
+describe("ProsoponSession", () => {
+  test("monotonic seq across emits", () => {
+    const session = new ProsoponSession({ sessionId: "sess-1" });
+    const a = session.emit({
+      type: "heartbeat",
+      ts: new Date().toISOString(),
+    });
+    const b = session.emit({
+      type: "heartbeat",
+      ts: new Date().toISOString(),
+    });
+    expect(a.seq).toBe(1);
+    expect(b.seq).toBe(2);
+    expect(a.session_id).toBe("sess-1");
+  });
+
+  test("emitFrame yields valid jsonl", () => {
+    const session = new ProsoponSession({ sessionId: "sess-2" });
+    const frame = session.emitFrame({
+      type: "heartbeat",
+      ts: new Date().toISOString(),
+    });
+    expect(frame.endsWith("\n")).toBe(true);
+    const env: Envelope = JSON.parse(frame.trim());
+    expect(env.session_id).toBe("sess-2");
+  });
+});
+
+// helpers ---------------------------------------------------------------
+
+function findById(scene: Scene, id: string): SceneNode | undefined {
+  const walk = (node: SceneNode): SceneNode | undefined => {
+    if (node.id === id) return node;
+    for (const c of node.children ?? []) {
+      const hit = walk(c);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  return walk(scene.root);
+}

--- a/packages/prosopon-ts/tsconfig.json
+++ b/packages/prosopon-ts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
Ships PR A + PR B from the /life \u2192 Prosopon wiring plan. @broomva/prosopon package with auto-gen types from prosopon-core schemas + codec + apply-event reducer + WS/SSE client; new /api/life/run/[project]/prosopon endpoint emitting Envelope<ProsoponEvent> stream. Legacy /api/life/run stays for current UI; PR C migrates UI to envelopes. Build + typecheck + 12/12 roundtrip tests green.