### PR TITLE
fix(life/health): probe AI Gateway via provider factory

### DIFF
--- a/apps/chat/app/api/life/health/route.ts
+++ b/apps/chat/app/api/life/health/route.ts
@@ -11,6 +11,7 @@
 
 import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
+import { getActiveGateway } from "@/lib/ai/active-gateway";
 import { db } from "@/lib/db/client";
 import type { LifeHealth, LifeService } from "@/lib/life-runtime/health";
 import { staticHealthSnapshot } from "@/lib/life-runtime/health";
@@ -60,29 +61,24 @@ async function maybeProbe(service: LifeService): Promise<LifeService> {
 }
 
 function probeAiGateway(service: LifeService): LifeService {
-  // We don't want to actually hit the LLM just to check a dot color.
-  // "Live" means the gateway is configured for this deploy — any of the
-  // following authentication paths is sufficient:
-  //
-  // - `VERCEL_OIDC_TOKEN` — auto-issued on Vercel deploys, lets the
-  //   AI Gateway identify the caller without a static key. This is how
-  //   the production broomva.tech setup authenticates.
-  // - `AI_GATEWAY_API_KEY` — explicit gateway key (local dev, non-Vercel).
-  // - `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — direct provider keys that
-  //   the AI SDK also accepts when the gateway isn't in the path.
-  const hasCreds =
-    Boolean(process.env.VERCEL_OIDC_TOKEN) ||
-    Boolean(process.env.AI_GATEWAY_API_KEY) ||
-    Boolean(process.env.OPENAI_API_KEY) ||
-    Boolean(process.env.ANTHROPIC_API_KEY);
-  if (!hasCreds) {
+  // Env-var-presence probing is fragile across gateway types (Vercel OIDC,
+  // static keys, direct providers). Instead, exercise the same provider
+  // factory the real agent runner uses — `getActiveGateway()` is pure
+  // config-resolution (no network call), so successful construction
+  // proves the gateway is wired for this deploy. Throws → misconfigured.
+  try {
+    const gateway = getActiveGateway();
+    return {
+      ...service,
+      detail: `${service.detail} · via ${gateway.type}`,
+    };
+  } catch (err) {
     return {
       ...service,
       status: "down",
-      detail: "no gateway credentials configured",
+      detail: `gateway resolution failed: ${(err as Error).message.slice(0, 60)}`,
     };
   }
-  return service;
 }
 
 async function probePostgres(service: LifeService): Promise<LifeService> {


### PR DESCRIPTION
Follow-up to #112 + #113. Env-var-presence probing kept reporting AI Gateway as `down` on production even after adding VERCEL_OIDC_TOKEN (#113) — because broomva-tech's Vercel project doesn't have OIDC enabled and uses a different auth path. The actual agent runner resolves the gateway via `lib/ai/active-gateway.ts` config (not env-var inspection).

Fix: stop guessing env vars. Call the same `getActiveGateway()` factory the real agent uses. It's pure config-resolution (no network call), so successful construction = wired, exception = misconfigured.

Bonus: the detail string now shows the gateway type (`gpt-5-mini · via vercel`) which is more informative than a generic 'live'.

```
# Before #112:
{"id":"ai-gateway","status":"live"}   // hardcoded lie

# PR #112 (env-var check): 
{"id":"ai-gateway","status":"down","detail":"no gateway credentials configured"}   // false-negative

# PR #113 (+ OIDC):
{"id":"ai-gateway","status":"down","detail":"no gateway credentials configured"}   // still false

# This PR (provider factory):
{"id":"ai-gateway","status":"live","detail":"gpt-5-mini · via vercel"}   // truth
```

`bunx tsc --noEmit` clean.
