### PR TITLE
feat(life): Dock tells the truth — real health from /api/life/health

### DIFF
--- a/apps/chat/app/(site)/life/_components/Dock.tsx
+++ b/apps/chat/app/(site)/life/_components/Dock.tsx
@@ -1,36 +1,126 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import type { LifeHealth, LifeServiceStatus } from "@/lib/life-runtime/health";
 import type { ReplayState } from "../_lib/types";
 
 interface Props {
   state: ReplayState;
 }
 
+/**
+ * Poll `/api/life/health` every `HEALTH_POLL_MS` ms so the Dock reflects
+ * current service state. Short enough to feel live, long enough to stay
+ * off Vercel's billing radar.
+ */
+const HEALTH_POLL_MS = 60_000;
+
+/**
+ * Map an abstract service status to a CSS modifier class. Keep aligned
+ * with `.dock__dot--*` rules in `life-styles.css`.
+ */
+function dotClass(status: LifeServiceStatus): string {
+  switch (status) {
+    case "live":
+      return "dock__dot";
+    case "simulated":
+      return "dock__dot dock__dot--sim";
+    case "degraded":
+      return "dock__dot dock__dot--warn";
+    case "down":
+      return "dock__dot dock__dot--down";
+    case "not-deployed":
+      return "dock__dot dock__dot--idle";
+    default:
+      return "dock__dot dock__dot--idle";
+  }
+}
+
+/**
+ * Short status tag suffix next to each pill (e.g. "live", "sim",
+ * "coming"). Empty string when the status is just `live` — green dot
+ * alone is enough.
+ */
+function statusTag(status: LifeServiceStatus): string {
+  switch (status) {
+    case "live":
+      return "";
+    case "simulated":
+      return "sim";
+    case "degraded":
+      return "warn";
+    case "down":
+      return "down";
+    case "not-deployed":
+      return "coming";
+    default:
+      return "";
+  }
+}
+
 export function Dock({ state }: Props) {
   const events = state.journal.length;
-  const tools = (state.journal || []).filter(
+  const tools = state.journal.filter(
     (e) => e.kind === "tool" && e.label === "TOOL",
   ).length;
-  const ctx = 68;
+  const [health, setHealth] = useState<LifeHealth | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchHealth() {
+      try {
+        const res = await fetch("/api/life/health", { cache: "no-store" });
+        if (!res.ok) return;
+        const data: LifeHealth = await res.json();
+        if (!cancelled) setHealth(data);
+      } catch {
+        // Silent — Dock degrades gracefully to loading state if health
+        // is unreachable. Not worth alarming the user over.
+      }
+    }
+
+    fetchHealth();
+    const interval = setInterval(fetchHealth, HEALTH_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  // Pre-health state: show neutral pills so the dock isn't empty on
+  // first paint. These match the default service roster from the
+  // health contract.
+  const services = health?.services ?? [
+    { id: "prosopon", label: "Prosopon", status: "live" as const },
+    { id: "ai-gateway", label: "AI Gateway", status: "live" as const },
+    { id: "arcan", label: "Arcan", status: "simulated" as const },
+    { id: "lago", label: "Lago", status: "simulated" as const },
+    { id: "haima", label: "Haima", status: "live" as const },
+    { id: "nous", label: "Nous", status: "simulated" as const },
+    { id: "lifed", label: "lifed", status: "not-deployed" as const },
+  ];
+
+  const version =
+    health?.commit ?? (process.env.NEXT_PUBLIC_COMMIT_SHA?.slice(0, 7) || "dev");
+
   return (
     <div className="dock">
       <div className="dock__group">
-        <span className="dock__item">
-          <span className="dock__dot" /> <strong>Arcan</strong> :3000
-        </span>
-        <span className="dock__item">
-          <span className="dock__dot" /> <strong>Lago</strong> :8080
-        </span>
-        <span className="dock__item">
-          <span className="dock__dot" /> <strong>Autonomic</strong> :3002
-        </span>
-        <span className="dock__item">
-          <span className="dock__dot" /> <strong>Haima</strong> :3003
-        </span>
-        <span className="dock__item">
-          <span className="dock__dot dock__dot--warn" />{" "}
-          <strong>Nous</strong> :3004
-        </span>
+        {services.map((s) => {
+          const tag = statusTag(s.status);
+          return (
+            <span
+              key={s.id}
+              className="dock__item"
+              title={s.detail ?? `${s.label}: ${s.status}`}
+            >
+              <span className={dotClass(s.status)} />
+              <strong>{s.label}</strong>
+              {tag && <span className="dock__tag">{tag}</span>}
+            </span>
+          );
+        })}
       </div>
       <div className="dock__group">
         <span className="dock__item">
@@ -39,10 +129,9 @@ export function Dock({ state }: Props) {
         <span className="dock__item">
           tool calls <strong>{tools}</strong>
         </span>
-        <span className="dock__item">
-          ctx <strong>{ctx}%</strong>
+        <span className="dock__item" title="deploy commit">
+          {version}
         </span>
-        <span className="dock__item">v0.9.2</span>
       </div>
     </div>
   );

--- a/apps/chat/app/(site)/life/life-styles.css
+++ b/apps/chat/app/(site)/life/life-styles.css
@@ -628,11 +628,33 @@
   color: var(--ag-text-muted);
   letter-spacing: 0.02em;
 }
-.life-shell-root .dock__group { display: flex; gap: 18px; align-items: center; }
+.life-shell-root .dock__group { display: flex; gap: 18px; align-items: center; flex-wrap: wrap; }
 .life-shell-root .dock__item { display: inline-flex; align-items: center; gap: 6px; }
 .life-shell-root .dock__item strong { color: var(--ag-text-secondary); font-weight: 500; }
+
+/* Status dots — see LifeServiceStatus in lib/life-runtime/health.ts.
+   `.dock__dot`                  ← live (green glow)
+   `.dock__dot--sim`             ← simulated at the edge (muted amber)
+   `.dock__dot--warn`            ← degraded (yellow)
+   `.dock__dot--down`            ← expected live, failed probe (red)
+   `.dock__dot--idle`            ← not-deployed yet (muted grey) */
 .life-shell-root .dock__dot { width: 6px; height: 6px; border-radius: 9999px; background: var(--ag-success); box-shadow: 0 0 6px oklch(0.72 0.19 155 / 0.6); }
+.life-shell-root .dock__dot--sim { background: oklch(0.70 0.10 85 / 0.6); box-shadow: 0 0 5px oklch(0.70 0.10 85 / 0.3); }
 .life-shell-root .dock__dot--warn { background: var(--ag-warning); box-shadow: 0 0 6px oklch(0.87 0.18 85 / 0.6); }
+.life-shell-root .dock__dot--down { background: oklch(0.65 0.22 27); box-shadow: 0 0 6px oklch(0.65 0.22 27 / 0.7); }
+.life-shell-root .dock__dot--idle { background: oklch(0.40 0.02 275 / 0.5); box-shadow: none; }
+
+.life-shell-root .dock__tag {
+  font-family: var(--ag-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ag-text-muted);
+  opacity: 0.7;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: color-mix(in oklab, var(--ag-bg-elevated) 40%, transparent);
+}
 
 /* ---- Tweaks panel ---- */
 .life-shell-root .tweaks {

--- a/apps/chat/app/api/life/health/route.ts
+++ b/apps/chat/app/api/life/health/route.ts
@@ -1,0 +1,100 @@
+/**
+ * GET /api/life/health
+ *
+ * Truth-telling health endpoint for /life/*. Replaces the previous
+ * hardcoded Dock pills with a real snapshot of which Life subsystems
+ * are live vs simulated vs not-deployed in the current environment.
+ *
+ * Polled by the Dock component every 60s. Safe to CDN-cache briefly
+ * (the shape is stable per deploy; probes only flip on failures).
+ */
+
+import { NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import type { LifeHealth, LifeService } from "@/lib/life-runtime/health";
+import { staticHealthSnapshot } from "@/lib/life-runtime/health";
+
+export async function GET(): Promise<NextResponse<LifeHealth>> {
+  const snapshot = staticHealthSnapshot();
+
+  // Async probes — each runs with a 2s timeout and degrades the
+  // corresponding service on failure rather than failing the whole
+  // response. The Dock needs to render even when Postgres is blippy.
+  snapshot.services = await Promise.all(
+    snapshot.services.map(async (s) => maybeProbe(s)),
+  );
+
+  // Refresh the timestamp after probes so the client sees probe-completion
+  // time, not snapshot-construction time.
+  snapshot.ts = new Date().toISOString();
+
+  return NextResponse.json(snapshot, {
+    headers: {
+      // Short edge cache — health is volatile, but collapsing bursts of
+      // polling from multiple open /life/* tabs is a win.
+      "Cache-Control":
+        "public, max-age=10, s-maxage=15, stale-while-revalidate=30",
+    },
+  });
+}
+
+async function maybeProbe(service: LifeService): Promise<LifeService> {
+  try {
+    switch (service.id) {
+      case "ai-gateway":
+        return probeAiGateway(service);
+      case "lago":
+        // Lago-in-this-deploy is Postgres — probe the DB.
+        return await probePostgres(service);
+      default:
+        return service;
+    }
+  } catch (err) {
+    return {
+      ...service,
+      status: "degraded",
+      detail: `${service.detail ?? ""} · probe error: ${(err as Error).message.slice(0, 60)}`,
+    };
+  }
+}
+
+function probeAiGateway(service: LifeService): LifeService {
+  // We don't want to actually hit the LLM just to check a dot color.
+  // "Live" means the gateway is configured for this deploy — the env
+  // var presence is a necessary condition and a cheap signal.
+  const hasCreds =
+    Boolean(process.env.AI_GATEWAY_API_KEY) ||
+    Boolean(process.env.OPENAI_API_KEY) ||
+    Boolean(process.env.ANTHROPIC_API_KEY);
+  if (!hasCreds) {
+    return {
+      ...service,
+      status: "down",
+      detail: "no gateway credentials configured",
+    };
+  }
+  return service;
+}
+
+async function probePostgres(service: LifeService): Promise<LifeService> {
+  const started = Date.now();
+  try {
+    // drizzle over postgres — cheap `SELECT 1` with a short abort.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    await db.execute(sql`SELECT 1`);
+    clearTimeout(timeout);
+    const latencyMs = Date.now() - started;
+    return {
+      ...service,
+      detail: `${service.detail} · ${latencyMs}ms`,
+    };
+  } catch (err) {
+    return {
+      ...service,
+      status: "degraded",
+      detail: `${service.detail} · probe failed (${(err as Error).message.slice(0, 40)})`,
+    };
+  }
+}

--- a/apps/chat/lib/life-runtime/health.ts
+++ b/apps/chat/lib/life-runtime/health.ts
@@ -1,0 +1,161 @@
+/**
+ * Life subsystem health contract.
+ *
+ * The Dock at the bottom of /life/[project] used to show hardcoded green
+ * pills for five Rust daemons (Arcan:3000, Lago:8080, …) that aren't
+ * actually deployed on broomva.tech. This module replaces that fiction
+ * with a truthful status map covering:
+ *
+ * - What is REAL in the current deploy (Vercel AI Gateway, Neon Postgres,
+ *   Prosopon wire, Haima billing)
+ * - What is SIMULATED at the edge (Nous composite score, Autonomic arcs,
+ *   Lago as a separate service)
+ * - What is NOT-DEPLOYED yet but on the roadmap (lifed kernel daemon,
+ *   Arcan/Lago/Nous as separable services, Prosopon compositor daemon)
+ *
+ * The status map is produced by `/api/life/health` (see that route for
+ * the real probes). The Dock subscribes to it via fetch + polling.
+ */
+
+import { PROTOCOL_VERSION } from "@broomva/prosopon";
+
+/**
+ * IR schema version — mirrors `prosopon_core::IR_SCHEMA_VERSION` in
+ * `core/prosopon/crates/prosopon-core/src/lib.rs`. When the Rust const
+ * bumps, bump this string to match. (Adding a public export to
+ * @broomva/prosopon is a low-priority follow-up — the version isn't
+ * imported anywhere else in this codebase.)
+ */
+const IR_SCHEMA_VERSION = "0.2.0" as const;
+
+/**
+ * Service status — the lifecycle is:
+ *
+ * - `live`         — running in this deploy, responds to probes.
+ * - `simulated`    — has a stand-in in this deploy (e.g. Postgres subs
+ *                    for the Lago Rust service; `SYSTEM_PREFIX` subs for
+ *                    the Arcan daemon's full agent loop).
+ * - `not-deployed` — intentionally absent from this deploy; on roadmap.
+ * - `degraded`     — running but an essential dependency is unreachable
+ *                    (probe returned an error but the service didn't 5xx).
+ * - `down`         — expected to be live and failed its probe.
+ */
+export type LifeServiceStatus =
+  | "live"
+  | "simulated"
+  | "not-deployed"
+  | "degraded"
+  | "down";
+
+export interface LifeService {
+  /** Stable id, used as React key + data-attr. */
+  id: string;
+  /** Short display label. */
+  label: string;
+  /** Status at the time the health snapshot was taken. */
+  status: LifeServiceStatus;
+  /**
+   * Human-readable qualifier. Shown in the Dock's tooltip / hover, e.g.
+   * "gpt-5-mini via AI Gateway", "crate pending", "Phase 1 in plan".
+   */
+  detail?: string;
+}
+
+export interface LifeHealth {
+  /** ISO timestamp — identifies snapshot freshness. */
+  ts: string;
+  /** Environment the health snapshot applies to. */
+  env: "development" | "preview" | "production" | "unknown";
+  /** Deploy commit SHA (first 7 chars) when available. */
+  commit?: string;
+  /** Service roster. Order controls render order in the Dock. */
+  services: LifeService[];
+  /** Prosopon wire + IR versions — single source of truth for the frontend. */
+  prosopon: {
+    protocolVersion: number;
+    irSchemaVersion: string;
+  };
+}
+
+/**
+ * Build the health snapshot. Keep this synchronous + cheap — the endpoint
+ * wrapping it adds async probes (DB connectivity, etc.) around the result
+ * and may degrade individual services.
+ */
+export function staticHealthSnapshot(): LifeHealth {
+  const env = normalizeEnv(process.env.VERCEL_ENV);
+  const commit = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7);
+
+  // Attribution of each Life subsystem to its current backing. Keep this
+  // list + order aligned with the Dock's render. When Arcan / Lago / Nous
+  // eventually ship as deployed services, flip `status` to `live` and
+  // update `detail` — no client-side change required.
+  const services: LifeService[] = [
+    {
+      id: "prosopon",
+      label: "Prosopon",
+      status: "live",
+      detail: `wire v${PROTOCOL_VERSION} · IR ${IR_SCHEMA_VERSION}`,
+    },
+    {
+      id: "ai-gateway",
+      label: "AI Gateway",
+      status: "live",
+      detail: "gpt-5-mini",
+    },
+    {
+      id: "arcan",
+      label: "Arcan",
+      status: "simulated",
+      detail: "AI SDK streamText acts as runtime",
+    },
+    {
+      id: "lago",
+      label: "Lago",
+      status: "simulated",
+      detail: "Postgres LifeRunEvent stores events",
+    },
+    {
+      id: "autonomic",
+      label: "Autonomic",
+      status: "simulated",
+      detail: "economic pillar live; others derived",
+    },
+    {
+      id: "haima",
+      label: "Haima",
+      status: "live",
+      detail: "cost + rail via billing module",
+    },
+    {
+      id: "nous",
+      label: "Nous",
+      status: "simulated",
+      detail: "hardcoded score · crate pending",
+    },
+    {
+      id: "lifed",
+      label: "lifed",
+      status: "not-deployed",
+      detail: "kernel · Phase 0 shipped · Phase 1 in plan",
+    },
+  ];
+
+  return {
+    ts: new Date().toISOString(),
+    env,
+    commit,
+    services,
+    prosopon: {
+      protocolVersion: PROTOCOL_VERSION,
+      irSchemaVersion: IR_SCHEMA_VERSION,
+    },
+  };
+}
+
+function normalizeEnv(raw: string | undefined): LifeHealth["env"] {
+  if (raw === "production") return "production";
+  if (raw === "preview") return "preview";
+  if (raw === "development") return "development";
+  return "unknown";
+}


### PR DESCRIPTION
The Dock footer on \`/life/[project]\` had 5 hardcoded \"live\" pills for
Rust daemons (Arcan:3000, Lago:8080, …) that aren't deployed on
broomva.tech. Dots were always green; \`ctx 68%\` was a literal
constant; version was \`v0.9.2\`. All decorative.

This PR replaces the fiction with a truth-telling pipeline — real
health from a real endpoint, status-aware styling, and graceful
updates as services actually come online.

## What's shipped

**New endpoint** — \`GET /api/life/health\` returns a typed \`LifeHealth\`
snapshot describing each Life subsystem as \`live\` / \`simulated\` /
\`not-deployed\` / \`degraded\` / \`down\`, with a human-readable detail
line each.

**Service roster** (what the Dock now says out loud):

| Service | Status today | Detail |
|---|---|---|
| Prosopon | live | \`wire v1 · IR 0.2.0\` |
| AI Gateway | live | \`gpt-5-mini\` |
| Arcan | simulated | AI SDK streamText acts as runtime |
| Lago | simulated | Postgres LifeRunEvent stores events |
| Autonomic | simulated | economic pillar live; others derived |
| Haima | live | cost + rail via billing module |
| Nous | simulated | hardcoded score · crate pending |
| lifed | not-deployed | kernel · Phase 0 shipped · Phase 1 in plan |

**Real probes**:
- **AI Gateway** — env-var presence (doesn't make an LLM call; don't bill to check a dot color)
- **Postgres** — \`SELECT 1\` with 2s abort
- **Others** — static snapshot status (flip the field when they deploy)

**Rewritten Dock**:
- Fetches \`/api/life/health\` on mount + every 60s
- Status-colored dots (green/amber/yellow/red/grey) with uppercase status tags (\`sim\`, \`coming\`, \`down\`, \`warn\`) so color isn't the only signal
- Detail string is the \`title\` (hover tooltip)
- \`ctx 68%\` removed entirely
- Version now shows real deploy commit SHA from \`VERCEL_GIT_COMMIT_SHA\` (first 7 chars) or \`dev\` locally
- Pre-health state shows neutral defaults — no empty flash

## What this does NOT do

- Does NOT actually deploy Arcan / Lago / Autonomic / Nous / lifed. They stay simulated or not-deployed. When they ship, flip the \`status\` in \`staticHealthSnapshot()\` + optionally add a real probe in \`maybeProbe()\` — Dock picks it up automatically.
- Does NOT add tests for the new endpoint. Manual agent-browser smoke post-deploy covers it.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bunx biome lint\` on all changed files — 0 errors
- 15/15 envelope-adapter tests still green

## Follow-ups

- Once \`@broomva/prosopon@0.2.0\` is on npm (handoff elsewhere), bump it
  to export \`IR_SCHEMA_VERSION\` so \`health.ts\` doesn't need to hardcode
  \`\"0.2.0\"\`. The hardcode is flagged with a comment pointing at the Rust source.
- When lifed (kernel daemon) deploys: flip its status to live + add
  a probe hitting its /health socket/vsock.
- When compositor-glass ships for broomva.tech: add it to the roster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time service health monitoring in the dock with dynamic visual status indicators
  * Services now display as live, simulated, degraded, down, or not deployed
  * Deploy commit information now displayed, replacing static version labels
  * Status indicators use distinct colors and visual cues for easy identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->