### PR TITLE
fix(content): point arcan project to arcan.la (was wrongly arcanai.app)

### DIFF
--- a/apps/chat/content/projects/arcan.mdx
+++ b/apps/chat/content/projects/arcan.mdx
@@ -12,7 +12,7 @@ links:
   - label: Repository
     url: https://github.com/broomva/arcan
   - label: Live site
-    url: https://arcanai.app
+    url: https://arcan.la
 audio: /audio/projects/arcan.mp3
 ---
 
@@ -24,7 +24,7 @@ Teams want agent help for real workflows, not isolated prompts. The hard part is
 
 ## Approach
 
-Arcan is a Next.js product (live at [arcanai.app](https://arcanai.app)) that focuses on explicit workflow structure:
+Arcan is a Next.js product (live at [arcan.la](https://arcan.la)) that focuses on explicit workflow structure:
 
 - clear task boundaries with typed inputs and outputs
 - tool-first execution paths where agents use defined tools, not freeform generation


### PR DESCRIPTION
## Summary

The "Live site" link on `/projects/arcan` was sending visitors to **arcanai.app**, which isn't ours. Correct domain is **arcan.la**.

Updates two occurrences in `apps/chat/content/projects/arcan.mdx`:
- Frontmatter `links[].url` (the "Live site" button)
- Inline body reference

## Test plan

- [x] `bun run check:links` passes
- [x] `bun run check:content` passes
- [ ] Verify Vercel preview: visit `/projects/arcan`, "Live site" button points to `https://arcan.la`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the live-site link for the Arcan project to reflect the new domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->