### PR TITLE
fix(life/session): agent-kind sessions persistable + rehydratable

### DIFF
--- a/apps/chat/app/api/life/run/[project]/prosopon/route.ts
+++ b/apps/chat/app/api/life/run/[project]/prosopon/route.ts
@@ -203,19 +203,22 @@ async function handlePost(
   }
 
   // Sessions (LifeSession on our side, separate from ProsoponSession id).
+  //
+  // Every live turn gets a LifeSession, including agent-kind callers.
+  // Previously agents skipped the session table, which meant the Prosopon
+  // session id fell through to `run.id` and the /state endpoint couldn't
+  // rehydrate them. The `LifeSession.consumerKind` enum was widened to
+  // accept 'agent' (see schema.ts) so all three kinds can now persist.
   const isLiveTurn = userMessage.length > 0;
-  const sessionConsumerKind: "user" | "anon" =
-    consumer.kind === "user" ? "user" : "anon";
-  const lifeSession =
-    isLiveTurn && consumer.kind !== "agent"
-      ? await getOrCreateSession({
-          projectId: project.id,
-          sessionId: lifeSessionIdHint,
-          consumerKind: sessionConsumerKind,
-          consumerId: consumer.id,
-          organizationId: consumer.organizationId,
-        })
-      : null;
+  const lifeSession = isLiveTurn
+    ? await getOrCreateSession({
+        projectId: project.id,
+        sessionId: lifeSessionIdHint,
+        consumerKind: consumer.kind,
+        consumerId: consumer.id,
+        organizationId: consumer.organizationId,
+      })
+    : null;
   const history = lifeSession ? await getSessionHistory(lifeSession.id) : [];
 
   const rulesVersion = await getCurrentRulesVersion(project);

