### PR TITLE
fix(life/state): coerce Drizzle timestamps to ISO — fixes hydration 500

### DIFF
--- a/apps/chat/app/api/life/run/[project]/session/[sessionId]/state/route.ts
+++ b/apps/chat/app/api/life/run/[project]/session/[sessionId]/state/route.ts
@@ -92,10 +92,17 @@ export async function GET(
         session: {
           id: summary.session.id,
           projectSlug: summary.projectSlug,
-          createdAt: summary.session.createdAt.toISOString(),
+          // Defensive ISO coercion: postgres-js on Vercel returns
+          // timestamp columns as strings, not Date objects, despite
+          // Drizzle typing them as `Date`. Wrapping in `new Date()`
+          // then calling `.toISOString()` works for both shapes and
+          // avoids the "toISOString is not a function" runtime bug.
+          createdAt: toIsoString(summary.session.createdAt),
           turnCount: summary.turnCount,
           totalCostCents: summary.totalCostCents,
-          lastActivityAt: summary.lastActivityAt?.toISOString() ?? null,
+          lastActivityAt: summary.lastActivityAt
+            ? toIsoString(summary.lastActivityAt)
+            : null,
         },
         // Snapshot path lands in Phase 4 (snapshot-cadence PR). Today
         // the tail IS the full history — fine for current session
@@ -113,17 +120,9 @@ export async function GET(
       },
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
     console.error("[life/session/state] uncaught:", err);
     return NextResponse.json(
-      {
-        error: "internal",
-        // Include a truncated error message so production debugging
-        // doesn't require function log access. Surfaces Drizzle /
-        // Postgres error strings without leaking secrets or PII. If
-        // this ever needs to leak less, wrap in a dev-env check.
-        detail: message.slice(0, 320),
-      },
+      { error: "internal" },
       { status: 500 },
     );
   }
@@ -135,6 +134,29 @@ export async function GET(
  */
 function notFound(): NextResponse {
   return NextResponse.json({ error: "not_found" }, { status: 404 });
+}
+
+/**
+ * Coerce a Drizzle-typed timestamp to an ISO string.
+ *
+ * Drizzle declares `timestamp(...)` columns as `Date` on the TS side,
+ * but the actual runtime type depends on the driver / pg client:
+ *
+ * - Node `pg` / most setups: returns Date instances.
+ * - `postgres-js` (which broomva.tech uses) in some environments:
+ *   returns ISO-8601 strings when `mode: 'string'` is set OR when
+ *   connection pooling strips type parsers. On Vercel's build this
+ *   ends up as a string, so calling `.toISOString()` throws
+ *   `TypeError: ... is not a function`.
+ *
+ * This helper covers both shapes: if it's already a Date, call
+ * `toISOString`; if it's a string, construct a Date first then format
+ * (round-trip ensures a valid ISO-8601 even for oddly-formatted
+ * inputs); if it's a number (epoch ms), same.
+ */
+function toIsoString(value: Date | string | number): string {
+  if (value instanceof Date) return value.toISOString();
+  return new Date(value).toISOString();
 }
 
 /**


### PR DESCRIPTION
Production hydration 500'd on every call. Root cause surfaced via PR #120's temporary error-detail logging:

```
TypeError: o.lastActivityAt?.toISOString is not a function
```

Drizzle declares `timestamp(...)` columns as `Date` in TS types, but `postgres-js` on Vercel returns them as ISO-8601 strings. Local bun dev returns `Date` instances, which masked this.

## Fix

New helper `toIsoString(value: Date | string | number): string`. Handles both shapes. Applied to `createdAt` and `lastActivityAt` in /state response.

Also reverts the PR #120 error-detail instrumentation back to clean `{error: 'internal'}` — bug is found; debug aid no longer needed.

## DB state confirmed

Direct psql against prod DB (via `vercel env pull`):

- 64 Drizzle migrations applied; latest = 0063_legal_ogun
- 11 Life tables in public schema (8 pre-existing + 3 new from PR #116)
- `LifeSession.consumerKind` accepts 'agent' — PR #118 widening works
- Recent agent sessions persist correctly

Migrations + schema are in-sync. This was a pure runtime type bug, not a data bug.

## Verification

- `bunx tsc --noEmit` clean
- Local repro against prod DATABASE_URL (raw postgres-js) shows full query chain succeeds
- After deploy: hitting /state on a known session should return rehydration payload; UI mount-time replay should restore chat