### PR TITLE
perf(content): server-side image optimization on /writing & /projects

### DIFF
--- a/apps/chat/components/site/prose-content.tsx
+++ b/apps/chat/components/site/prose-content.tsx
@@ -1,39 +1,18 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-
 interface ProseContentProps {
   html: string;
 }
 
+/**
+ * Renders prose HTML produced by `getContentBySlug`. The HTML already has
+ * optimized image src/srcset/sizes/loading attributes injected server-side
+ * (see `optimizeProseImages` in lib/content.ts), so this component is just
+ * a styled wrapper around dangerouslySetInnerHTML.
+ */
 export function ProseContent({ html }: ProseContentProps) {
-  const ref = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    if (!ref.current) return;
-    const imgs = ref.current.querySelectorAll<HTMLImageElement>(
-      "img[src^='/images/']"
-    );
-    for (const img of imgs) {
-      const src = img.getAttribute("src");
-      if (!src) continue;
-      const srcset = [640, 828, 1200]
-        .map(
-          (w) =>
-            `/_next/image?url=${encodeURIComponent(src)}&w=${w}&q=80 ${w}w`
-        )
-        .join(", ");
-      img.setAttribute("src", `/_next/image?url=${encodeURIComponent(src)}&w=1200&q=80`);
-      img.setAttribute("srcset", srcset);
-      img.setAttribute("sizes", "(max-width: 768px) 100vw, 800px");
-      img.setAttribute("loading", "lazy");
-      img.setAttribute("decoding", "async");
-    }
-  }, [html]);
-
   return (
     <article
-      ref={ref}
       className="prose prose-invert max-w-none prose-headings:font-display prose-headings:text-text-primary prose-a:text-ai-blue hover:prose-a:text-ai-blue/80 prose-strong:text-text-primary prose-table:w-full prose-table:border-collapse prose-table:text-sm prose-th:border prose-th:border-[var(--ag-border-default)] prose-th:bg-[var(--ag-bg-elevated)] prose-th:px-4 prose-th:py-2.5 prose-th:text-left prose-th:font-semibold prose-th:text-text-primary prose-td:border prose-td:border-[var(--ag-border-subtle)] prose-td:px-4 prose-td:py-2 prose-td:text-text-secondary prose-tr:transition-colors hover:prose-tr:bg-[var(--ag-bg-hover)] prose-code:rounded prose-code:bg-[var(--ag-bg-elevated)] prose-code:px-1.5 prose-code:py-0.5 prose-code:text-[0.85em] prose-code:before:content-none prose-code:after:content-none prose-pre:rounded-xl prose-pre:border prose-pre:border-[var(--ag-border-subtle)] prose-pre:bg-[var(--ag-bg-dark)]"
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/apps/chat/lib/content.ts
+++ b/apps/chat/lib/content.ts
@@ -225,6 +225,8 @@ export async function getContentBySlug(
     "$1",
   );
 
+  html = optimizeProseImages(html);
+
   // Rewrite frontmatter image/audio URLs
   if (summary.image) {
     summary.image = rewriteAssetUrl(summary.image);
@@ -239,6 +241,41 @@ export async function getContentBySlug(
     content: rewrittenContent,
     html,
   };
+}
+
+/**
+ * Rewrite <img src="/images/..."> tags in rendered HTML to use Next.js's
+ * /_next/image proxy with width/srcset hints. The first image becomes the
+ * LCP candidate (loading="eager", fetchpriority="high"); subsequent images
+ * stay lazy. This is server-side so the SSR HTML ships optimized URLs and
+ * the browser never makes a wasted request to the raw asset.
+ *
+ * Idempotent: tags that already carry a srcset are left untouched.
+ */
+function optimizeProseImages(html: string): string {
+  const widths = [640, 828, 1200] as const;
+  let index = 0;
+  return html.replace(
+    /<img\b([^>]*?)\ssrc=(["'])(\/images\/[^"']+)\2([^>]*?)\/?>/g,
+    (match, before: string, _quote: string, src: string, after: string) => {
+      const tail = `${before} ${after}`;
+      if (/\bsrcset=/.test(tail)) {
+        return match;
+      }
+      const encoded = encodeURIComponent(src);
+      const srcset = widths
+        .map((w) => `/_next/image?url=${encoded}&w=${w}&q=80 ${w}w`)
+        .join(", ");
+      const optimizedSrc = `/_next/image?url=${encoded}&w=1200&q=80`;
+      const sizes = '(max-width: 768px) 100vw, 800px';
+      const isFirst = index === 0;
+      index += 1;
+      const loadingAttr = isFirst
+        ? 'loading="eager" fetchpriority="high" decoding="async"'
+        : 'loading="lazy" decoding="async"';
+      return `<img${before} src="${optimizedSrc}" srcset="${srcset}" sizes="${sizes}" ${loadingAttr}${after}>`;
+    },
+  );
 }
 
 export function estimateReadingTime(content: string): number {


### PR DESCRIPTION
## Summary

Article pages (\`/writing/[slug]\`, \`/projects/[slug]\`, \`/notes/[slug]\`) had a costly two-step image load:

1. SSR HTML shipped raw \`<img src="/images/...">\` tags
2. Browser fetched the **full-size unoptimized** image
3. After hydration, \`prose-content.tsx\` ran a \`useEffect\` that rewrote each tag's \`src\` and \`srcset\` to use \`/_next/image?...\`
4. Browser fired a **second** request for the optimized version

Plus: every image — including the LCP candidate at the top of articles — got \`loading="lazy"\`, delaying first paint of the hero image.

### Change

Move the rewrite into \`lib/content.ts\` as \`optimizeProseImages\`, applied right after remark renders the markdown. Cached HTML now ships with \`/_next/image\` URLs + \`srcset\` + \`sizes\` already baked in.

The **first image gets**:
\`\`\`
loading="eager" fetchpriority="high" decoding="async"
\`\`\`

Subsequent images stay \`loading="lazy" decoding="async"\`.

Idempotent — tags already carrying a \`srcset\` are skipped, so HTML cached before this change degrades gracefully (and the next \`cacheLife("hours")\` window picks up the new format).

### Files

- \`lib/content.ts\` — new \`optimizeProseImages\` helper, called inside \`getContentBySlug\` after \`rewriteAssetUrls\`
- \`components/site/prose-content.tsx\` — reduced to a styled \`dangerouslySetInnerHTML\` wrapper (no \`useEffect\`, no \`useRef\`)

### Net effect

- LCP hero image: single optimized request, marked high-priority (was: raw fetch → JS rewrite → second optimized fetch, all lazy)
- Below-the-fold images: still lazy
- Slightly less hydration JS on article pages (no scan + setAttribute loop)

## Test plan

- [x] biome lint clean on changed files
- [x] \`bun run test:types\` passes
- [x] \`bun run check:links\` passes
- [x] \`bun run check:content\` passes
- [x] Regex sanity-tested via node REPL on representative MDX-rendered HTML
- [ ] Vercel preview build succeeds
- [ ] Smoke test on preview:
  - [ ] \`/writing/16-patterns-agent-governance\` (has multiple images): hero image src is \`/_next/image?...\` with \`loading="eager" fetchpriority="high"\` in initial HTML; subsequent images \`loading="lazy"\`
  - [ ] No console errors or layout shift on image swap (there shouldn't be — they don't swap anymore)
- [ ] Speed Insights on article routes after 24h: LCP improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)