### PR TITLE
fix(site): tooltip positioning + landing /profile CTA + hero anonymization

### DIFF
--- a/apps/chat/components/site/dock.tsx
+++ b/apps/chat/components/site/dock.tsx
@@ -193,16 +193,18 @@ function DockLabel({ children, className, ...rest }: DockLabelProps) {
     <AnimatePresence>
       {isVisible && (
         <motion.div
-          initial={{ opacity: 0, y: 0 }}
-          animate={{ opacity: 1, y: -10 }}
-          exit={{ opacity: 0, y: 0 }}
-          transition={{ duration: 0.2 }}
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 4 }}
+          transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
           className={cn(
-            "absolute -top-6 left-1/2 w-fit whitespace-pre rounded-md border border-zinc-700 bg-zinc-800 px-2 py-0.5 text-xs text-zinc-200",
+            // Anchor above parent via bottom-full (no fixed pixel offset),
+            // center via inset-x-0 + mx-auto so positioning is stable even
+            // while the DockItem parent's width is mid-animation.
+            "pointer-events-none absolute bottom-full inset-x-0 z-50 mx-auto mb-2 w-fit max-w-[10rem] whitespace-pre rounded-md border border-zinc-700 bg-zinc-900/95 px-2 py-0.5 text-xs text-zinc-200 shadow-md backdrop-blur-md",
             className,
           )}
           role="tooltip"
-          style={{ x: "-50%" }}
         >
           {children}
         </motion.div>

--- a/apps/chat/components/site/landing-sections.tsx
+++ b/apps/chat/components/site/landing-sections.tsx
@@ -13,6 +13,7 @@ import ThermodynamicGrid from "@/components/ui/interactive-thermodynamic-grid";
 /* ------------------------------------------------------------------ */
 
 const socials = [
+  { href: "/profile", label: "Profile" },
   { href: "https://github.com/broomva", label: "GitHub" },
   { href: "https://www.linkedin.com/in/broomva/", label: "LinkedIn" },
   { href: "https://x.com/broomva_tech", label: "X" },
@@ -167,7 +168,7 @@ export function HeroSection({ userName }: { userName?: string | null }) {
         >
           {firstName
             ? "How can I help you today?"
-            : "Lead AI at Stimulus. Databricks expert. Rust Agent OS builder. From scalable data pipelines to autonomous agent infrastructure — reliability engineering across software, body, and craft."}
+            : "Agent OS architect and AI engineering lead. Builder of multi-tenant agentic platforms, lakehouse-native data substrates, and the open-source Rust Agent OS — reliability engineering across software, body, and craft."}
         </motion.p>
 
         {/* Social links — only when not logged in */}


### PR DESCRIPTION
## Summary
- **Landing**: adds /profile as first social pill so visitors can route to the canonical profile surface; anonymizes hero subtitle (drops explicit "Lead AI at Stimulus" client-name) to match the anonymization stance applied across CV, cover letter, and elsewhere on the site.
- **Dock tooltip**: re-anchors DockLabel above parent via \`bottom-full\` instead of fixed -top-6; centers via \`inset-x-0 mx-auto\` instead of \`left-1/2 + translateX(-50%)\` (the latter recalculated each frame against the magnifying DockItem width, causing the visible jitter).
- Adds \`pointer-events-none\`, \`z-50\`, slightly darker bg + backdrop-blur, tighter 0.18s transition.

## Test plan
- [x] \`bun run test:types\` — clean
- [x] \`bun run build\` — \`/profile\` still prerenders as static (○); no new errors introduced
- [ ] Visual: hover items in the bottom dock — tooltip should appear directly above the icon, no horizontal jitter as adjacent items magnify
- [ ] Visual: anonymous landing — hero subtitle no longer mentions Stimulus by name; first social pill is "Profile" linking to /profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)