### PR TITLE
feat(life): migrate /life UI to Prosopon envelope wire (PR C)

### DIFF
--- a/apps/chat/app/(site)/life/_components/LifeShell.tsx
+++ b/apps/chat/app/(site)/life/_components/LifeShell.tsx
@@ -9,7 +9,11 @@ import {
 } from "../_lib/tweaks";
 import type { ScenarioId, TweaksState } from "../_lib/types";
 import { useReplay } from "../_lib/use-replay";
-import { useLiveRun } from "../_lib/use-live-run";
+// Prosopon-native live runner. Swapped in PR C — see
+// docs/superpowers/specs/2026-04-23-life-prosopon-wiring.md. `useLiveRun`
+// (legacy wire) is retained until PR D decommissions the non-/prosopon
+// endpoint; anything relying on it directly should migrate here.
+import { useProsoponRun } from "../_lib/use-prosopon-run";
 import { PaymentRequiredBanner } from "./PaymentRequiredBanner";
 import type { LifeUserIdentity } from "./AnimaPane";
 import { AnimaPopover } from "./AnimaPopover";
@@ -110,7 +114,7 @@ export function LifeShell({
   // No server-side scenario auto-play (that was a Phase 2 / early-Phase-3
   // crutch that made the UI look scripted). The empty state now invites
   // the user to type; sendMessage() kicks off the first real turn.
-  const [liveState, setLiveState, liveMeta] = useLiveRun({
+  const [liveState, setLiveState, liveMeta] = useProsoponRun({
     projectSlug,
     enabled: liveEnabled,
     autoStart: false,

--- a/apps/chat/app/(site)/life/_lib/envelope-adapter.test.ts
+++ b/apps/chat/app/(site)/life/_lib/envelope-adapter.test.ts
@@ -1,0 +1,353 @@
+// Unit tests for the Prosopon → ReplayEvent adapter.
+//
+// These lock in the shape the `useProsoponRun` hook depends on: each
+// Prosopon envelope variant produces exactly the ReplayEvents the legacy
+// `applyReplayEvent` reducer expects. When the server-side emitter
+// (`lib/life-runtime/prosopon-emitter.ts`) changes its wire format, this
+// file is where the round-trip contract breaks first.
+
+import { describe, expect, it } from "vitest";
+import type { Envelope } from "@broomva/prosopon";
+
+import { EnvelopeAdapter, TOPICS } from "./envelope-adapter";
+
+function env(event: unknown, seq = 1): Envelope {
+  return {
+    version: 1,
+    session_id: "sess-test",
+    seq,
+    ts: new Date("2026-04-23T12:00:00Z").toISOString(),
+    event: event as Envelope["event"],
+  };
+}
+
+describe("EnvelopeAdapter", () => {
+  it("scene_reset signals a reset with no replay events", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "scene_reset",
+        scene: {
+          id: "s",
+          root: {
+            id: "root",
+            intent: { type: "section", title: "X" },
+            children: [],
+            bindings: [],
+            actions: [],
+            attrs: {},
+            lifecycle: { created_at: new Date().toISOString() },
+          },
+          signals: {},
+          hints: {},
+        },
+      }),
+      0,
+    );
+    expect(out.reset).toBe(true);
+    expect(out.replay).toHaveLength(0);
+  });
+
+  it("reasoning Section (msg-<id>) → agent-thinking-start", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "chat",
+        node: {
+          id: "msg-abc",
+          intent: { type: "section", title: "Reasoning", collapsible: true },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      100,
+    );
+    expect(out.replay).toEqual([
+      { t: 100, kind: "agent-thinking-start", id: "abc" },
+    ]);
+  });
+
+  it("node_updated on msg-<id> with lifecycle resolved → agent-thinking-end", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_updated",
+        id: "msg-xyz",
+        patch: {
+          lifecycle: {
+            created_at: new Date().toISOString(),
+            status: { kind: "resolved" },
+          },
+        },
+      }),
+      200,
+    );
+    expect(out.replay).toContainEqual({
+      t: 200,
+      kind: "agent-thinking-end",
+      id: "xyz",
+    });
+  });
+
+  it("stream node + stream_chunk → agent-text-start + agent-text-append", () => {
+    const a = new EnvelopeAdapter();
+    const startOut = a.feed(
+      env({
+        type: "node_added",
+        parent: "chat",
+        node: {
+          id: "stream-m1",
+          intent: { type: "stream", id: "stream-m1", kind: "text" },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      10,
+    );
+    expect(startOut.replay).toEqual([
+      { t: 10, kind: "agent-text-start", id: "m1", text: "" },
+    ]);
+
+    const chunkOut = a.feed(
+      env({
+        type: "stream_chunk",
+        id: "stream-m1",
+        chunk: {
+          seq: 1,
+          payload: { encoding: "text", text: "Hello" },
+          final_: false,
+        },
+      }),
+      20,
+    );
+    expect(chunkOut.replay).toEqual([
+      { t: 20, kind: "agent-text-append", id: "m1", text: "Hello" },
+    ]);
+  });
+
+  it("tool_call node → tool-call event, tool_result patch → tool-result event", () => {
+    const a = new EnvelopeAdapter();
+    const callOut = a.feed(
+      env({
+        type: "node_added",
+        parent: "chat",
+        node: {
+          id: "tool-call-1",
+          intent: {
+            type: "tool_call",
+            name: "fs.read:/path/x.md",
+            args: { path: "/path/x.md" },
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      50,
+    );
+    expect(callOut.replay[0]).toMatchObject({
+      t: 50,
+      kind: "tool-call",
+      id: "call-1",
+      name: "fs.read",
+      target: "/path/x.md",
+      journalKind: "fs",
+    });
+
+    const resultOut = a.feed(
+      env({
+        type: "node_updated",
+        id: "tool-call-1",
+        patch: {
+          intent: {
+            type: "tool_result",
+            success: true,
+            payload: { text: "file contents" },
+          },
+          lifecycle: {
+            created_at: new Date().toISOString(),
+            status: { kind: "resolved" },
+          },
+        },
+      }),
+      80,
+    );
+    expect(resultOut.replay).toEqual([
+      { t: 80, kind: "tool-result", id: "call-1", result: "file contents" },
+    ]);
+  });
+
+  it("Custom{kind:fs.op} node → fs-op event with content/path/bytes", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "workspace",
+        node: {
+          id: "fs-1",
+          intent: {
+            type: "custom",
+            kind: "fs.op",
+            payload: {
+              path: "notes/hello.md",
+              op: "write",
+              content: "# hi",
+              title: "greeting",
+              bytes: 4,
+            },
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      120,
+    );
+    expect(out.replay).toEqual([
+      {
+        t: 120,
+        kind: "fs-op",
+        path: "notes/hello.md",
+        op: "write",
+        content: "# hi",
+        title: "greeting",
+        bytes: 4,
+      },
+    ]);
+  });
+
+  it("nous.composite + nous.band + nous.note collapse into one nous-score", () => {
+    const a = new EnvelopeAdapter();
+    const comp = a.feed(
+      env({
+        type: "signal_changed",
+        topic: TOPICS.NOUS_COMPOSITE,
+        value: { Scalar: 0.82 },
+        ts: new Date().toISOString(),
+      }),
+      10,
+    );
+    // Composite alone: not yet emittable because band is missing.
+    expect(comp.replay).toHaveLength(0);
+
+    const band = a.feed(
+      env({
+        type: "signal_changed",
+        topic: TOPICS.NOUS_BAND,
+        value: { Scalar: "good" },
+        ts: new Date().toISOString(),
+      }),
+      11,
+    );
+    expect(band.replay).toEqual([
+      { t: 11, kind: "nous-score", score: 0.82, band: "good", note: "" },
+    ]);
+
+    // Note arrives later — re-emit with updated note.
+    const note = a.feed(
+      env({
+        type: "signal_changed",
+        topic: TOPICS.NOUS_NOTE,
+        value: { Scalar: "context broadly anchored" },
+        ts: new Date().toISOString(),
+      }),
+      12,
+    );
+    expect(note.replay).toEqual([
+      {
+        t: 12,
+        kind: "nous-score",
+        score: 0.82,
+        band: "good",
+        note: "context broadly anchored",
+      },
+    ]);
+  });
+
+  it("autonomic.<pillar>.note emits once per distinct value per pillar", () => {
+    const a = new EnvelopeAdapter();
+    const first = a.feed(
+      env({
+        type: "signal_changed",
+        topic: "autonomic.operational.note",
+        value: { Scalar: "nominal" },
+        ts: new Date().toISOString(),
+      }),
+      5,
+    );
+    expect(first.replay).toEqual([
+      { t: 5, kind: "autonomic-event", pillar: "operational", text: "nominal" },
+    ]);
+
+    // Same value again → suppressed.
+    const repeat = a.feed(
+      env({
+        type: "signal_changed",
+        topic: "autonomic.operational.note",
+        value: { Scalar: "nominal" },
+        ts: new Date().toISOString(),
+      }),
+      6,
+    );
+    expect(repeat.replay).toHaveLength(0);
+
+    // Different value → emits.
+    const drift = a.feed(
+      env({
+        type: "signal_changed",
+        topic: "autonomic.operational.note",
+        value: { Scalar: "drift detected" },
+        ts: new Date().toISOString(),
+      }),
+      7,
+    );
+    expect(drift.replay).toEqual([
+      {
+        t: 7,
+        kind: "autonomic-event",
+        pillar: "operational",
+        text: "drift detected",
+      },
+    ]);
+  });
+
+  it("haima/vigil signals flow to the meta channel, not replay", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "signal_changed",
+        topic: TOPICS.HAIMA_SPEND,
+        value: { Scalar: 42 },
+        ts: new Date().toISOString(),
+      }),
+      0,
+    );
+    expect(out.replay).toHaveLength(0);
+    expect(out.meta).toEqual([{ kind: "cost-total", value: 42 }]);
+  });
+
+  it("heartbeat + action_emitted + unknown → noop", () => {
+    const a = new EnvelopeAdapter();
+    for (const ev of [
+      { type: "heartbeat", ts: new Date().toISOString() },
+      { type: "action_emitted", slot: {} },
+      { type: "totally_new_future_event", whatever: 1 },
+    ]) {
+      const out = a.feed(env(ev), 0);
+      expect(out.replay).toHaveLength(0);
+      expect(out.meta).toHaveLength(0);
+      expect(out.reset).toBe(false);
+    }
+  });
+});

--- a/apps/chat/app/(site)/life/_lib/envelope-adapter.ts
+++ b/apps/chat/app/(site)/life/_lib/envelope-adapter.ts
@@ -1,0 +1,441 @@
+// Envelope → ReplayEvent adapter.
+//
+// Takes a Prosopon `Envelope<ProsoponEvent>` stream and maps it back into
+// the legacy `ReplayEvent` stream the existing `applyReplayEvent` reducer
+// understands. This is the inverse of `lib/life-runtime/prosopon-emitter.ts`
+// — by round-tripping through the canonical Prosopon wire we prove both
+// sides agree, AND we get to keep every pane unchanged.
+//
+// The adapter is stateful because a few signals have to be *paired* before
+// the reducer sees a coherent event:
+//   - `nous.composite` + `nous.band` + `nous.note` arrive as three separate
+//     signal_changed envelopes but collapse into one `nous-score` ReplayEvent.
+//   - `autonomic.<pillar>.note` is a last-value-wins signal. To preserve
+//     the reducer's history semantics we append an `autonomic-event` event
+//     only when the signal value actually changes.
+//
+// This is intentionally a pure data transform — zero DOM / React / fetch
+// dependencies — so it's trivial to unit-test and run in any JS runtime.
+
+import type {
+  Envelope,
+  ProsoponEvent,
+  SceneNode,
+  SignalValue,
+} from "@broomva/prosopon";
+import type { JournalKind, ReplayEvent } from "./types";
+
+// ---------------------------------------------------------------------------
+// Wire-level shapes we care about
+// ---------------------------------------------------------------------------
+
+/** Topics published by `prosopon-emitter.ts`. Centralised for lint-ability. */
+export const TOPICS = {
+  NOUS_COMPOSITE: "nous.composite",
+  NOUS_BAND: "nous.band",
+  NOUS_NOTE: "nous.note",
+  HAIMA_SPEND: "haima.spend.cents",
+  HAIMA_LAST_TURN: "haima.last_turn.cents",
+  HAIMA_PAYMENT_MODE: "haima.payment_mode",
+  VIGIL_TOKENS_IN: "vigil.tokens.input",
+  VIGIL_TOKENS_OUT: "vigil.tokens.output",
+  VIGIL_DURATION_MS: "vigil.duration.ms",
+  LIFE_PROJECT_SLUG: "life.project.slug",
+} as const;
+
+/** Topic prefix for autonomic pillar notes: `autonomic.<pillar>.note`. */
+const AUTONOMIC_PREFIX = "autonomic.";
+
+type Pillar = "operational" | "cognitive" | "economic";
+const PILLARS: readonly Pillar[] = ["operational", "cognitive", "economic"];
+
+function isPillar(s: string): s is Pillar {
+  return (PILLARS as readonly string[]).includes(s);
+}
+
+/**
+ * Signal payloads from the emitter are wrapped as `{ Scalar: <value> }`.
+ * Prosopon's wider SignalValue union supports Scalar / Array / Object /
+ * Tensor; today the emitter only uses Scalar, so unwrapping that covers
+ * 100% of cases. Future encodings would need explicit handling here.
+ */
+function unwrapScalar(v: SignalValue | undefined): string | number | boolean | null {
+  if (!v || typeof v !== "object") return null;
+  const scalar = (v as Record<string, unknown>).Scalar;
+  if (typeof scalar === "string" || typeof scalar === "number" || typeof scalar === "boolean") {
+    return scalar;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Meta surface — the hook cares about a handful of signals that don't map
+// to ReplayEvents but DO drive the LiveRunMeta contract (cost, tokens, etc).
+// We surface them on a separate channel so the hook can thread them into
+// its meta state without tangling the replay stream.
+// ---------------------------------------------------------------------------
+
+export interface AdapterMetaEvent {
+  kind: "cost-total" | "cost-turn" | "tokens-in" | "tokens-out" | "duration-ms" | "payment-mode";
+  value: number | string;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+export interface AdapterOutput {
+  /** Replay events to fold through `applyReplayEvent` in order. */
+  replay: ReplayEvent[];
+  /** Meta updates the hook should apply to its LiveRunMeta slot. */
+  meta: AdapterMetaEvent[];
+  /** True for `scene_reset` — the caller should zero out state first. */
+  reset: boolean;
+}
+
+const EMPTY: AdapterOutput = { replay: [], meta: [], reset: false };
+
+/**
+ * Build an empty `AdapterOutput` (useful for adapter misses).
+ */
+function emptyOutput(): AdapterOutput {
+  return { replay: [], meta: [], reset: false };
+}
+
+export class EnvelopeAdapter {
+  // Pending-nous ensemble. The reducer wants a single `nous-score` event
+  // with all three fields; signals arrive separately so we buffer.
+  private nousScore: number | null = null;
+  private nousBand: "good" | "warn" | null = null;
+  private nousNote: string = "";
+
+  // Last-seen value per autonomic pillar; we emit only on change.
+  private lastAutonomic: Partial<Record<Pillar, string>> = {};
+
+  /**
+   * Translate one envelope. Returns the replay events to feed the reducer,
+   * plus any meta-channel updates for the hook.
+   */
+  feed(envelope: Envelope, tMs: number): AdapterOutput {
+    const ev = envelope.event as ProsoponEvent & { type: string };
+
+    switch (ev.type) {
+      case "scene_reset":
+        this.resetState();
+        return { ...emptyOutput(), reset: true };
+
+      case "node_added":
+        return this.onNodeAdded(ev, tMs);
+
+      case "node_updated":
+        return this.onNodeUpdated(ev, tMs);
+
+      case "node_removed":
+        // No legacy ReplayEvent corresponds to node removal. We'd have to
+        // reconcile on the reducer side (e.g. remove a message). Rare in
+        // the current server emitter — log once and pass through.
+        return emptyOutput();
+
+      case "signal_changed":
+        return this.onSignalChanged(ev, tMs);
+
+      case "stream_chunk":
+        return this.onStreamChunk(ev, tMs);
+
+      case "heartbeat":
+      case "action_emitted":
+        return emptyOutput();
+
+      default:
+        return emptyOutput();
+    }
+  }
+
+  private resetState(): void {
+    this.nousScore = null;
+    this.nousBand = null;
+    this.nousNote = "";
+    this.lastAutonomic = {};
+  }
+
+  // -------------------------------------------------------------------------
+  // Scene-mutating events
+  // -------------------------------------------------------------------------
+
+  private onNodeAdded(
+    ev: Extract<ProsoponEvent, { type: "node_added" }>,
+    tMs: number,
+  ): AdapterOutput {
+    const node = ev.node as SceneNode;
+    const intent = node.intent as { type: string } & Record<string, unknown>;
+    switch (intent.type) {
+      case "section": {
+        // "Reasoning" sections are thinking blocks. The emitter prefixes the
+        // node id with "msg-<original-id>"; we strip it so the reducer's
+        // id-keyed bookkeeping matches the server-side thinking id.
+        if (intent.title === "Reasoning" && node.id.startsWith("msg-")) {
+          return {
+            ...emptyOutput(),
+            replay: [
+              { t: tMs, kind: "agent-thinking-start", id: node.id.slice(4) },
+            ],
+          };
+        }
+        return emptyOutput();
+      }
+      case "stream": {
+        // Text streams — seed an empty agent-text message keyed on the
+        // originating message id (stream id = "stream-<id>").
+        if ((intent as { kind?: string }).kind === "text" && node.id.startsWith("stream-")) {
+          return {
+            ...emptyOutput(),
+            replay: [
+              {
+                t: tMs,
+                kind: "agent-text-start",
+                id: node.id.slice(7),
+                text: "",
+              },
+            ],
+          };
+        }
+        return emptyOutput();
+      }
+      case "tool_call": {
+        // Tool call node id is "tool-<callId>". Recover the raw callId so
+        // the matching tool-result ReplayEvent targets the same bucket.
+        const callId = node.id.startsWith("tool-") ? node.id.slice(5) : node.id;
+        const name = (intent as { name?: string }).name ?? "unknown";
+        const [bare, target = ""] = name.includes(":") ? name.split(":", 2) : [name];
+        const args = (intent as { args?: unknown }).args ?? {};
+        return {
+          ...emptyOutput(),
+          replay: [
+            {
+              t: tMs,
+              kind: "tool-call",
+              id: callId,
+              name: bare ?? name,
+              target,
+              args: typeof args === "string" ? args : JSON.stringify(args),
+              journalKind: inferJournalKind(bare ?? name),
+            },
+          ],
+        };
+      }
+      case "custom": {
+        // Only `fs.op` today — the workspace / filesystem view.
+        if ((intent as { kind?: string }).kind !== "fs.op") return emptyOutput();
+        const payload = ((intent as { payload?: unknown }).payload ?? {}) as Record<
+          string,
+          unknown
+        >;
+        const path = typeof payload.path === "string" ? payload.path : "";
+        const op = typeof payload.op === "string" ? payload.op : "write";
+        return {
+          ...emptyOutput(),
+          replay: [
+            {
+              t: tMs,
+              kind: "fs-op",
+              path,
+              op: (op as "read" | "write" | "create" | "delete") ?? "write",
+              content: typeof payload.content === "string" ? payload.content : undefined,
+              title: typeof payload.title === "string" ? payload.title : undefined,
+              bytes: typeof payload.bytes === "number" ? payload.bytes : undefined,
+            },
+          ],
+        };
+      }
+      case "confirm":
+        // Error surfaces — non-fatal for the replay stream. Hook tracks
+        // failures via its status field.
+        return emptyOutput();
+      default:
+        return emptyOutput();
+    }
+  }
+
+  private onNodeUpdated(
+    ev: Extract<ProsoponEvent, { type: "node_updated" }>,
+    tMs: number,
+  ): AdapterOutput {
+    const patch = ev.patch as Record<string, unknown>;
+    const id = ev.id;
+
+    // msg-<id> being updated with lifecycle resolved → thinking_end.
+    if (id.startsWith("msg-")) {
+      const origId = id.slice(4);
+      const attrs = patch.attrs as Record<string, unknown> | undefined;
+      const lifecycle = patch.lifecycle as { status?: { kind?: string } } | undefined;
+      const events: ReplayEvent[] = [];
+      if (attrs && typeof attrs.thinking === "string") {
+        events.push({ t: tMs, kind: "thinking", id: origId, text: attrs.thinking });
+      }
+      if (lifecycle?.status?.kind === "resolved") {
+        events.push({ t: tMs, kind: "agent-thinking-end", id: origId });
+      }
+      return { ...emptyOutput(), replay: events };
+    }
+
+    // tool-<callId> becoming ToolResult → tool-result event.
+    if (id.startsWith("tool-")) {
+      const callId = id.slice(5);
+      const newIntent = patch.intent as
+        | { type?: string; payload?: Record<string, unknown> }
+        | undefined;
+      if (newIntent?.type === "tool_result") {
+        const text =
+          typeof newIntent.payload?.text === "string"
+            ? newIntent.payload.text
+            : JSON.stringify(newIntent.payload ?? {});
+        return {
+          ...emptyOutput(),
+          replay: [
+            { t: tMs, kind: "tool-result", id: callId, result: text },
+          ],
+        };
+      }
+    }
+
+    return emptyOutput();
+  }
+
+  // -------------------------------------------------------------------------
+  // Streaming
+  // -------------------------------------------------------------------------
+
+  private onStreamChunk(
+    ev: Extract<ProsoponEvent, { type: "stream_chunk" }>,
+    tMs: number,
+  ): AdapterOutput {
+    // Map stream-<id> → append to message id <id>.
+    const streamId = (ev as unknown as { id: string }).id;
+    const chunk = (ev as unknown as {
+      chunk: { payload?: { text?: string }; final_?: boolean };
+    }).chunk;
+    const msgId = streamId.startsWith("stream-") ? streamId.slice(7) : streamId;
+    const text = chunk?.payload?.text ?? "";
+    if (!text) return emptyOutput();
+    return {
+      ...emptyOutput(),
+      replay: [{ t: tMs, kind: "agent-text-append", id: msgId, text }],
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Signals
+  // -------------------------------------------------------------------------
+
+  private onSignalChanged(
+    ev: Extract<ProsoponEvent, { type: "signal_changed" }>,
+    tMs: number,
+  ): AdapterOutput {
+    const topic = (ev as unknown as { topic: string }).topic;
+    const value = unwrapScalar((ev as unknown as { value: SignalValue }).value);
+
+    // Haima / vigil / meta signals flow to the meta channel, not replay.
+    switch (topic) {
+      case TOPICS.HAIMA_SPEND:
+        return {
+          ...emptyOutput(),
+          meta: typeof value === "number" ? [{ kind: "cost-total", value }] : [],
+        };
+      case TOPICS.HAIMA_LAST_TURN:
+        return {
+          ...emptyOutput(),
+          meta: typeof value === "number" ? [{ kind: "cost-turn", value }] : [],
+        };
+      case TOPICS.VIGIL_TOKENS_IN:
+        return {
+          ...emptyOutput(),
+          meta: typeof value === "number" ? [{ kind: "tokens-in", value }] : [],
+        };
+      case TOPICS.VIGIL_TOKENS_OUT:
+        return {
+          ...emptyOutput(),
+          meta: typeof value === "number" ? [{ kind: "tokens-out", value }] : [],
+        };
+      case TOPICS.VIGIL_DURATION_MS:
+        return {
+          ...emptyOutput(),
+          meta: typeof value === "number" ? [{ kind: "duration-ms", value }] : [],
+        };
+      case TOPICS.HAIMA_PAYMENT_MODE:
+        return {
+          ...emptyOutput(),
+          meta: typeof value === "string" ? [{ kind: "payment-mode", value }] : [],
+        };
+      case TOPICS.LIFE_PROJECT_SLUG:
+        return emptyOutput();
+    }
+
+    // Nous: buffer across three topics, emit once we have enough signal.
+    if (topic === TOPICS.NOUS_COMPOSITE && typeof value === "number") {
+      this.nousScore = value;
+      return this.tryEmitNous(tMs);
+    }
+    if (topic === TOPICS.NOUS_BAND && typeof value === "string") {
+      if (value === "good" || value === "warn") this.nousBand = value;
+      return this.tryEmitNous(tMs);
+    }
+    if (topic === TOPICS.NOUS_NOTE && typeof value === "string") {
+      this.nousNote = value;
+      return this.tryEmitNous(tMs);
+    }
+
+    // Autonomic per-pillar notes: append only on change.
+    if (topic.startsWith(AUTONOMIC_PREFIX) && topic.endsWith(".note") && typeof value === "string") {
+      const pillar = topic.slice(AUTONOMIC_PREFIX.length, -".note".length);
+      if (!isPillar(pillar)) return emptyOutput();
+      if (this.lastAutonomic[pillar] === value) return emptyOutput();
+      this.lastAutonomic[pillar] = value;
+      return {
+        ...emptyOutput(),
+        replay: [{ t: tMs, kind: "autonomic-event", pillar, text: value }],
+      };
+    }
+
+    return emptyOutput();
+  }
+
+  /**
+   * Emit a `nous-score` ReplayEvent once we have at least score+band. The
+   * note is optional (it may arrive shortly after the pair — on the next
+   * emit cycle it will replace the existing state.nous through the reducer).
+   */
+  private tryEmitNous(tMs: number): AdapterOutput {
+    if (this.nousScore === null || this.nousBand === null) return emptyOutput();
+    return {
+      ...emptyOutput(),
+      replay: [
+        {
+          t: tMs,
+          kind: "nous-score",
+          score: this.nousScore,
+          band: this.nousBand,
+          note: this.nousNote,
+        },
+      ],
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror of the journal-kind classifier that the legacy server endpoint used
+ * — keeps Journal column colours consistent when the same tool set shows up
+ * through the Prosopon wire.
+ */
+function inferJournalKind(name: string): JournalKind {
+  const lc = name.toLowerCase();
+  if (lc.startsWith("fs.") || lc.startsWith("fs_") || lc.startsWith("read_file")) return "fs";
+  if (lc.includes("judge") || lc.includes("nous")) return "nous";
+  if (lc.startsWith("autonomic")) return "autonomic";
+  if (lc.startsWith("haima") || lc.includes("payment")) return "haima";
+  if (lc.startsWith("llm") || lc.includes("chat.complete")) return "llm";
+  return "tool";
+}

--- a/apps/chat/app/(site)/life/_lib/use-prosopon-run.ts
+++ b/apps/chat/app/(site)/life/_lib/use-prosopon-run.ts
@@ -1,0 +1,381 @@
+// Prosopon-native live-run hook. Drop-in replacement for `useLiveRun` —
+// same public shape so LifeShell consumes it identically. Internally it:
+//
+//   1. POSTs to `/api/life/run/<slug>/prosopon` (the envelope endpoint).
+//   2. Parses each SSE `data:` frame as `Envelope<ProsoponEvent>`.
+//   3. Feeds the envelope through `EnvelopeAdapter`, which yields a
+//      zero-or-more ReplayEvent stream + meta-channel updates.
+//   4. Folds the replay events through `applyReplayEvent` — the same
+//      reducer the local scenario clock uses — so every pane keeps
+//      working unchanged.
+//
+// The net effect: broomva.tech/life/<slug> now speaks Prosopon end-to-end
+// on the wire, but the UI reducer / panes are untouched. Rewriting the
+// panes as Scene selectors is deferred to PR C.2 + the Intent::FileWrite
+// RFC. This PR is strictly about the wire swap.
+//
+// Why an adapter instead of rewriting panes immediately?
+//   - Ships the wire migration today without touching 15 pane components.
+//   - Lets us decommission the legacy /api/life/run/<slug> endpoint in
+//     the follow-up PR D with high confidence (fewer moving parts).
+//   - Provides a natural home for future wire-format evolution — when
+//     Intent::FileWrite lands as a first-class IR node, the adapter
+//     grows one more branch, not the panes.
+
+"use client";
+
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Envelope } from "@broomva/prosopon";
+import type { ReplayEvent, ReplayState } from "./types";
+import { EMPTY_REPLAY_STATE, applyReplayEvent } from "./use-replay";
+import { EnvelopeAdapter, type AdapterMetaEvent } from "./envelope-adapter";
+
+// ---------------------------------------------------------------------------
+// Public surface — identical to `useLiveRun` so the hook is a drop-in.
+// ---------------------------------------------------------------------------
+
+export interface PaymentQuote {
+  amount: number;
+  currency: "USD";
+  railsAccepted: Array<"usdc-base" | "bre-b" | "stripe">;
+  nonce: string;
+}
+
+export type ProsoponRunStatus =
+  | "idle"
+  | "streaming"
+  | "succeeded"
+  | "failed"
+  | "payment-required";
+
+export interface ProsoponRunMeta {
+  status: ProsoponRunStatus;
+  error?: string;
+  sessionId?: string;
+  runId?: string;
+  model?: string;
+  paymentMode?: string;
+  totalCostCents: number;
+  lastTurnCostCents: number;
+  tokensIn?: number;
+  tokensOut?: number;
+  durationMs?: number;
+  paymentQuote?: PaymentQuote;
+  projectSlug?: string;
+  dismiss?: () => void;
+  retryWithPayment?: (header: string | null) => void;
+  sendMessage?: (text: string) => void;
+}
+
+export type ProsoponRunHookResult = [
+  ReplayState,
+  Dispatch<SetStateAction<ReplayState>>,
+  ProsoponRunMeta,
+];
+
+export interface UseProsoponRunOptions {
+  /** URL slug of the project to run. */
+  projectSlug: string;
+  /** Master toggle — turn the hook on/off. */
+  enabled: boolean;
+  /**
+   * True ⇒ automatically POST a first envelope stream on mount (demo mode).
+   * The Prosopon endpoint rejects auto-start today (requires a `message`)
+   * so this is only honoured when there's a valid user message pending.
+   */
+  autoStart?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useProsoponRun({
+  projectSlug,
+  enabled,
+  autoStart = false,
+}: UseProsoponRunOptions): ProsoponRunHookResult {
+  const [state, setState] = useState<ReplayState>(EMPTY_REPLAY_STATE);
+  const [status, setStatus] = useState<ProsoponRunStatus>("idle");
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [paymentQuote, setPaymentQuote] = useState<PaymentQuote | undefined>(
+    undefined,
+  );
+  const [paymentHeader, setPaymentHeader] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | undefined>(undefined);
+  const [runId, setRunId] = useState<string | undefined>(undefined);
+  const [paymentMode, setPaymentMode] = useState<string | undefined>(undefined);
+  const [totalCostCents, setTotalCostCents] = useState(0);
+  const [lastTurnCostCents, setLastTurnCostCents] = useState(0);
+  const [tokensIn, setTokensIn] = useState<number | undefined>(undefined);
+  const [tokensOut, setTokensOut] = useState<number | undefined>(undefined);
+  const [durationMs, setDurationMs] = useState<number | undefined>(undefined);
+
+  const [pendingMessage, setPendingMessage] = useState<string | undefined>(
+    undefined,
+  );
+  const [turnCounter, setTurnCounter] = useState(0);
+  const hasAutoStartedRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const startTsRef = useRef<number>(0);
+
+  // New EnvelopeAdapter per turn — it's stateful (nous buffer, autonomic
+  // diff tracking), and we want each turn to be a fresh scene reset.
+  const adapterRef = useRef<EnvelopeAdapter>(new EnvelopeAdapter());
+
+  useEffect(() => {
+    if (!enabled) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+      return;
+    }
+    if (typeof window === "undefined") return;
+
+    const sendingMessage = pendingMessage;
+    const isAutoStart =
+      !sendingMessage && autoStart && !hasAutoStartedRef.current;
+    // Prosopon endpoint requires a user message — no auto-start without one.
+    if (!sendingMessage && !isAutoStart) return;
+    if (isAutoStart && !sendingMessage) return;
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    if (sendingMessage) {
+      setState((prev) => ({ ...prev, t: 0 }));
+    } else {
+      setState(EMPTY_REPLAY_STATE);
+    }
+    setStatus("streaming");
+    setError(undefined);
+    setPaymentQuote(undefined);
+    setLastTurnCostCents(0);
+    startTsRef.current = performance.now();
+    if (isAutoStart) hasAutoStartedRef.current = true;
+    if (sendingMessage) setPendingMessage(undefined);
+    adapterRef.current = new EnvelopeAdapter();
+
+    (async () => {
+      try {
+        const reqHeaders: Record<string, string> = {
+          "Content-Type": "application/json",
+        };
+        if (paymentHeader) reqHeaders["X-PAYMENT"] = paymentHeader;
+
+        const reqBody: {
+          input: null;
+          sessionId?: string;
+          message?: string;
+        } = { input: null };
+        if (sessionId) reqBody.sessionId = sessionId;
+        if (sendingMessage) reqBody.message = sendingMessage;
+
+        const resp = await fetch(
+          `/api/life/run/${projectSlug}/prosopon`,
+          {
+            method: "POST",
+            signal: controller.signal,
+            headers: reqHeaders,
+            body: JSON.stringify(reqBody),
+          },
+        );
+
+        if (resp.status === 402) {
+          const body = await resp.json().catch(() => ({ quote: undefined }));
+          setStatus("payment-required");
+          if (body.quote) setPaymentQuote(body.quote as PaymentQuote);
+          return;
+        }
+
+        if (!resp.ok || !resp.body) {
+          const bodyText = await resp.text().catch(() => "");
+          setStatus("failed");
+          setError(`HTTP ${resp.status}: ${bodyText.slice(0, 200)}`);
+          return;
+        }
+
+        // Inject the synthetic user message — server-side Prosopon stream
+        // never emits one because it's already known from the request body.
+        if (sendingMessage) {
+          const elapsed = performance.now() - startTsRef.current;
+          const userEv: ReplayEvent = {
+            t: elapsed,
+            kind: "user",
+            text: sendingMessage,
+          };
+          setState((prev) => applyReplayEvent({ ...prev, t: elapsed }, userEv));
+        }
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const frames = buf.split("\n\n");
+          buf = frames.pop() ?? "";
+          for (const frame of frames) {
+            const envelope = parseSseFrame(frame);
+            if (!envelope) continue;
+            const elapsed = performance.now() - startTsRef.current;
+            handleEnvelope(envelope, elapsed);
+          }
+        }
+
+        // Trailing buffer — flush any final frame.
+        if (buf.trim().length) {
+          const envelope = parseSseFrame(buf);
+          if (envelope) {
+            const elapsed = performance.now() - startTsRef.current;
+            handleEnvelope(envelope, elapsed);
+          }
+        }
+
+        setStatus((s) => (s === "streaming" ? "succeeded" : s));
+      } catch (err) {
+        if ((err as { name?: string })?.name === "AbortError") return;
+        setStatus("failed");
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+
+    /**
+     * Drain one envelope into hook state. Keeps the async reader loop
+     * small — any state wiring lives here for readability.
+     */
+    function handleEnvelope(envelope: Envelope, tMs: number): void {
+      // Persist session/run ids off the envelope itself.
+      if (envelope.session_id && envelope.session_id !== sessionId) {
+        setSessionId(envelope.session_id);
+      }
+
+      const out = adapterRef.current.feed(envelope, tMs);
+      if (out.reset) {
+        // scene_reset collapses to "start from empty state". The hook
+        // already zeroed state before the POST, so nothing to do beyond
+        // advancing the clock.
+        setState((prev) => ({ ...prev, t: tMs }));
+      }
+      if (out.replay.length) {
+        setState((prev) => {
+          let next = { ...prev, t: tMs };
+          for (const ev of out.replay) {
+            next = applyReplayEvent(next, ev);
+          }
+          return next;
+        });
+      }
+      for (const m of out.meta) applyMeta(m);
+    }
+
+    /** Fold a meta-channel update into the appropriate hook slot. */
+    function applyMeta(m: AdapterMetaEvent): void {
+      switch (m.kind) {
+        case "cost-total":
+          setTotalCostCents(Number(m.value));
+          break;
+        case "cost-turn":
+          setLastTurnCostCents(Number(m.value));
+          break;
+        case "tokens-in":
+          setTokensIn(Number(m.value));
+          break;
+        case "tokens-out":
+          setTokensOut(Number(m.value));
+          break;
+        case "duration-ms":
+          setDurationMs(Number(m.value));
+          break;
+        case "payment-mode":
+          setPaymentMode(String(m.value));
+          break;
+      }
+    }
+
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, projectSlug, turnCounter]);
+
+  // Reset conversation-wide state when the project changes.
+  useEffect(() => {
+    setSessionId(undefined);
+    setRunId(undefined);
+    setTotalCostCents(0);
+    setLastTurnCostCents(0);
+    setTokensIn(undefined);
+    setTokensOut(undefined);
+    setDurationMs(undefined);
+    hasAutoStartedRef.current = false;
+    setState(EMPTY_REPLAY_STATE);
+    setStatus("idle");
+    adapterRef.current = new EnvelopeAdapter();
+  }, [projectSlug]);
+
+  const dismiss = useCallback(() => {
+    setPaymentQuote(undefined);
+    setStatus("idle");
+    setPaymentHeader(null);
+  }, []);
+
+  const retryWithPayment = useCallback((header: string | null) => {
+    setPaymentHeader(header);
+    setPaymentQuote(undefined);
+    setStatus("streaming");
+    setTurnCounter((k) => k + 1);
+  }, []);
+
+  const sendMessage = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setPendingMessage(trimmed);
+    setTurnCounter((k) => k + 1);
+  }, []);
+
+  return [
+    state,
+    setState,
+    {
+      status,
+      error,
+      sessionId,
+      runId,
+      model: undefined,
+      paymentMode,
+      totalCostCents,
+      lastTurnCostCents,
+      tokensIn,
+      tokensOut,
+      durationMs,
+      paymentQuote,
+      projectSlug,
+      dismiss,
+      retryWithPayment,
+      sendMessage,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// SSE framing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse one SSE frame (the block separated by a blank line). Returns the
+ * decoded Prosopon envelope or `null` when the frame is a comment, a
+ * heartbeat without payload, or unparseable.
+ */
+function parseSseFrame(frame: string): Envelope | null {
+  const lines = frame.split("\n").filter(Boolean);
+  const dataLines = lines
+    .filter((l) => l.startsWith("data:"))
+    .map((l) => l.slice(5).trimStart());
+  if (dataLines.length === 0) return null;
+  const json = dataLines.join("");
+  try {
+    return JSON.parse(json) as Envelope;
+  } catch {
+    return null;
+  }
+}

--- a/apps/chat/lib/life-runtime/prosopon-emitter.ts
+++ b/apps/chat/lib/life-runtime/prosopon-emitter.ts
@@ -379,6 +379,15 @@ export class ProsoponEmitter {
           } as unknown as Record<string, unknown>,
           ts: nowIso(),
         } as ProsoponEvent);
+        const note = payloadString(event, "note");
+        if (typeof note === "string" && note.length > 0) {
+          yield this.session.emit({
+            type: "signal_changed",
+            topic: "nous.note",
+            value: { Scalar: note } as unknown as Record<string, unknown>,
+            ts: nowIso(),
+          } as ProsoponEvent);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

broomva.tech/life/<slug> now consumes the canonical Prosopon envelope
stream end-to-end. The wire swaps from the legacy `/api/life/run/<slug>`
RunEvent shape to the Prosopon-native `/api/life/run/<slug>/prosopon`
endpoint shipped in [PR #104](https://github.com/broomva/broomva.tech/pull/104).
Panes are unchanged; migration is achieved through a thin `EnvelopeAdapter`
that maps envelope variants back into the existing `ReplayEvent` stream.

**Strategy: adapter, not rewrite.** Rewriting 15 panes as Scene selectors
is deferred to PR C.2 (paired with the `Intent::FileWrite` RFC). This PR
is strictly about the wire swap.

## What changed

**New — `apps/chat/app/(site)/life/_lib/envelope-adapter.ts`**
`EnvelopeAdapter` — stateful inverse of the server-side `ProsoponEmitter`:

- `scene_reset` → reset signal (caller zeros state)
- `node_added` Reasoning Section → `agent-thinking-start`
- `node_added` Stream text → `agent-text-start`
- `node_added` ToolCall → `tool-call` (with journal-kind inference)
- `node_added` Custom{kind:"fs.op"} → `fs-op` (preserves path/content/bytes)
- `node_updated` msg-X + lifecycle.resolved → `agent-thinking-end`
- `node_updated` tool-X → tool_result → `tool-result`
- `stream_chunk` → `agent-text-append`
- `signal_changed` `nous.composite` + `nous.band` + `nous.note` → single paired `nous-score`
- `signal_changed` `autonomic.<pillar>.note` → `autonomic-event` (dedup on change)
- `signal_changed` `haima.*` / `vigil.*` → meta channel (cost, tokens, duration)

**New — `apps/chat/app/(site)/life/_lib/use-prosopon-run.ts`**
Drop-in replacement for `useLiveRun`. Same `[state, setState, meta]`
signature. POSTs to `/api/life/run/<slug>/prosopon`, feeds envelopes
through `EnvelopeAdapter`, folds replay events through the unchanged
`applyReplayEvent` reducer. Adds `tokensIn`, `tokensOut`, `durationMs`
to the meta contract.

**Modified — `apps/chat/app/(site)/life/_components/LifeShell.tsx`**
Single import swap: `useLiveRun` → `useProsoponRun`. All other shell
code (payment banner, composer handoff, pane wiring) is untouched.

**Modified — `apps/chat/lib/life-runtime/prosopon-emitter.ts`**
Server-side: adds `nous.note` signal emission. Previously only
`nous.composite` + `nous.band` crossed the wire, so the Nous pane's
note was lost in the round trip. Now fully preserved.

**New — `apps/chat/app/(site)/life/_lib/envelope-adapter.test.ts`**
10 tests locking the round-trip contract for all 8 Prosopon event
variants. Green.

**Retained — `use-live-run.ts` + `/api/life/run/<slug>` (legacy)**
Intentionally kept intact for 7-day soak. PR D decommissions both
after production signal confirms the Prosopon path is stable.

## Test plan

- [x] `bun run vitest run envelope-adapter.test.ts` — 10/10 green
- [x] `bunx tsc --noEmit` — exit 0 (no type regressions)
- [x] `@broomva/prosopon` — 12/12 green
- [ ] Preview URL: exercise `/life/sentinel` end-to-end — send message, verify chat streams, tool call lands, filesystem pane updates
- [ ] Preview URL: exercise `/life/materiales-intel` — same acceptance
- [ ] Paywall flow: trigger 402, approve, verify retry with X-PAYMENT header works
- [ ] Verify Nous pane renders the note (was lost on PR #104)
- [ ] Vigil pane: tokensIn / tokensOut / durationMs populated from `vigil.*` signals

## Follow-ups (not blocking this PR)

- **PR C.2**: rewrite panes as Scene selectors (`scene.root` + `signals` direct), retire `ReplayState`
- **RFC**: `Intent::FileWrite` + `Intent::FileRead` first-class variants in prosopon-core (bump `IR_SCHEMA_VERSION` 0.1.0 → 0.2.0)
- **PR D**: drop `/api/life/run/<slug>` + `use-live-run.ts` after 7-day soak
- **Move @broomva/prosopon** to `core/prosopon/bindings/typescript/` + npm publish when second consumer appears

Spec: [`docs/superpowers/specs/2026-04-23-life-prosopon-wiring.md`](https://github.com/broomva/workspace/blob/chore/life-modules-scaffold/docs/superpowers/specs/2026-04-23-life-prosopon-wiring.md) in the workspace repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)