### PR TITLE
fix(life): mobile topbar "life" text collides with Anima badge

### DIFF
--- a/apps/chat/app/(site)/life/_components/Topbar.tsx
+++ b/apps/chat/app/(site)/life/_components/Topbar.tsx
@@ -40,7 +40,12 @@ export function Topbar({
         <div className="topbar__crumb">
           <strong>{crumb.brand}</strong>
           <span className="sep">/</span>
-          life
+          {/* Wrap the literal "life" segment in a span so the mobile hide-
+              rule in life-styles.css (`.topbar__crumb > :not(.topbar__crumb-project)`)
+              can actually target it. CSS selectors don't match text nodes,
+              so without this wrapper the word stays visible at <768px and
+              visually collides with the Anima badge. */}
+          <span className="topbar__crumb-fixed">life</span>
           <span className="sep">/</span>
           <span className="topbar__crumb-project">{crumb.project}</span>
         </div>


### PR DESCRIPTION
Found during /gstack QA sweep on production.

## Bug

On mobile (<768px), the literal \`life\` segment of the topbar breadcrumb
stayed visible and visually collided with the Anima badge's pill background.

## Root cause

The CSS hide rule shipped in PR #108:

\`\`\`css
.topbar__crumb strong,
.topbar__crumb .sep,
.topbar__crumb > :not(.topbar__crumb-project) {
  display: none;
}
\`\`\`

The third selector targets non-project child **elements**. CSS selectors
don't match text nodes — and the \`life\` in \`Topbar.tsx\` was a bare text
node, not an element, so it slipped through.

## Fix

Wrap \`life\` in \`<span class=\"topbar__crumb-fixed\">\` so the existing
selector has an element to hide. Zero CSS changes needed — the selector
already catches it.

## Evidence

From \`$B js\` on production at 375x812:

\`\`\`json
{
  \"topbar\":   { \"h\": 52, \"w\": 375 },
  \"badge\":    { \"r\": 88.125, \"w\": 78.125 },
  \"crumb\":    { \"l\": 96.125, \"w\": 238.4375, \"overflow\": false }
}
\`\`\`

Mathematically the elements don't overlap (8px gap). The visual collision
was purely the non-hidden \"life\" text rendering inside the crumb column
over where the badge's pill background bleeds.

## Test plan

- [x] Desktop + tablet unchanged — hide-rule doesn't engage ≥ 768px
- [ ] Preview URL on mobile at 375px: \"life\" hidden, only project name visible
- [x] \`bun run build\` — clean
- [x] \`biome lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a mobile display issue where breadcrumb navigation text was overlapping with other interface elements, causing visual clutter. The breadcrumb now renders correctly with proper spacing and separation, improving layout clarity and user experience on mobile and smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->