### PR TITLE
fix(life/health): recognise VERCEL_OIDC_TOKEN as AI Gateway auth

### DIFF
--- a/apps/chat/app/api/life/health/route.ts
+++ b/apps/chat/app/api/life/health/route.ts
@@ -61,9 +61,17 @@ async function maybeProbe(service: LifeService): Promise<LifeService> {
 
 function probeAiGateway(service: LifeService): LifeService {
   // We don't want to actually hit the LLM just to check a dot color.
-  // "Live" means the gateway is configured for this deploy — the env
-  // var presence is a necessary condition and a cheap signal.
+  // "Live" means the gateway is configured for this deploy — any of the
+  // following authentication paths is sufficient:
+  //
+  // - `VERCEL_OIDC_TOKEN` — auto-issued on Vercel deploys, lets the
+  //   AI Gateway identify the caller without a static key. This is how
+  //   the production broomva.tech setup authenticates.
+  // - `AI_GATEWAY_API_KEY` — explicit gateway key (local dev, non-Vercel).
+  // - `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — direct provider keys that
+  //   the AI SDK also accepts when the gateway isn't in the path.
   const hasCreds =
+    Boolean(process.env.VERCEL_OIDC_TOKEN) ||
     Boolean(process.env.AI_GATEWAY_API_KEY) ||
     Boolean(process.env.OPENAI_API_KEY) ||
     Boolean(process.env.ANTHROPIC_API_KEY);


### PR DESCRIPTION
Follow-up to #112. Production reported AI Gateway as `down` because the probe only looked for static API keys. On Vercel the gateway authenticates via `VERCEL_OIDC_TOKEN` — agents stream fine, but the Dock said `down`.

Fix: accept `VERCEL_OIDC_TOKEN` as a valid credential path. Static-key checks remain for local dev + non-Vercel deploys.

Verified production:
```
curl https://broomva.tech/api/life/health | jq '.services[1]'
# before:
{"id":"ai-gateway","status":"down","detail":"no gateway credentials configured"}
```

After merge expected: status → live, detail → `gpt-5-mini`.