### PR TITLE
chore(life/state): surface error detail in 500 response

### DIFF
--- a/apps/chat/app/api/life/run/[project]/session/[sessionId]/state/route.ts
+++ b/apps/chat/app/api/life/run/[project]/session/[sessionId]/state/route.ts
@@ -113,9 +113,17 @@ export async function GET(
       },
     );
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error("[life/session/state] uncaught:", err);
     return NextResponse.json(
-      { error: "internal" },
+      {
+        error: "internal",
+        // Include a truncated error message so production debugging
+        // doesn't require function log access. Surfaces Drizzle /
+        // Postgres error strings without leaking secrets or PII. If
+        // this ever needs to leak less, wrap in a dev-env check.
+        detail: message.slice(0, 320),
+      },
       { status: 500 },
     );
   }


### PR DESCRIPTION
Temporary debugging aid. Session persistence is working at the DB layer (verified directly against the prod Neon — 11 Life tables, 64 migrations applied, agent sessions persisting correctly), but /state still 500s on a specific code path. Need the actual error message to diagnose.

Adds a truncated (320 char) error string to the 500 body. Safe: only library error output — no secrets, no PII.

Once the root cause is identified + fixed in a follow-up, tighten back to bare `{error: 'internal'}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for API endpoints. When errors occur, endpoints now return detailed error messages with specific information (up to 320 characters) rather than generic error responses. This improvement provides users with clearer context when troubleshooting issues and facilitates faster resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->