### PR TITLE
feat(life): consume RFC-0004 typed filesystem intents end-to-end

### DIFF
--- a/apps/chat/app/(site)/life/_lib/envelope-adapter.test.ts
+++ b/apps/chat/app/(site)/life/_lib/envelope-adapter.test.ts
@@ -186,7 +186,164 @@ describe("EnvelopeAdapter", () => {
     ]);
   });
 
-  it("Custom{kind:fs.op} node → fs-op event with content/path/bytes", () => {
+  it("Intent::FileWrite node → fs-op event (RFC-0004 typed variant)", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "workspace",
+        node: {
+          id: "fs-1",
+          intent: {
+            type: "file_write",
+            path: "notes/audit.md",
+            op: "create",
+            content: "# Audit\n\nfindings go here\n",
+            title: "Audit report",
+            bytes: 26,
+            mime: "text/markdown",
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      125,
+    );
+    expect(out.replay).toEqual([
+      {
+        t: 125,
+        kind: "fs-op",
+        path: "notes/audit.md",
+        op: "create",
+        content: "# Audit\n\nfindings go here\n",
+        title: "Audit report",
+        bytes: 26,
+      },
+    ]);
+  });
+
+  it("Intent::FileWrite with op=append → fs-op op=append", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "workspace",
+        node: {
+          id: "fs-append-1",
+          intent: {
+            type: "file_write",
+            path: "log.txt",
+            op: "append",
+            content: "entry\n",
+            bytes: 6,
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      130,
+    );
+    expect(out.replay[0]).toMatchObject({ op: "append", path: "log.txt" });
+  });
+
+  it("Intent::FileWrite with unknown op falls back to write", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "workspace",
+        node: {
+          id: "fs-weird-1",
+          intent: {
+            type: "file_write",
+            path: "x",
+            op: "patch", // future / unknown
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      140,
+    );
+    // Forward-compat: unknown op narrows to "write" so the pane still renders.
+    expect(out.replay[0]).toMatchObject({ op: "write", path: "x" });
+  });
+
+  it("Intent::FileRead pending → fs-op op=read without content", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "workspace",
+        node: {
+          id: "fs-read-1",
+          intent: {
+            type: "file_read",
+            path: "/workspace/input.md",
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      150,
+    );
+    expect(out.replay).toEqual([
+      {
+        t: 150,
+        kind: "fs-op",
+        path: "/workspace/input.md",
+        op: "read",
+        content: undefined,
+        bytes: undefined,
+      },
+    ]);
+  });
+
+  it("Intent::FileRead resolved → fs-op op=read with content + bytes", () => {
+    const a = new EnvelopeAdapter();
+    const out = a.feed(
+      env({
+        type: "node_added",
+        parent: "workspace",
+        node: {
+          id: "fs-read-2",
+          intent: {
+            type: "file_read",
+            path: "notes/context.md",
+            content: "# Context\n",
+            bytes: 10,
+            mime: "text/markdown",
+          },
+          children: [],
+          bindings: [],
+          actions: [],
+          attrs: {},
+          lifecycle: { created_at: new Date().toISOString() },
+        },
+      }),
+      155,
+    );
+    expect(out.replay[0]).toMatchObject({
+      op: "read",
+      path: "notes/context.md",
+      content: "# Context\n",
+      bytes: 10,
+    });
+  });
+
+  it("Custom{kind:fs.op} node → fs-op event with content/path/bytes (back-compat)", () => {
     const a = new EnvelopeAdapter();
     const out = a.feed(
       env({

--- a/apps/chat/app/(site)/life/_lib/envelope-adapter.ts
+++ b/apps/chat/app/(site)/life/_lib/envelope-adapter.ts
@@ -23,7 +23,7 @@ import type {
   SceneNode,
   SignalValue,
 } from "@broomva/prosopon";
-import type { JournalKind, ReplayEvent } from "./types";
+import type { FsOpKind, JournalKind, ReplayEvent } from "./types";
 
 // ---------------------------------------------------------------------------
 // Wire-level shapes we care about
@@ -223,8 +223,63 @@ export class EnvelopeAdapter {
           ],
         };
       }
+      case "file_read": {
+        // RFC-0004 — typed filesystem read. Maps straight to the existing
+        // `fs-op` ReplayEvent with `op: "read"` so the reducer / panes need
+        // no change (rewriting panes to consume Scene selectors directly is
+        // PR C.2).
+        const raw = intent as Record<string, unknown>;
+        const path = typeof raw.path === "string" ? raw.path : "";
+        const content = raw.content;
+        const bytes = raw.bytes;
+        return {
+          ...emptyOutput(),
+          replay: [
+            {
+              t: tMs,
+              kind: "fs-op",
+              path,
+              op: "read",
+              content: typeof content === "string" ? content : undefined,
+              bytes: typeof bytes === "number" ? bytes : undefined,
+            },
+          ],
+        };
+      }
+      case "file_write": {
+        // RFC-0004 — typed filesystem write. The `op` field narrows to a
+        // FileWriteKind; we pass it straight through to the reducer's fs-op
+        // shape.
+        const raw = intent as Record<string, unknown>;
+        const path = typeof raw.path === "string" ? raw.path : "";
+        const op = raw.op;
+        const content = raw.content;
+        const bytes = raw.bytes;
+        const title = raw.title;
+        const narrowedOp: FsOpKind =
+          op === "create" || op === "append" || op === "delete" || op === "write"
+            ? op
+            : "write";
+        return {
+          ...emptyOutput(),
+          replay: [
+            {
+              t: tMs,
+              kind: "fs-op",
+              path,
+              op: narrowedOp,
+              content: typeof content === "string" ? content : undefined,
+              title: typeof title === "string" ? title : undefined,
+              bytes: typeof bytes === "number" ? bytes : undefined,
+            },
+          ],
+        };
+      }
       case "custom": {
-        // Only `fs.op` today — the workspace / filesystem view.
+        // Back-compat fallback: producers still emitting
+        // `Custom { kind: "fs.op", payload }` before adopting RFC-0004
+        // typed variants continue to work through this branch. New emitters
+        // should use Intent::FileRead / Intent::FileWrite directly.
         if ((intent as { kind?: string }).kind !== "fs.op") return emptyOutput();
         const payload = ((intent as { payload?: unknown }).payload ?? {}) as Record<
           string,

--- a/apps/chat/app/(site)/life/_lib/types.ts
+++ b/apps/chat/app/(site)/life/_lib/types.ts
@@ -34,7 +34,12 @@ export type JournalKind =
   | "autonomic"
   | "haima";
 
-export type FsOpKind = "read" | "write" | "create" | "delete";
+/**
+ * The filesystem ops the reducer + panes model. Aligned with RFC-0004's
+ * `FileWriteKind` plus the read variant (`FileRead`). Adapter narrows the
+ * Prosopon `op` into this shape.
+ */
+export type FsOpKind = "read" | "write" | "create" | "append" | "delete";
 
 /**
  * Replay events feed the `applyReplayEvent` reducer. On the live wire they

--- a/apps/chat/lib/life-runtime/prosopon-emitter.ts
+++ b/apps/chat/lib/life-runtime/prosopon-emitter.ts
@@ -337,27 +337,62 @@ export class ProsoponEmitter {
       }
 
       case "fs_op": {
+        // RFC-0004: emit typed `Intent::FileRead` / `Intent::FileWrite` nodes
+        // instead of `Custom { kind: "fs.op" }`. The EnvelopeAdapter on the
+        // client side branches on the typed variant directly, but also keeps
+        // a Custom-path branch for back-compat with any producer on <0.2.0.
         const path = payloadString(event, "path") ?? "";
-        const op = payloadString(event, "op") ?? "write";
+        const rawOp = payloadString(event, "op") ?? "write";
         const content = payloadString(event, "content") ?? "";
         const title = payloadString(event, "title") ?? "";
         const bytes = payloadNumber(event, "bytes") ?? content.length;
+        const hasContent = content.length > 0;
+
         const id = `fs-${++this.fsNodeCounter}`;
-        const fsNode = freshNode(id, {
-          type: "custom",
-          kind: "fs.op",
-          payload: {
+
+        if (rawOp === "read") {
+          const readNode = freshNode(id, {
+            type: "file_read",
             path,
-            op,
-            content,
-            title,
-            bytes,
-          } as Record<string, unknown>,
+            content: hasContent ? content : undefined,
+            bytes: hasContent ? bytes : undefined,
+          });
+          yield this.session.emit({
+            type: "node_added",
+            parent: WORKSPACE_NODE_ID,
+            node: readNode,
+          });
+          return;
+        }
+
+        // Everything else is a FileWrite — narrow to the FileWriteKind enum.
+        // Unknown op strings fall back to `write` with a warning so the
+        // emitter stays forward-compatible with server-side RunEvent evolution.
+        let writeKind: "create" | "write" | "append" | "delete";
+        switch (rawOp) {
+          case "create":
+          case "write":
+          case "append":
+          case "delete":
+            writeKind = rawOp;
+            break;
+          default:
+            writeKind = "write";
+            break;
+        }
+
+        const writeNode = freshNode(id, {
+          type: "file_write",
+          path,
+          op: writeKind,
+          content: writeKind === "delete" ? undefined : hasContent ? content : undefined,
+          bytes: writeKind === "delete" ? undefined : hasContent ? bytes : undefined,
+          title: title ? title : undefined,
         });
         yield this.session.emit({
           type: "node_added",
           parent: WORKSPACE_NODE_ID,
-          node: fsNode,
+          node: writeNode,
         });
         return;
       }

--- a/packages/prosopon-ts/src/generated/event.json
+++ b/packages/prosopon-ts/src/generated/event.json
@@ -666,6 +666,39 @@
         "spacious"
       ]
     },
+    "FileWriteKind": {
+      "description": "What kind of filesystem write a `FileWrite` intent represents.\n\n`#[non_exhaustive]` so future variants (e.g. `Patch` for diff-based writes) land additively.",
+      "oneOf": [
+        {
+          "description": "New file at `path`. The write MUST fail if the file already exists.",
+          "type": "string",
+          "enum": [
+            "create"
+          ]
+        },
+        {
+          "description": "Overwrite an existing file at `path`. Compositors MAY render as a `mod`/`modified` badge.",
+          "type": "string",
+          "enum": [
+            "write"
+          ]
+        },
+        {
+          "description": "Append content to the end of an existing file.",
+          "type": "string",
+          "enum": [
+            "append"
+          ]
+        },
+        {
+          "description": "Remove the file at `path`. `content` SHOULD be absent.",
+          "type": "string",
+          "enum": [
+            "delete"
+          ]
+        }
+      ]
+    },
     "FormationKind": {
       "description": "A coherent grouping of agents — renders as a cluster, swarm, or quorum.",
       "oneOf": [
@@ -1179,6 +1212,108 @@
           }
         },
         {
+          "description": "A filesystem read. The `content` slot fills in when the read completes.\n\nLifecycle — mirrors the `ToolCall` pattern: - `NodeAdded` with `content: None` when the agent decides to read. Paired lifecycle status `pending`. - `NodeUpdated { patch: { intent: FileRead { content: Some(...) } } }` when the content lands. Lifecycle moves to `resolved`.\n\nFor very large reads the agent MAY pair this with a sibling `Stream` intent and populate `content` only on `StreamChunk { final_: true }`.",
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "bytes": {
+              "description": "Byte count. Compositors may compute from `content.len()` if the emitter doesn't supply it; supplying it authoritatively is preferred for multi-byte encodings.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "content": {
+              "description": "File content once the read completes. Absent while in-flight.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mime": {
+              "description": "MIME type hint — enables syntax highlighting and preview-mode switching. Compositors SHOULD assume `text/plain` when absent.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "description": "Absolute or workspace-relative path. Compositors MAY render it as a clickable target. No scheme is implied; the emitter decides.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "file_read"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A filesystem write. `op` narrows the kind of write (create / write / append / delete); `content` slots in when the write completes.\n\nLifecycle: 1. `NodeAdded` with `content: None` and `op` set. Lifecycle `pending`. 2. `NodeUpdated` patching `content` (and `bytes` if the emitter knows them) when the write resolves. Lifecycle `resolved` on success, `failed` on error.\n\nFor streamed writes, pair with a sibling `Stream` intent and patch `content` on stream completion.",
+          "type": "object",
+          "required": [
+            "op",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "bytes": {
+              "description": "Byte count — authoritative when supplied, else derive from `content.len()`.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "content": {
+              "description": "The full body written. Absent until the write resolves. SHOULD be absent for `FileWriteKind::Delete`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mime": {
+              "description": "MIME type hint, as in `FileRead`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "op": {
+              "description": "The kind of write. Constrained via `FileWriteKind`.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/FileWriteKind"
+                }
+              ]
+            },
+            "path": {
+              "description": "Target path — see `FileRead::path`.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Optional human-readable title the agent chose for this artifact. Useful when `path` is a synthetic workspace path and `title` is the user-facing name the compositor should surface.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "file_write"
+              ]
+            }
+          }
+        },
+        {
           "description": "A container whose `GroupKind` tells the compositor how to lay out children.",
           "type": "object",
           "required": [
@@ -1552,7 +1687,7 @@
         },
         "lifecycle": {
           "default": {
-            "created_at": "2026-04-23T20:28:10.606342Z",
+            "created_at": "2026-04-24T00:29:59.823026Z",
             "priority": "normal",
             "status": {
               "kind": "active"

--- a/packages/prosopon-ts/src/generated/scene.json
+++ b/packages/prosopon-ts/src/generated/scene.json
@@ -354,6 +354,39 @@
         "spacious"
       ]
     },
+    "FileWriteKind": {
+      "description": "What kind of filesystem write a `FileWrite` intent represents.\n\n`#[non_exhaustive]` so future variants (e.g. `Patch` for diff-based writes) land additively.",
+      "oneOf": [
+        {
+          "description": "New file at `path`. The write MUST fail if the file already exists.",
+          "type": "string",
+          "enum": [
+            "create"
+          ]
+        },
+        {
+          "description": "Overwrite an existing file at `path`. Compositors MAY render as a `mod`/`modified` badge.",
+          "type": "string",
+          "enum": [
+            "write"
+          ]
+        },
+        {
+          "description": "Append content to the end of an existing file.",
+          "type": "string",
+          "enum": [
+            "append"
+          ]
+        },
+        {
+          "description": "Remove the file at `path`. `content` SHOULD be absent.",
+          "type": "string",
+          "enum": [
+            "delete"
+          ]
+        }
+      ]
+    },
     "FormationKind": {
       "description": "A coherent grouping of agents — renders as a cluster, swarm, or quorum.",
       "oneOf": [
@@ -867,6 +900,108 @@
           }
         },
         {
+          "description": "A filesystem read. The `content` slot fills in when the read completes.\n\nLifecycle — mirrors the `ToolCall` pattern: - `NodeAdded` with `content: None` when the agent decides to read. Paired lifecycle status `pending`. - `NodeUpdated { patch: { intent: FileRead { content: Some(...) } } }` when the content lands. Lifecycle moves to `resolved`.\n\nFor very large reads the agent MAY pair this with a sibling `Stream` intent and populate `content` only on `StreamChunk { final_: true }`.",
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "bytes": {
+              "description": "Byte count. Compositors may compute from `content.len()` if the emitter doesn't supply it; supplying it authoritatively is preferred for multi-byte encodings.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "content": {
+              "description": "File content once the read completes. Absent while in-flight.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mime": {
+              "description": "MIME type hint — enables syntax highlighting and preview-mode switching. Compositors SHOULD assume `text/plain` when absent.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "description": "Absolute or workspace-relative path. Compositors MAY render it as a clickable target. No scheme is implied; the emitter decides.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "file_read"
+              ]
+            }
+          }
+        },
+        {
+          "description": "A filesystem write. `op` narrows the kind of write (create / write / append / delete); `content` slots in when the write completes.\n\nLifecycle: 1. `NodeAdded` with `content: None` and `op` set. Lifecycle `pending`. 2. `NodeUpdated` patching `content` (and `bytes` if the emitter knows them) when the write resolves. Lifecycle `resolved` on success, `failed` on error.\n\nFor streamed writes, pair with a sibling `Stream` intent and patch `content` on stream completion.",
+          "type": "object",
+          "required": [
+            "op",
+            "path",
+            "type"
+          ],
+          "properties": {
+            "bytes": {
+              "description": "Byte count — authoritative when supplied, else derive from `content.len()`.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "content": {
+              "description": "The full body written. Absent until the write resolves. SHOULD be absent for `FileWriteKind::Delete`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "mime": {
+              "description": "MIME type hint, as in `FileRead`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "op": {
+              "description": "The kind of write. Constrained via `FileWriteKind`.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/FileWriteKind"
+                }
+              ]
+            },
+            "path": {
+              "description": "Target path — see `FileRead::path`.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Optional human-readable title the agent chose for this artifact. Useful when `path` is a synthetic workspace path and `title` is the user-facing name the compositor should surface.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "file_write"
+              ]
+            }
+          }
+        },
+        {
           "description": "A container whose `GroupKind` tells the compositor how to lay out children.",
           "type": "object",
           "required": [
@@ -1240,7 +1375,7 @@
         },
         "lifecycle": {
           "default": {
-            "created_at": "2026-04-23T20:28:10.200826Z",
+            "created_at": "2026-04-24T00:29:59.387121Z",
             "priority": "normal",
             "status": {
               "kind": "active"

--- a/packages/prosopon-ts/src/generated/types.ts
+++ b/packages/prosopon-ts/src/generated/types.ts
@@ -4,7 +4,7 @@
  * Source of truth: core/prosopon/crates/prosopon-core (Rust).
  * Regenerate with `bun run generate` from packages/prosopon-ts/.
  *
- * Generated on: 2026-04-23T20:31:02.253Z
+ * Generated on: 2026-04-24T00:30:22.749Z
  */
 /* eslint-disable */
 /* biome-ignore-all */
@@ -188,6 +188,52 @@ export type Intent =
       type: "progress";
     }
   | {
+      /**
+       * Byte count. Compositors may compute from `content.len()` if the emitter doesn't supply it; supplying it authoritatively is preferred for multi-byte encodings.
+       */
+      bytes?: number | null;
+      /**
+       * File content once the read completes. Absent while in-flight.
+       */
+      content?: string | null;
+      /**
+       * MIME type hint — enables syntax highlighting and preview-mode switching. Compositors SHOULD assume `text/plain` when absent.
+       */
+      mime?: string | null;
+      /**
+       * Absolute or workspace-relative path. Compositors MAY render it as a clickable target. No scheme is implied; the emitter decides.
+       */
+      path: string;
+      type: "file_read";
+    }
+  | {
+      /**
+       * Byte count — authoritative when supplied, else derive from `content.len()`.
+       */
+      bytes?: number | null;
+      /**
+       * The full body written. Absent until the write resolves. SHOULD be absent for `FileWriteKind::Delete`.
+       */
+      content?: string | null;
+      /**
+       * MIME type hint, as in `FileRead`.
+       */
+      mime?: string | null;
+      /**
+       * The kind of write. Constrained via `FileWriteKind`.
+       */
+      op: FileWriteKind;
+      /**
+       * Target path — see `FileRead::path`.
+       */
+      path: string;
+      /**
+       * Optional human-readable title the agent chose for this artifact. Useful when `path` is a synthetic workspace path and `title` is the user-facing name the compositor should surface.
+       */
+      title?: string | null;
+      type: "file_write";
+    }
+  | {
       layout: GroupKind;
       type: "group";
     }
@@ -276,6 +322,12 @@ export type InputKind =
   | {
       kind: "json";
     };
+/**
+ * What kind of filesystem write a `FileWrite` intent represents.
+ *
+ * `#[non_exhaustive]` so future variants (e.g. `Patch` for diff-based writes) land additively.
+ */
+export type FileWriteKind = "create" | "write" | "append" | "delete";
 /**
  * How a `Group` lays out its children.
  */


### PR DESCRIPTION
Migrates \`/life/[project]\` to emit and consume the typed \`Intent::FileRead\` /
\`Intent::FileWrite\` variants added in prosopon@0.2.0 (RFC-0004, prosopon#5).
No UI behavior changes — the adapter still produces the same \`fs-op\`
ReplayEvent stream for panes; the wire is now typed.

## What changed

- **Regenerated TS bindings** — \`packages/prosopon-ts/src/generated/{scene,event,types.ts}\`
  pulled from prosopon's updated \`cargo run -p prosopon-cli -- schema\`.
- **Emitter** (\`apps/chat/lib/life-runtime/prosopon-emitter.ts\`) —
  \`fs_op\` RunEvent → typed \`Intent::FileRead\` / \`Intent::FileWrite\`
  instead of \`Custom { kind: \"fs.op\" }\`. Write ops narrow to
  \`FileWriteKind\` (create/write/append/delete); unknown ops forward-compat
  to \`write\`.
- **Adapter** (\`apps/chat/app/(site)/life/_lib/envelope-adapter.ts\`) —
  new branches for \`file_read\` and \`file_write\` node_added events.
  The \`custom{kind:\"fs.op\"}\` branch stays as a back-compat fallback.
- **Types** — \`FsOpKind\` extended to include \`\"append\"\` (aligned with
  \`FileWriteKind\` variant set).
- **Tests** — 5 new adapter test cases covering FileWrite (all kinds),
  FileRead (pending + resolved), unknown-op forward-compat. 15 total, all green.

## Verification

- \`bun run vitest run envelope-adapter.test.ts\` → **15/15 green** ✓
- \`bun test\` in \`packages/prosopon-ts\` → **12/12 green** ✓
- \`bunx tsc --noEmit\` → clean ✓
- \`bunx biome lint \"app/(site)/life\"\` → 0 errors ✓

## Compatibility

Zero-downtime cutover. The new emitter produces typed intents; the adapter
consumes BOTH typed AND legacy \`custom\` forms. Any producer on prosopon
<0.2.0 keeps working until we retire the back-compat branch (planned for
PR C.2 after a soak period).

## Stack

- [x] RFC-0004 — prosopon#4 (draft)
- [x] Implementation PR — prosopon#5 (merged)
- [x] **This PR** — broomva.tech emitter + adapter migration

## Follow-up (PR C.2, separate)

- Rewrite panes as Scene selectors (read \`scene.root\` + \`signals\` directly)
- \`PreviewPane\` reads \`FileWrite.content\` from the intent
- Retire legacy \`Custom{kind:\"fs.op\"}\` back-compat branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)