### PR TITLE
fix(auth): make /profile a public route

### DIFF
--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -13,6 +13,7 @@ const PUBLIC_PAGE_PREFIXES = [
   "/now",
   "/contact",
   "/prompts",
+  "/profile",
   "/share/",
   "/privacy",
   "/terms",


### PR DESCRIPTION
## Summary

\`/profile\` is meant as a public surface (canonical CV / about page) but \`proxy.ts\`'s \`PUBLIC_PAGE_PREFIXES\` allowlist didn't include it, so unauthenticated visitors hit the auth redirect.

Add \`/profile\` to the allowlist alongside \`/projects\`, \`/writing\`, \`/notes\`, etc.

## Test plan

- [x] biome lint clean
- [x] \`bun run test:types\` passes
- [ ] Vercel preview: incognito visit to \`/profile\` renders the page (no login redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile pages are now publicly accessible without authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->