--- a/apps/chat/app/api/life/run/[project]/session/[sessionId]/state/route.ts
+++ b/apps/chat/app/api/life/run/[project]/session/[sessionId]/state/route.ts
@@ -134,10 +134,24 @@ function notFound(): NextResponse {
  * the consumer-resolution logic in the Prosopon run endpoint so behavior
  * is consistent. Returns false on any ambiguity — callers treat false
  * the same as "session doesn't exist."
+ *
+ * Three origins we must handle:
+ *
+ * - `user` — signed-in principal. Require better-auth session match.
+ * - `anon` — anonymous but cookie-bound. Require matching anon cookie.
+ * - `agent` — x402 / fallback caller. Two sub-cases:
+ *   - `consumerId === "anonymous"` — the auth-less fallback the run
+ *     endpoint uses when no credentials are present. Anyone can
+ *     access it; that matches the sharing model the session was
+ *     created under. Proper owner-binding for no-auth visits needs
+ *     an anon cookie issued on first /life visit (follow-up).
+ *   - otherwise — `consumerId` is a wallet address; require matching
+ *     `x-payment-sender` header. Keeps agent-to-agent sessions scoped.
  */
-async function callerOwnsSession(
-  session: { consumerKind: "user" | "anon"; consumerId: string },
-): Promise<boolean> {
+async function callerOwnsSession(session: {
+  consumerKind: "user" | "anon" | "agent";
+  consumerId: string;
+}): Promise<boolean> {
   const hdrs = await headers();
 
   if (session.consumerKind === "user") {
@@ -145,7 +159,19 @@ async function callerOwnsSession(
     return authed?.user?.id === session.consumerId;
   }
 
-  // consumerKind === "anon" — match on anon cookie id.
-  const anon = await getAnonymousSession();
-  return anon?.id === session.consumerId;
+  if (session.consumerKind === "anon") {
+    const anon = await getAnonymousSession();
+    return anon?.id === session.consumerId;
+  }
+
+  // consumerKind === "agent"
+  if (session.consumerId === "anonymous") {
+    // Fallback anonymous-agent sessions have no owner binding.
+    // Legitimate access is uncontrollable until anon-cookie binding
+    // lands; matching pre-persistence /prosopon semantics (anyone
+    // without creds could hit it then; same now).
+    return true;
+  }
+  const xPaymentSender = hdrs.get("x-payment-sender");
+  return xPaymentSender === session.consumerId;
 }

--- a/apps/chat/lib/db/schema.ts
+++ b/apps/chat/lib/db/schema.ts
@@ -1660,10 +1660,20 @@ export const lifeSession = pgTable(
     projectId: uuid("projectId")
       .notNull()
       .references(() => lifeProject.id, { onDelete: "cascade" }),
-    /** 'user' | 'anon' */
+    /**
+     * 'user' | 'anon' | 'agent'
+     *
+     * Widened from the original ('user' | 'anon') so x402 wallet
+     * callers and the auth-less fallback (both use kind='agent')
+     * can also own LifeSessions and be persisted + rehydrated via
+     * /api/life/run/[project]/session/[id]/state.
+     *
+     * The DB column is plain VARCHAR(16) with no CHECK constraint —
+     * widening the enum is TypeScript-only; no migration required.
+     */
     consumerKind: varchar("consumerKind", {
       length: 16,
-      enum: ["user", "anon"],
+      enum: ["user", "anon", "agent"],
     }).notNull(),
     consumerId: varchar("consumerId", { length: 256 }).notNull(),
     /** Optional org context for authed sessions. */

--- a/apps/chat/lib/life-runtime/queries.ts
+++ b/apps/chat/lib/life-runtime/queries.ts
@@ -80,7 +80,12 @@ export interface CreateRunParams {
 export interface GetOrCreateSessionParams {
   projectId: string;
   sessionId?: string; // if provided, must belong to (consumerKind, consumerId)
-  consumerKind: "user" | "anon";
+  /**
+   * Widened from ('user' | 'anon') to match the LifeSession schema
+   * change so the /prosopon endpoint can persist agent-kind sessions
+   * (both x402 wallets and the auth-less anonymous fallback).
+   */
+  consumerKind: "user" | "anon" | "agent";
   consumerId: string;
   organizationId?: string;
 }
@@ -409,7 +414,8 @@ export async function getSessionSummary(
   session: {
     id: string;
     projectId: string;
-    consumerKind: "user" | "anon";
+    /** 'user' | 'anon' | 'agent' — see LifeSession schema note. */
+    consumerKind: "user" | "anon" | "agent";
     consumerId: string;
     organizationId: string | null;
     createdAt: Date;


### PR DESCRIPTION
Follow-up to #116. Hydration didn't fire for anonymous visitors because agent-kind sessions skipped LifeSession creation, falling back to run.id for the Prosopon session id — which /state couldn't look up.

## Root cause chain

1. Visitor with no auth → `consumer.kind === 'agent'`, `consumerId === 'anonymous'`
2. /prosopon used `consumer.kind !== 'agent'` as the gate for LifeSession creation → skipped
3. prosoponSessionId fell through to `run.id` (one per turn)
4. localStorage mirrored that run id
5. /state lookup by run id → 404
6. Hydration silent no-op → fresh-session on every reload

## Fix (4 tightly-coupled changes)

| File | Change |
|---|---|
| `schema.ts` | Widen `LifeSession.consumerKind` → 'user'\|'anon'\|'agent'. Plain VARCHAR, no CHECK → no migration. |
| `queries.ts` | `GetOrCreateSessionParams` + `getSessionSummary` return accept 'agent'. |
| `prosopon/route.ts` | Always create LifeSession for live turns. |
| `state/route.ts` | Auth check handles all three kinds. Agent/anonymous → passthrough (matches /prosopon no-auth creation). Wallet-bound agents → x-payment-sender match. |

## Supersedes #117

PR #117 had an accidentally mixed commit history from a separate content branch (external branch-switching during this session). This is the clean equivalent off main.

## Verification

- `bunx tsc --noEmit` clean
- 17/17 envelope-adapter tests still green