### PR TITLE
perf(site): Suspense-stream session lookup on /prompts

### DIFF
--- a/apps/chat/app/(site)/prompts/page.tsx
+++ b/apps/chat/app/(site)/prompts/page.tsx
@@ -1,9 +1,10 @@
 import { headers } from "next/headers";
-import { PromptsList } from "@/components/site/prompts-list";
+import { Suspense } from "react";
 import { PromptsEnergyBeam } from "@/components/site/prompts-energy-beam";
+import { PromptsList } from "@/components/site/prompts-list";
 import { UserPrompts } from "@/components/site/user-prompts";
-import { getContentList } from "@/lib/content";
 import { getSafeSession } from "@/lib/auth";
+import { getContentList } from "@/lib/content";
 
 export const metadata = {
   title: "Prompts",
@@ -12,10 +13,7 @@ export const metadata = {
 };
 
 export default async function PromptsPage() {
-  const [entries, { data: session }] = await Promise.all([
-    getContentList("prompts"),
-    getSafeSession({ fetchOptions: { headers: await headers() } }),
-  ]);
+  const entries = await getContentList("prompts");
 
   return (
     <>
@@ -29,10 +27,22 @@ export default async function PromptsPage() {
             review, research, architecture, and more.
           </p>
         </header>
-        {session ? <UserPrompts session={session} /> : null}
+        {/* User-owned prompts are session-dependent; stream them so the
+            public list renders immediately without waiting on auth. */}
+        <Suspense fallback={null}>
+          <UserPromptsSlot />
+        </Suspense>
         <PromptsList entries={entries} />
       </main>
       <PromptsEnergyBeam />
     </>
   );
+}
+
+async function UserPromptsSlot() {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (!session) return null;
+  return <UserPrompts session={session} />;
 }


### PR DESCRIPTION
## Summary

Re-do of #131 (closed; that branch had stacked obsolete commits from a stale rebase). This PR is rebased fresh onto current main with a single commit.

The \`/prompts\` page awaited \`getSafeSession()\` in the page-level \`Promise.all\`, forcing full dynamic rendering — the public prompts list (already cached via \`getContentList\`) had to wait on auth before any HTML could be sent.

### Change

Move the session lookup into a \`UserPromptsSlot\` async server component, wrap in \`<Suspense fallback={null}>\`. Same pattern as \`/\` in #128.

Now:
- Header + \`<PromptsList>\` render immediately from the cached static partition
- \`<UserPrompts>\` (only visible when signed in) streams in once session resolves

### Out of scope

- \`/graph\` and \`/life/[project]\` use the same \`headers()\`-at-page-level pattern but session is a deep prop in client trees. Refactoring those needs the consuming components to accept a Promise via \`use()\` or fetch user data client-side. Deferred.

## Test plan

- [x] biome lint clean
- [x] \`bun run test:types\` passes
- [ ] Vercel preview build succeeds
- [ ] Smoke test on preview: \`/prompts\` renders the public list immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved prompts page responsiveness and loading performance for public prompts list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->