### PR TITLE
feat(landing): link to /life live demo from home + project page

### DIFF
--- a/apps/chat/app/(site)/projects/[slug]/page.tsx
+++ b/apps/chat/app/(site)/projects/[slug]/page.tsx
@@ -1,9 +1,19 @@
-import type { Metadata } from "next";
+import type { Metadata, Route } from "next";
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ContentArticle } from "@/components/site/content-article";
 import { PageHero } from "@/components/site/page-hero";
 import { formatDate } from "@/lib/date";
 import { getAllSlugs, getContentBySlug, estimateReadingTime } from "@/lib/content";
+
+/**
+ * A frontmatter link is "internal" when its url is a site-relative path.
+ * Internal links route via Next.js <Link> (SPA nav, no new tab); external
+ * links stay `<a target="_blank" rel="noopener noreferrer">`.
+ */
+function isInternalUrl(url: string): boolean {
+  return url.startsWith("/") && !url.startsWith("//");
+}
 
 export async function generateStaticParams() {
   const slugs = await getAllSlugs("projects");
@@ -56,17 +66,32 @@ export default async function ProjectPage({
 
       {project.links.length ? (
         <div className="mt-6 flex flex-wrap gap-3">
-          {project.links.map((link) => (
-            <a
-              key={link.url}
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-full border border-border px-4 py-2 text-sm transition hover:border-ai-blue/40 hover:text-ai-blue"
-            >
-              {link.label}
-            </a>
-          ))}
+          {project.links.map((link) => {
+            const className =
+              "rounded-full border border-border px-4 py-2 text-sm transition hover:border-ai-blue/40 hover:text-ai-blue";
+            return isInternalUrl(link.url) ? (
+              // Frontmatter link — typed as free-form `string`, so cast to
+              // Next.js's typed Route helper. Runtime value is validated by
+              // isInternalUrl() above.
+              <Link
+                key={link.url}
+                href={link.url as Route}
+                className={className}
+              >
+                {link.label}
+              </Link>
+            ) : (
+              <a
+                key={link.url}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={className}
+              >
+                {link.label}
+              </a>
+            );
+          })}
         </div>
       ) : null}
 

--- a/apps/chat/components/site/landing-sections.tsx
+++ b/apps/chat/components/site/landing-sections.tsx
@@ -100,6 +100,8 @@ const stack = [
     description:
       "Arcan runtime, Lago persistence, Vigil observability, Praxis tool execution, Haima finance, and Spaces networking — unified in one Cargo workspace.",
     href: "/projects/life",
+    demoHref: "/life",
+    demoLabel: "Try the live demo →",
   },
   {
     name: "Autoany",
@@ -514,23 +516,33 @@ function StackSection() {
           <div className="mt-8 grid gap-4 sm:grid-cols-3">
             {stack.map((item, i) => (
               <ScrollReveal key={item.name} delay={i * 0.1} direction="left">
-                <Link
-                  href={item.href as Route}
-                  className="group glass-card block h-full transition hover:border-ai-blue/40"
-                >
-                  <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-ai-blue/50">
-                    {String(i + 1).padStart(2, "0")}
-                  </span>
-                  <p className="mt-2 font-display text-xl text-text-primary transition group-hover:text-ai-blue">
-                    {item.name}
-                  </p>
-                  <p className="mt-1 text-xs uppercase tracking-[0.15em] text-text-muted">
-                    {item.role}
-                  </p>
-                  <p className="mt-3 text-sm leading-relaxed text-text-secondary">
-                    {item.description}
-                  </p>
-                </Link>
+                <div className="flex h-full flex-col gap-2">
+                  <Link
+                    href={item.href as Route}
+                    className="group glass-card block h-full transition hover:border-ai-blue/40"
+                  >
+                    <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-ai-blue/50">
+                      {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <p className="mt-2 font-display text-xl text-text-primary transition group-hover:text-ai-blue">
+                      {item.name}
+                    </p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.15em] text-text-muted">
+                      {item.role}
+                    </p>
+                    <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+                      {item.description}
+                    </p>
+                  </Link>
+                  {item.demoHref && (
+                    <Link
+                      href={item.demoHref as Route}
+                      className="inline-flex items-center gap-1.5 self-start rounded-full border border-ai-blue/25 bg-ai-blue/5 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-ai-blue/80 transition hover:border-ai-blue/60 hover:bg-ai-blue/10 hover:text-ai-blue"
+                    >
+                      {item.demoLabel ?? "Live demo →"}
+                    </Link>
+                  )}
+                </div>
               </ScrollReveal>
             ))}
           </div>

--- a/apps/chat/content/projects/life.mdx
+++ b/apps/chat/content/projects/life.mdx
@@ -10,6 +10,8 @@ tags:
   - agent-os
   - monorepo
 links:
+  - label: Live demo
+    url: /life
   - label: Repository
     url: https://github.com/broomva/life
 audio: /audio/projects/life.mp3


### PR DESCRIPTION
Found during /gstack QA: the \`/life/*\` workspace had no discovery path
from the broomva.tech landing page. The stack card pointed at
\`/projects/life\` (info page), and that page only linked to GitHub — so
users had to know the URL to try the demo.

## Three small changes

1. **Landing stack card** — new secondary \"Try the live demo →\" pill
   below the Life card, linking to \`/life\`. Extended the hardcoded
   \`stack\` array with optional \`demoHref\`/\`demoLabel\` fields. Other
   cards untouched.
2. **\`/projects/[slug]\`** — render internal frontmatter links via
   Next.js \`<Link>\` for SPA nav instead of \`<a target=\"_blank\">\`.
   External URLs unchanged. Small utility \`isInternalUrl()\` added.
3. **\`content/projects/life.mdx\`** — added a \`Live demo → /life\`
   entry to the frontmatter \`links:\` array, so the first pill on
   \`/projects/life\` routes to the demo grid.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bunx biome lint\` — 0 errors, 3 pre-existing warnings

## UX after

| Path | Reaches /life? |
|---|---|
| broomva.tech home → Life stack card | ✅ (secondary pill below card) |
| broomva.tech home → Life card body | Still goes to \`/projects/life\` (detail page) |
| \`/projects/life\` | ✅ First pill under title |
| \`/life\` | ✅ Grid of sentinel / materiales / sentinel-paid |

🤖 Generated with [Claude Code](https://claude.com/claude-code)