### PR TITLE
chore(tests,lint): make repo cleanly validate green

### DIFF
--- a/apps/chat/app/(site)/life/_lib/autonomy.ts
+++ b/apps/chat/app/(site)/life/_lib/autonomy.ts
@@ -47,7 +47,9 @@ export function readAutonomy(): AutonomyPrefs {
       autoApproveMaxCents: Number(
         parsed.autoApproveMaxCents ?? DEFAULT_AUTONOMY.autoApproveMaxCents,
       ),
-      sessionMaxCents: Number(parsed.sessionMaxCents ?? DEFAULT_AUTONOMY.sessionMaxCents),
+      sessionMaxCents: Number(
+        parsed.sessionMaxCents ?? DEFAULT_AUTONOMY.sessionMaxCents,
+      ),
       sessionSpentCents: Number(
         parsed.sessionSpentCents ?? DEFAULT_AUTONOMY.sessionSpentCents,
       ),
@@ -76,7 +78,8 @@ export function shouldAutoApprove(
 ): boolean {
   if (prefs.mode !== "auto") return false;
   if (quotedCents > prefs.autoApproveMaxCents) return false;
-  if (prefs.sessionSpentCents + quotedCents > prefs.sessionMaxCents) return false;
+  if (prefs.sessionSpentCents + quotedCents > prefs.sessionMaxCents)
+    return false;
   return true;
 }
 

--- a/apps/chat/app/(site)/life/_lib/envelope-adapter.ts
+++ b/apps/chat/app/(site)/life/_lib/envelope-adapter.ts
@@ -105,10 +105,12 @@ export interface AdapterOutput {
   reset: boolean;
 }
 
-const EMPTY: AdapterOutput = { replay: [], meta: [], reset: false };
-
 /**
  * Build an empty `AdapterOutput` (useful for adapter misses).
+ *
+ * Returned as a fresh object each call so callers who spread into it
+ * (`{ ...emptyOutput(), replay: [...] }`) can't accidentally mutate a
+ * shared sentinel.
  */
 function emptyOutput(): AdapterOutput {
   return { replay: [], meta: [], reset: false };

--- a/apps/chat/app/(site)/life/_lib/project-map.ts
+++ b/apps/chat/app/(site)/life/_lib/project-map.ts
@@ -33,7 +33,8 @@ export const PROJECTS: Record<string, LifeProjectInfo> = {
       },
       {
         label: "List 3 signs of follow-up risk",
-        prompt: "List 3 signs of follow-up risk on a closed work order. Be brief.",
+        prompt:
+          "List 3 signs of follow-up risk on a closed work order. Be brief.",
       },
       {
         label: "Draft an audit checklist",

--- a/apps/chat/app/(site)/life/_lib/reducer.ts
+++ b/apps/chat/app/(site)/life/_lib/reducer.ts
@@ -31,9 +31,13 @@ export const EMPTY_REPLAY_STATE: ReplayState = {
 
 function formatTime(ms: number): string {
   const total = Math.floor(ms / 1000);
-  const m = Math.floor(total / 60).toString().padStart(2, "0");
+  const m = Math.floor(total / 60)
+    .toString()
+    .padStart(2, "0");
   const s = (total % 60).toString().padStart(2, "0");
-  const mm = Math.floor((ms % 1000) / 10).toString().padStart(2, "0");
+  const mm = Math.floor((ms % 1000) / 10)
+    .toString()
+    .padStart(2, "0");
   return `${m}:${s}.${mm}`;
 }
 
@@ -127,7 +131,9 @@ export function applyReplayEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
       };
     }
     case "tool-call": {
-      const lastAgent = [...s.messages].reverse().find((m) => m.role === "agent");
+      const lastAgent = [...s.messages]
+        .reverse()
+        .find((m) => m.role === "agent");
       const tool: LifeTool = {
         id: ev.id,
         name: ev.name,
@@ -227,7 +233,10 @@ export function applyReplayEvent(s: ReplayState, ev: ReplayEvent): ReplayState {
       };
       return {
         ...s,
-        autonomic: [...s.autonomic, { t: ev.t, pillar: ev.pillar, text: ev.text }],
+        autonomic: [
+          ...s.autonomic,
+          { t: ev.t, pillar: ev.pillar, text: ev.text },
+        ],
         journal: [...s.journal, journal],
       };
     }

--- a/apps/chat/app/(site)/life/_lib/tweaks.ts
+++ b/apps/chat/app/(site)/life/_lib/tweaks.ts
@@ -11,7 +11,13 @@ export const DEFAULT_TWEAKS: TweaksState = {
   rightMode: "vigil",
 };
 
-const MIDDLE: MiddleMode[] = ["files", "journal", "timeline", "graph", "spaces"];
+const MIDDLE: MiddleMode[] = [
+  "files",
+  "journal",
+  "timeline",
+  "graph",
+  "spaces",
+];
 const RIGHT: RightMode[] = [
   "preview",
   "vigil",

--- a/apps/chat/app/(site)/life/_lib/use-prosopon-run.ts
+++ b/apps/chat/app/(site)/life/_lib/use-prosopon-run.ts
@@ -24,12 +24,12 @@
 
 "use client";
 
+import type { Envelope } from "@broomva/prosopon";
 import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Envelope } from "@broomva/prosopon";
+import { type AdapterMetaEvent, EnvelopeAdapter } from "./envelope-adapter";
+import { applyReplayEvent, EMPTY_REPLAY_STATE } from "./reducer";
 import type { ReplayEvent, ReplayState } from "./types";
-import { EMPTY_REPLAY_STATE, applyReplayEvent } from "./reducer";
-import { EnvelopeAdapter, type AdapterMetaEvent } from "./envelope-adapter";
 
 // ---------------------------------------------------------------------------
 // Public surface — identical to `useLiveRun` so the hook is a drop-in.
@@ -137,6 +137,12 @@ export function useProsoponRun({
   // diff tracking), and we want each turn to be a fresh scene reset.
   const adapterRef = useRef<EnvelopeAdapter>(new EnvelopeAdapter());
 
+  // Intentional trigger-via-counter pattern. The effect MUST only re-fire
+  // on explicit turn submission (`turnCounter` bump) or project change —
+  // NOT on every `pendingMessage` / `autoStart` / `sessionId` prop change,
+  // which would spam requests. Those values are captured by closure at
+  // schedule time and read fresh via the setter when needed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     if (!enabled) {
       abortRef.current?.abort();
@@ -183,15 +189,12 @@ export function useProsoponRun({
         if (sessionId) reqBody.sessionId = sessionId;
         if (sendingMessage) reqBody.message = sendingMessage;
 
-        const resp = await fetch(
-          `/api/life/run/${projectSlug}/prosopon`,
-          {
-            method: "POST",
-            signal: controller.signal,
-            headers: reqHeaders,
-            body: JSON.stringify(reqBody),
-          },
-        );
+        const resp = await fetch(`/api/life/run/${projectSlug}/prosopon`, {
+          method: "POST",
+          signal: controller.signal,
+          headers: reqHeaders,
+          body: JSON.stringify(reqBody),
+        });
 
         if (resp.status === 402) {
           const body = await resp.json().catch(() => ({ quote: undefined }));
@@ -308,10 +311,14 @@ export function useProsoponRun({
     }
 
     return () => controller.abort();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, projectSlug, turnCounter]);
 
-  // Reset conversation-wide state when the project changes.
+  // Intentional "trigger only on projectSlug change" effect. The setters
+  // inside never reference `projectSlug` — it's in the deps solely to
+  // schedule a reset when the user switches projects. Removing it (as
+  // Biome's autofix suggests) would collapse this into an on-mount-only
+  // reset, breaking multi-project navigation.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     setSessionId(undefined);
     setRunId(undefined);

--- a/apps/chat/app/api/life/run/[project]/prosopon/route.ts
+++ b/apps/chat/app/api/life/run/[project]/prosopon/route.ts
@@ -17,10 +17,8 @@
 
 import {
   type Envelope,
-  encode as encodeEnvelope,
   makeEnvelope,
   type ProsoponEvent,
-  ProsoponSession,
 } from "@broomva/prosopon";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
@@ -274,6 +272,16 @@ async function handlePost(
     }
   }
 
+  let finalCostCents = 0;
+  let model: string | undefined;
+  let provider: string | undefined;
+  let assistantTextAccum = "";
+
+  // `onFinish` is threaded via the constructor (not post-construction
+  // assignment) so the runner's `opts` can stay private. It's the terminal
+  // cost-attribution hook — captures LLM cents + model identity so the
+  // downstream `finishRun` / `settleCreditsDebit` calls have the real
+  // numbers rather than a quote.
   const runner = new RealAgentRunner({
     projectSlug: slug,
     moduleTypeId: project.moduleTypeId,
@@ -283,12 +291,12 @@ async function handlePost(
     history,
     userMessage,
     paymentMode: decision.mode,
+    onFinish: (cost) => {
+      finalCostCents = cost.llmCents;
+      model = cost.model;
+      provider = cost.provider;
+    },
   });
-
-  let finalCostCents = 0;
-  let model: string | undefined;
-  let provider: string | undefined;
-  let assistantTextAccum = "";
 
   const emitter = new ProsoponEmitter({
     sessionId: prosoponSessionId,
@@ -326,13 +334,6 @@ async function handlePost(
         await write(
           emitter.userTurnStarted({ text: userMessage, turnId: run.id }),
         );
-
-        // Attach the onFinish hook so we capture llm cost + model.
-        runner["opts"].onFinish = (cost) => {
-          finalCostCents = cost.llmCents;
-          model = cost.model;
-          provider = cost.provider;
-        };
 
         for await (const yielded of runner.run()) {
           // Accumulate the assistant's final text by peeking at AI SDK

--- a/apps/chat/lib/db/migrations/migrations-journal.test.ts
+++ b/apps/chat/lib/db/migrations/migrations-journal.test.ts
@@ -12,8 +12,8 @@
  * 2. Journal idx values are contiguous (no gaps).
  * 3. Every journal entry references an existing .sql file.
  */
-import { readFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -42,12 +42,21 @@ function loadJournal(): Journal {
 /**
  * SQL files that exist on disk but are legitimately not in the journal.
  * These are historical alternative drafts that were superseded by another
- * migration with the same numeric prefix (e.g. 0001_sparkling_blue_marvel
- * replaced 0001_add_refresh_token_table before the journal was committed).
+ * migration that actually creates the same tables (e.g.
+ * `0001_sparkling_blue_marvel` replaced `0001_add_refresh_token_table`
+ * before the journal was committed, and `0056_equal_maginty` contains the
+ * `SandboxInstance` + `SandboxSnapshot` CREATE TABLE statements that were
+ * originally drafted in `0055_add_sandbox_tables`).
+ *
+ * The tables exist in production and are exercised by the app; the draft
+ * SQL file is kept as historical record only and must stay in the
+ * allowlist so the "every file is journaled" invariant continues to catch
+ * genuinely-missing drizzle-generated migrations.
  */
 const KNOWN_ORPHANED_MIGRATIONS = new Set([
   "0001_add_refresh_token_table",
   "0047_cooing_gressill",
+  "0055_add_sandbox_tables",
 ]);
 
 function getSqlFiles(): string[] {

--- a/apps/chat/lib/life-runtime/billing.ts
+++ b/apps/chat/lib/life-runtime/billing.ts
@@ -26,13 +26,9 @@
 
 import "server-only";
 import { randomUUID } from "node:crypto";
-import type { LifeProject } from "@/lib/db/schema";
 import { deductCredits, getCredits } from "@/lib/db/credits";
-import type {
-  BillingDecision,
-  ConsumerIdentity,
-  PaymentMode,
-} from "./types";
+import type { LifeProject } from "@/lib/db/schema";
+import type { BillingDecision, ConsumerIdentity, PaymentMode } from "./types";
 
 /**
  * Pricing config shape (matches projects.pricing JSONB column).
@@ -68,7 +64,8 @@ export function pickPaymentMode(args: {
 }): BillingDecision {
   const { project, consumer, byokKeyId } = args;
   const pricing = (project.pricing as PricingConfig | null) ?? null;
-  const isPaid = pricing && pricing.model !== "free" && pricing.consumerPriceCents > 0;
+  const isPaid =
+    pricing && pricing.model !== "free" && pricing.consumerPriceCents > 0;
 
   // BYOK overrides everything — consumer provides the LLM billing rail.
   if (byokKeyId) {
@@ -76,7 +73,8 @@ export function pickPaymentMode(args: {
       mode: "byok",
       quotedCents: 0,
       maxCostCents: pricing?.maxCostCents ?? DEFAULT_FREE_TIER.maxCostCents,
-      rationale: "BYOK key supplied — LLM cost billed to consumer's own provider.",
+      rationale:
+        "BYOK key supplied — LLM cost billed to consumer's own provider.",
     };
   }
 
@@ -90,7 +88,8 @@ export function pickPaymentMode(args: {
       mode: "credits",
       quotedCents: pricing?.consumerPriceCents ?? 1, // nominal 1c for self-runs
       maxCostCents: pricing?.maxCostCents ?? DEFAULT_FREE_TIER.maxCostCents,
-      rationale: "Project owner running own agent — debited from subscription credits.",
+      rationale:
+        "Project owner running own agent — debited from subscription credits.",
     };
   }
 

--- a/apps/chat/providers/parse-chat-id-from-pathname.test.ts
+++ b/apps/chat/providers/parse-chat-id-from-pathname.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { parseChatIdFromPathname } from "./parse-chat-id-from-pathname";
 
+// The shape of `ParsedChatIdFromPathname` grew `source` + `projectId` fields
+// after these tests were first written; `toEqual` is strict on keys so we
+// update the expected objects to match the current contract. Keeping the
+// per-branch assertions explicit (rather than `toMatchObject`) so a future
+// field addition still trips the test and demands an intentional update.
+
 describe("parseChatIdFromPathname", () => {
   describe("shared routes (/share/:id)", () => {
     it("returns chat for /share/:id", () => {
       expect(parseChatIdFromPathname("/share/abc-123")).toEqual({
         type: "chat",
         id: "abc-123",
+        source: "share",
+        projectId: null,
       });
     });
 
@@ -14,6 +22,8 @@ describe("parseChatIdFromPathname", () => {
       expect(parseChatIdFromPathname("/share/abc-123-def-456")).toEqual({
         type: "chat",
         id: "abc-123-def-456",
+        source: "share",
+        projectId: null,
       });
     });
   });
@@ -23,15 +33,19 @@ describe("parseChatIdFromPathname", () => {
       expect(parseChatIdFromPathname("/project/proj-123")).toEqual({
         type: "provisional",
         id: null,
+        source: "project",
+        projectId: "proj-123",
       });
     });
 
     it("returns chat for /project/:projectId/chat/:chatId", () => {
       expect(
-        parseChatIdFromPathname("/project/proj-123/chat/chat-456")
+        parseChatIdFromPathname("/project/proj-123/chat/chat-456"),
       ).toEqual({
         type: "chat",
         id: "chat-456",
+        source: "project",
+        projectId: "proj-123",
       });
     });
   });
@@ -41,6 +55,8 @@ describe("parseChatIdFromPathname", () => {
       expect(parseChatIdFromPathname("/chat/chat-789")).toEqual({
         type: "chat",
         id: "chat-789",
+        source: "chat",
+        projectId: null,
       });
     });
   });
@@ -50,6 +66,8 @@ describe("parseChatIdFromPathname", () => {
       expect(parseChatIdFromPathname("/")).toEqual({
         type: "provisional",
         id: null,
+        source: "home",
+        projectId: null,
       });
     });
 
@@ -57,6 +75,8 @@ describe("parseChatIdFromPathname", () => {
       expect(parseChatIdFromPathname(null)).toEqual({
         type: "provisional",
         id: null,
+        source: "home",
+        projectId: null,
       });
     });
 
@@ -64,6 +84,8 @@ describe("parseChatIdFromPathname", () => {
       expect(parseChatIdFromPathname("/settings")).toEqual({
         type: "provisional",
         id: null,
+        source: "home",
+        projectId: null,
       });
     });
   });

--- a/apps/chat/vitest.config.ts
+++ b/apps/chat/vitest.config.ts
@@ -1,11 +1,21 @@
-import { defineConfig } from "vitest/config";
 import path from "node:path";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     environment: "node",
     include: ["**/*.test.ts", "**/*.test.tsx"],
-    exclude: ["node_modules", ".next", "tests/**"],
+    // `.arcan/` contains sibling skill test suites (gstack, skill-llm-eval,
+    // etc.) that have their own test runners and node_modules; they must
+    // not be scanned by the chat app's vitest. Same for `playwright-report/`
+    // and other test-adjacent generated directories.
+    exclude: [
+      "node_modules",
+      ".next",
+      ".arcan/**",
+      "tests/**",
+      "playwright-report/**",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Clears pre-existing test + lint issues so the repo validates cleanly. No behavior change.

**Before:** `bun run test:unit` → 9 real failures + scope-leak noise; biome touched-file warnings from earlier PRs. **After:** 129/129 tests green, 0 tsc errors, 0 biome warnings on touched files.

## Fixes

### Tests (9 → 0 failures)

| Test | Root cause | Fix |
|---|---|---|
| `parse-chat-id-from-pathname.test.ts` (8 fails) | Function grew `source` + `projectId` fields; `toEqual` assertions outdated | Update expected objects to current shape |
| `migrations-journal.test.ts` (1 fail) | `0055_add_sandbox_tables.sql` is a draft superseded by `0056_equal_maginty.sql` | Add to `KNOWN_ORPHANED_MIGRATIONS` allowlist (same pattern as `0001_add_refresh_token_table`, `0047_cooing_gressill`) |
| `vitest.config.ts` scope leak | `.arcan/` (gstack skill tests) + `playwright-report/` were being scanned | Add both to exclude list |

### Lint (scoped to life-runtime + route + life/_lib)

- **`route.ts`**: removed unused `encode as encodeEnvelope` import; replaced `runner["opts"].onFinish = …` post-construction escape hatch with constructor-time option (fixes `useLiteralKeys` + architecturally cleaner)
- **`envelope-adapter.ts`**: removed unused `EMPTY` sentinel; `emptyOutput()` is the only helper callers use
- **`use-prosopon-run.ts`**: replaced non-functional `eslint-disable-next-line` comments with proper `biome-ignore` directives + explicit rationale for trigger-via-counter and trigger-on-project-change patterns
- Biome organize-imports + format touched `autonomy.ts`, `project-map.ts`, `reducer.ts`, `tweaks.ts`, `billing.ts` as a side effect (pure formatting)

## Scope discipline

Only files already in the life-runtime / route / life/_lib zone — not codebase-wide. The repo has ~500 pending biome format warnings elsewhere; deliberately NOT touched to avoid a cosmetic mega-diff conflicting with in-flight work. Those can be a separate, explicit \"format the world\" PR if/when that's wanted.

## Note on TS errors

Earlier PRs flagged `@/.next/types/routes` import errors as \"pre-existing.\" They turned out to be a **local tooling artifact**: running `bunx tsc --noEmit` directly skips `next typegen`. CI uses `bun run test:types` which runs typegen first; that was always green. No fix needed.

## Validation

- [x] `bun run test:unit` → 11 files, **129/129 tests green**
- [x] `bun run test:types` → **0 errors** (CI command)
- [x] `bunx biome check` on all touched files → **0 warnings**

## Test plan

- [ ] CI `validate` job green
- [ ] Preview deploys cleanly (no functional change so no UI to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)