### PR TITLE
feat(life): rewrite /life as articulation page, not project picker

### DIFF
--- a/apps/chat/app/(site)/life/life-styles.css
+++ b/apps/chat/app/(site)/life/life-styles.css
@@ -800,6 +800,347 @@
 .life-landing__chip--emerald { color: oklch(0.78 0.15 155); border: 1px solid oklch(0.72 0.19 155 / 0.4); background: oklch(0.72 0.19 155 / 0.08); }
 .life-landing__chip--amber { color: oklch(0.87 0.18 85); border: 1px solid oklch(0.87 0.18 85 / 0.4); background: oklch(0.87 0.18 85 / 0.08); }
 
+/* ============================================================================
+   /life articulation page — hero, sections, subsystems, custody, quickstart.
+   Extends the project-picker styles above; everything stays under the
+   .life-landing namespace.
+   ============================================================================ */
+
+.life-landing__hero {
+  margin-bottom: 72px;
+}
+.life-landing__hero .life-landing__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.life-landing__pulse {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 9999px;
+  background: oklch(0.78 0.15 155);
+  box-shadow: 0 0 0 0 oklch(0.78 0.15 155 / 0.6);
+  animation: life-landing-pulse 2.4s ease-out infinite;
+}
+@keyframes life-landing-pulse {
+  0%   { box-shadow: 0 0 0 0 oklch(0.78 0.15 155 / 0.6); }
+  70%  { box-shadow: 0 0 0 10px oklch(0.78 0.15 155 / 0); }
+  100% { box-shadow: 0 0 0 0 oklch(0.78 0.15 155 / 0); }
+}
+.life-landing__br { display: none; }
+@media (min-width: 720px) {
+  .life-landing__br { display: inline; }
+  .life-landing__title { font-size: 64px; }
+}
+.life-landing__cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 36px;
+}
+.life-landing__cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 18px;
+  border-radius: 9999px;
+  font-family: var(--ag-font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  transition: transform var(--ag-transition-fast), border-color var(--ag-transition-fast), background var(--ag-transition-fast);
+}
+.life-landing__cta--primary {
+  background: var(--ag-ai-blue);
+  color: oklch(1 0 0);
+  border: 1px solid transparent;
+}
+.life-landing__cta--primary:hover {
+  background: color-mix(in oklab, var(--ag-ai-blue) 88%, white);
+  transform: translateY(-1px);
+}
+.life-landing__cta--ghost {
+  background: transparent;
+  color: var(--ag-text-primary);
+  border: 1px solid var(--ag-border-subtle);
+}
+.life-landing__cta--ghost:hover {
+  border-color: oklch(0.60 0.12 260 / 0.5);
+  color: var(--ag-ai-blue);
+}
+
+.life-landing__stat-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--ag-border-subtle);
+}
+.life-landing__stat {
+  background: color-mix(in oklab, var(--ag-bg-surface) 55%, transparent);
+  backdrop-filter: blur(12px) saturate(1.2);
+  padding: 14px 18px;
+}
+.life-landing__stat dt {
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ag-text-muted);
+  margin: 0 0 6px 0;
+}
+.life-landing__stat dd {
+  font-family: var(--ag-font-heading);
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  color: var(--ag-text-primary);
+  margin: 0;
+}
+
+/* ── Section scaffold ──────────────────────────────────────────── */
+.life-landing__section {
+  margin-bottom: 72px;
+}
+.life-landing__section-head {
+  margin-bottom: 28px;
+}
+.life-landing__kicker {
+  font-family: var(--ag-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ag-text-muted);
+  margin: 0 0 8px 0;
+}
+.life-landing__h2 {
+  font-family: var(--ag-font-heading);
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  color: var(--ag-text-primary);
+  margin: 0 0 14px 0;
+}
+@media (min-width: 720px) {
+  .life-landing__h2 { font-size: 36px; }
+}
+.life-landing__lede {
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ag-text-secondary);
+  max-width: 720px;
+  margin: 0;
+}
+.life-landing__lede--small {
+  font-size: 13px;
+  margin-top: 14px;
+  color: var(--ag-text-muted);
+}
+.life-landing__lede code,
+.life-landing__footnote code {
+  font-family: var(--ag-font-mono);
+  font-size: 0.92em;
+  background: color-mix(in oklab, var(--ag-bg-surface) 60%, transparent);
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 6px;
+  padding: 1px 6px;
+  color: var(--ag-text-primary);
+}
+
+/* ── Subsystem grid ────────────────────────────────────────────── */
+.life-landing__sub-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+}
+.life-landing__sub-card {
+  padding: 16px 18px;
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--ag-bg-surface) 50%, transparent);
+  backdrop-filter: blur(16px) saturate(1.2);
+  scroll-margin-top: 80px;
+}
+.life-landing__sub-name {
+  font-family: var(--ag-font-heading);
+  font-size: 17px;
+  letter-spacing: -0.01em;
+  color: var(--ag-text-primary);
+  margin: 0 0 6px 0;
+}
+.life-landing__sub-role {
+  display: inline-block;
+  margin-left: 6px;
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ag-text-muted);
+  vertical-align: middle;
+}
+.life-landing__sub-desc {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ag-text-secondary);
+  margin: 0;
+}
+
+/* ── Custody backend grid ─────────────────────────────────────── */
+.life-landing__custody-grid {
+  list-style: none;
+  margin: 0 0 18px 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+.life-landing__custody-card {
+  padding: 16px 18px;
+  border: 1px solid oklch(0.60 0.12 260 / 0.18);
+  border-radius: 12px;
+  background:
+    linear-gradient(145deg, oklch(0.60 0.12 260 / 0.04), transparent 60%),
+    color-mix(in oklab, var(--ag-bg-surface) 50%, transparent);
+  backdrop-filter: blur(16px) saturate(1.2);
+}
+.life-landing__custody-surface {
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ag-ai-blue);
+  margin: 0 0 6px 0;
+}
+.life-landing__custody-name {
+  font-family: var(--ag-font-mono);
+  font-size: 13px;
+  letter-spacing: 0;
+  color: var(--ag-text-primary);
+  margin: 0 0 6px 0;
+}
+.life-landing__custody-desc {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ag-text-secondary);
+  margin: 0;
+}
+.life-landing__footnote {
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--ag-text-muted);
+  margin: 0;
+}
+.life-landing__footnote-label {
+  font-family: var(--ag-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  color: var(--ag-text-secondary);
+  background: color-mix(in oklab, var(--ag-bg-surface) 70%, transparent);
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-right: 4px;
+}
+.life-landing__inline-link {
+  color: var(--ag-text-secondary);
+  text-decoration: underline;
+  text-decoration-color: var(--ag-border-subtle);
+  text-underline-offset: 3px;
+  transition: color var(--ag-transition-fast), text-decoration-color var(--ag-transition-fast);
+}
+.life-landing__inline-link:hover {
+  color: var(--ag-ai-blue);
+  text-decoration-color: var(--ag-ai-blue);
+}
+
+/* ── Code block ─────────────────────────────────────────────── */
+.life-landing__code {
+  border: 1px solid var(--ag-border-subtle);
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--ag-bg-deep) 65%, transparent);
+  backdrop-filter: blur(20px);
+  overflow: auto;
+  position: relative;
+}
+.life-landing__code::before {
+  content: "$";
+  position: absolute;
+  top: 14px; left: 14px;
+  font-family: var(--ag-font-mono);
+  font-size: 11px;
+  color: var(--ag-text-muted);
+  letter-spacing: 0.1em;
+}
+.life-landing__code pre {
+  margin: 0;
+  padding: 16px 18px 18px 36px;
+  font-family: var(--ag-font-mono);
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--ag-text-secondary);
+  overflow-x: auto;
+}
+.life-landing__code pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+.life-landing__footer {
+  margin-top: 80px;
+  padding-top: 32px;
+  border-top: 1px solid var(--ag-border-subtle);
+  text-align: center;
+}
+.life-landing__footer-line {
+  font-size: 13px;
+  color: var(--ag-text-muted);
+  margin: 0 0 14px 0;
+}
+.life-landing__footer-line strong {
+  color: var(--ag-text-secondary);
+  font-weight: 500;
+}
+.life-landing__footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--ag-font-mono);
+  font-size: 12px;
+  margin-bottom: 32px;
+}
+.life-landing__footer-links a {
+  color: var(--ag-text-secondary);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+  transition: color var(--ag-transition-fast);
+}
+.life-landing__footer-links a:hover {
+  color: var(--ag-ai-blue);
+}
+.life-landing__footer-links span {
+  color: var(--ag-text-muted);
+  opacity: 0.5;
+}
+.life-landing__epigraph {
+  font-family: var(--ag-font-heading);
+  font-size: 18px;
+  letter-spacing: -0.01em;
+  color: var(--ag-text-primary);
+  margin: 0;
+  opacity: 0.75;
+}
+
 .life-landing__notfound {
   padding: 80px 24px;
   text-align: center;

--- a/apps/chat/app/(site)/life/page.tsx
+++ b/apps/chat/app/(site)/life/page.tsx
@@ -9,46 +9,370 @@ const CHIP_LABELS: Record<ProjectChipColor, string> = {
 };
 
 export const metadata: Metadata = {
-  title: "Life · Agent Workspace",
+  title: "Life · An Operating System for AI Agents",
   description:
-    "Three-column AI-native agent workspace for Life — chat, workspace, and inspector.",
+    "Identity, memory, custody, payments, and execution as primitives — not bolt-ons. Rust-native, event-sourced, MIT licensed. Spec D 100% complete (May 2, 2026).",
+  openGraph: {
+    title: "Life — Agent Operating System",
+    description:
+      "An operating system for AI agents. 8 subsystems on one kernel contract. Production custody (6 backends), event-sourced persistence, native finance, cryptographic identity.",
+    type: "website",
+  },
 };
 
+// 8 subsystems on one kernel contract (aiOS). Each card answers
+// "what role does this play in the agent lifecycle" in one line.
+const SUBSYSTEMS: ReadonlyArray<{
+  name: string;
+  role: string;
+  description: string;
+  hash: string;
+}> = [
+  {
+    name: "Anima",
+    role: "Identity",
+    description:
+      "Soul, dual keypair (P-256 auth + secp256k1 wallet), DID, custody trait with 6 backends.",
+    hash: "#anima",
+  },
+  {
+    name: "Arcan",
+    role: "Runtime",
+    description:
+      "Agent loop — reconstruct from journal, call provider, execute tools, stream events.",
+    hash: "#arcan",
+  },
+  {
+    name: "Lago",
+    role: "Persistence",
+    description:
+      "Append-only event journal, content-addressed blobs, knowledge index, multi-format SSE.",
+    hash: "#lago",
+  },
+  {
+    name: "Haima",
+    role: "Finance",
+    description:
+      "x402 machine-payments, secp256k1 wallets, per-task billing, on-chain settlement.",
+    hash: "#haima",
+  },
+  {
+    name: "Autonomic",
+    role: "Homeostasis",
+    description:
+      "Three-pillar regulation — operational, cognitive, economic. Hysteresis anti-flapping.",
+    hash: "#autonomic",
+  },
+  {
+    name: "Praxis",
+    role: "Tools",
+    description:
+      "Sandbox, hashline editing (Blake3), SKILL.md registry, MCP server + client bridge.",
+    hash: "#praxis",
+  },
+  {
+    name: "Vigil",
+    role: "Observability",
+    description:
+      "OpenTelemetry tracing, GenAI semantic conventions, contract-derived spans.",
+    hash: "#vigil",
+  },
+  {
+    name: "Spaces",
+    role: "Networking",
+    description:
+      "SpacetimeDB 2.0 fabric, real-time agent communication, RBAC channels.",
+    hash: "#spaces",
+  },
+];
+
+// Spec D ships custody as a first-class trait with 6 backends.
+// Each card maps to one of L4-D5..D10's locked decisions.
+const CUSTODY_BACKENDS: ReadonlyArray<{
+  name: string;
+  surface: string;
+  desc: string;
+}> = [
+  {
+    name: "InProcessAnima",
+    surface: "Dev / single-host",
+    desc: "Master seed → P-256 auth + secp256k1 wallet, ChaCha20-Poly1305 at rest.",
+  },
+  {
+    name: "VaultTransitAnima",
+    surface: "Server-side",
+    desc: "HashiCorp Vault Transit — keys never leave the KMS. Per-user namespaces.",
+  },
+  {
+    name: "TpmAnima",
+    surface: "Desktop",
+    desc: "PKCS#11 against the host TPM. Auth-key never reveals the scalar.",
+  },
+  {
+    name: "WebCryptoAnima",
+    surface: "Browser",
+    desc: "Passkey-managed, non-extractable. Wallet ops delegated to RemoteAnima.",
+  },
+  {
+    name: "HardwareWalletAnima",
+    surface: "High-stakes",
+    desc: "Ledger over hidapi. Every wallet op is hardware-confirmed.",
+  },
+  {
+    name: "SomaCustody",
+    surface: "Multi-tenant",
+    desc: "soma admin custody-oracle UDS. SO_PEERCRED + group-based authn.",
+  },
+];
+
+const PROJECT_ENTRIES = Object.entries(PROJECTS);
+
 export default function LifeLandingPage() {
-  const entries = Object.entries(PROJECTS);
   return (
     <div className="life-landing">
       <div className="life-landing__inner">
-        <div className="life-landing__eyebrow">broomva.tech / life</div>
-        <h1 className="life-landing__title">Pick a Life project</h1>
-        <p className="life-landing__sub">
-          Each project is a three-column agent workspace: streaming chat on the
-          left, live filesystem and journal in the middle, and metrics inspectors
-          on the right. Today these are demo replays. Phase B wires real Arcan
-          streaming through <code>/api/life/run/[project]</code>.
-        </p>
-        <div className="life-landing__grid">
-          {entries.map(([slug, project]) => (
-            <Link
-              key={slug}
-              href={`/life/${slug}`}
-              className="life-landing__card"
+        {/* ── Hero ─────────────────────────────────────────────────── */}
+        <section className="life-landing__hero">
+          <div className="life-landing__eyebrow">
+            <span className="life-landing__pulse" aria-hidden="true" />
+            Spec D · 100% complete · May 2, 2026
+          </div>
+
+          <h1 className="life-landing__title">
+            An operating system <br className="life-landing__br" />
+            for AI agents.
+          </h1>
+
+          <p className="life-landing__sub">
+            Identity, memory, custody, payments, and execution &mdash;
+            primitives, not bolt-ons. Rust-native, event-sourced, MIT licensed.
+          </p>
+
+          <div className="life-landing__cta-row">
+            <a
+              className="life-landing__cta life-landing__cta--primary"
+              href="https://github.com/broomva/life"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              <span
-                className={`life-landing__chip life-landing__chip--${project.chipColor}`}
-              >
-                {CHIP_LABELS[project.chipColor]}
-              </span>
-              <div className="life-landing__card-eyebrow">{project.eyebrow}</div>
-              <div className="life-landing__card-title">{project.displayName}</div>
-              <div className="life-landing__card-body">
-                Open the {slug} workspace to replay an Arcan agent run with
-                full filesystem, journal, and metrics inspectors.
-              </div>
-              <div className="life-landing__card-cta">Open /life/{slug} ▸</div>
+              View on GitHub
+            </a>
+            <Link
+              className="life-landing__cta life-landing__cta--ghost"
+              href="/launch/life"
+            >
+              Read the longform pitch
             </Link>
-          ))}
-        </div>
+            <a
+              className="life-landing__cta life-landing__cta--ghost"
+              href="https://crates.io/crates/arcan"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              cargo install arcan
+            </a>
+          </div>
+
+          <dl className="life-landing__stat-strip">
+            <div className="life-landing__stat">
+              <dt>Rust tests</dt>
+              <dd>4,133+</dd>
+            </div>
+            <div className="life-landing__stat">
+              <dt>Subsystems</dt>
+              <dd>8</dd>
+            </div>
+            <div className="life-landing__stat">
+              <dt>Custody backends</dt>
+              <dd>6 / 6</dd>
+            </div>
+            <div className="life-landing__stat">
+              <dt>License</dt>
+              <dd>MIT</dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* ── What's inside ────────────────────────────────────────── */}
+        <section className="life-landing__section">
+          <header className="life-landing__section-head">
+            <p className="life-landing__kicker">The substrate</p>
+            <h2 className="life-landing__h2">Eight subsystems, one kernel contract.</h2>
+            <p className="life-landing__lede">
+              Every subsystem implements traits from <code>aios-protocol</code>{" "}
+              &mdash; the contract that defines events, state, policy, and the
+              agent lifecycle. Swap or extend any part without breaking the rest.
+            </p>
+          </header>
+
+          <ul className="life-landing__sub-grid">
+            {SUBSYSTEMS.map((s) => (
+              <li
+                key={s.name}
+                id={s.hash.slice(1)}
+                className="life-landing__sub-card"
+              >
+                <p className="life-landing__sub-name">
+                  {s.name}{" "}
+                  <span className="life-landing__sub-role">{s.role}</span>
+                </p>
+                <p className="life-landing__sub-desc">{s.description}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* ── What just shipped (Spec D) ──────────────────────────── */}
+        <section className="life-landing__section">
+          <header className="life-landing__section-head">
+            <p className="life-landing__kicker">Just shipped &middot; 2026-05-02</p>
+            <h2 className="life-landing__h2">Spec D: production custody.</h2>
+            <p className="life-landing__lede">
+              An agent's identity now ships with the same custody discipline a
+              human's does. Six backends span browser, server, desktop, and
+              hardware. Rotation and revocation are first-class events. A single
+              canonical multi-curve verifier (<code>lago-auth</code>) replaces
+              ad-hoc JWT validation across the stack.
+            </p>
+          </header>
+
+          <ul className="life-landing__custody-grid">
+            {CUSTODY_BACKENDS.map((b) => (
+              <li key={b.name} className="life-landing__custody-card">
+                <p className="life-landing__custody-surface">{b.surface}</p>
+                <p className="life-landing__custody-name">{b.name}</p>
+                <p className="life-landing__custody-desc">{b.desc}</p>
+              </li>
+            ))}
+          </ul>
+
+          <p className="life-landing__footnote">
+            <span className="life-landing__footnote-label">L4-D5</span>{" "}
+            split-custody for browser deployments &middot;{" "}
+            <span className="life-landing__footnote-label">L4-D6</span> P-256
+            ECDSA across the stack &middot;{" "}
+            <span className="life-landing__footnote-label">L4-D10</span>{" "}
+            <code>anima.identity_rotated</code> with{" "}
+            <code>rotation_proof_jws</code> signed by the old key. Full spec at{" "}
+            <a
+              href="https://github.com/broomva/life/blob/main/docs/superpowers/specs/2026-04-29-spec-d-anima-custody.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="life-landing__inline-link"
+            >
+              docs/superpowers/specs/spec-d
+            </a>
+            .
+          </p>
+        </section>
+
+        {/* ── Quickstart ─────────────────────────────────────────── */}
+        <section className="life-landing__section">
+          <header className="life-landing__section-head">
+            <p className="life-landing__kicker">Start building</p>
+            <h2 className="life-landing__h2">Six lines to a running agent.</h2>
+          </header>
+
+          <div className="life-landing__code">
+            <pre>
+              <code>{`# Clone and verify the substrate.
+git clone https://github.com/broomva/life.git
+cd life && cargo test --workspace
+
+# Generate an agent identity (anima).
+cargo run -p arcan -- identity new
+
+# Boot the runtime (arcand) on :3000.
+cargo run -p arcand -- --port 3000`}</code>
+            </pre>
+          </div>
+
+          <p className="life-landing__lede life-landing__lede--small">
+            Every event your agent emits is replayable from the journal. No
+            mutable state, no hidden side effects, no LLM call needed to
+            reconstruct yesterday's session. That's the OS thesis.
+          </p>
+        </section>
+
+        {/* ── Live demos (preserved project picker) ─────────────── */}
+        <section className="life-landing__section">
+          <header className="life-landing__section-head">
+            <p className="life-landing__kicker">See it run</p>
+            <h2 className="life-landing__h2">Live demos.</h2>
+            <p className="life-landing__lede">
+              Each demo opens a three-column agent workspace &mdash; streaming
+              chat, live filesystem and journal, identity + economic + reasoning
+              inspectors on the right.
+            </p>
+          </header>
+
+          <div className="life-landing__grid">
+            {PROJECT_ENTRIES.map(([slug, project]) => (
+              <Link
+                key={slug}
+                href={`/life/${slug}`}
+                className="life-landing__card"
+              >
+                <span
+                  className={`life-landing__chip life-landing__chip--${project.chipColor}`}
+                >
+                  {CHIP_LABELS[project.chipColor]}
+                </span>
+                <div className="life-landing__card-eyebrow">
+                  {project.eyebrow}
+                </div>
+                <div className="life-landing__card-title">
+                  {project.displayName}
+                </div>
+                <div className="life-landing__card-body">
+                  Open the {slug} workspace to step through a real Arcan agent
+                  run with full filesystem, journal, and metrics inspectors.
+                </div>
+                <div className="life-landing__card-cta">Open /life/{slug} ▸</div>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {/* ── Footer / deep links ────────────────────────────────── */}
+        <footer className="life-landing__footer">
+          <p className="life-landing__footer-line">
+            <strong>Life</strong> is open source under MIT. Published to
+            crates.io.
+          </p>
+          <div className="life-landing__footer-links">
+            <a
+              href="https://github.com/broomva/life"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub
+            </a>
+            <span aria-hidden="true">·</span>
+            <a
+              href="https://crates.io/crates/arcan"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              crates.io
+            </a>
+            <span aria-hidden="true">·</span>
+            <a
+              href="https://github.com/broomva/life/blob/main/docs/STATUS.md"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              changelog
+            </a>
+            <span aria-hidden="true">·</span>
+            <Link href="/launch/life">launch page</Link>
+            <span aria-hidden="true">·</span>
+            <Link href="/projects/life">project notes</Link>
+          </div>
+          <p className="life-landing__epigraph">
+            LLMs are controllers, not chatbots.
+          </p>
+        </footer>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Rewrites `/life` to be the canonical articulation page for the Life framework — what it is, what just shipped, and how to start building. Before, `/life` was a 55-LOC project picker with no framework context. Visitors landed on a stale "Phase B wires real Arcan streaming" hint and three demo cards.

The framework pitch lived only at `/launch/life` (corporate marketing surface). `/life` itself communicated nothing about what Life IS.

## Before / After

**Before** — 55 LOC. "Pick a Life project" + 3 cards. No mention of what Life is, what shipped, or why it exists.

**After** — 287 LOC of structured articulation:

1. **Hero** — Spec D 100% pulse + thesis ("an operating system for AI agents") + 1-line elaboration + 3 CTAs (GitHub / longform pitch / `cargo install`) + 4-stat strip (4,133+ tests / 8 subsystems / 6/6 custody backends / MIT)
2. **The substrate** — Eight subsystems on one kernel contract (`aios-protocol`). Anima, Arcan, Lago, Haima, Autonomic, Praxis, Vigil, Spaces — each with a one-line role. Anchored hashes for deep-linking.
3. **Just shipped (Spec D, 2026-05-02)** — All 6 custody backends as cards (InProcess / VaultTransit / Tpm / WebCrypto / HardwareWallet / Soma) with surface labels (Dev / Server-side / Desktop / Browser / High-stakes / Multi-tenant). Footnote with L4-D5/D6/D10 spec references and link to the canonical Spec D doc.
4. **Quickstart** — Six lines from `git clone` to `arcand` running on :3000. Honest about the OS thesis (event-sourced replayability).
5. **Live demos** — Preserves the existing project picker (sentinel / materiales / sentinel-paid) but rebranded as "see it run" proof, not the whole pitch.
6. **Footer** — Deep links to GitHub, crates.io, changelog, longform pitch, project notes. Closes with the "LLMs are controllers, not chatbots." epigraph.

## Visual language

Stays entirely within the existing **Arcan Glass** system:
- Same `.life-landing` namespace + radial-gradient backgrounds + glass cards + mono eyebrows
- New: hero pulse animation (matches "live" emerald), stat strip with 1px-grid hairlines, custody cards with subtle violet linear-gradient overlay, `$`-prefixed code block

Responsive (clamps under 720px), accessible (semantic `<section>` / `<dl>` / `<header>` / `aria-hidden` separators), SEO-tagged (updated metadata + OpenGraph).

## Test plan

- [x] `bunx tsc --noEmit` clean (0 errors)
- [x] `bunx biome lint app/(site)/life` — 0 errors in the life directory; remaining 18 warnings are stylistic (descending-specificity on compound `code`/`strong` selectors) or pre-existing (`!important` at line 1414)
- [x] Existing tests still pass: `app/(site)/life/_lib/envelope-adapter.test.ts` (19/19)
- [x] React SSR smoke: page renders to 10,511 bytes of HTML; all 12 articulation needles present (thesis copy, all 6 custody backend names, quickstart, demos, license)
- [ ] Manual visual QA on Vercel preview deployment

## Files

- `apps/chat/app/(site)/life/page.tsx` — 55 → 287 LOC (+232)
- `apps/chat/app/(site)/life/life-styles.css` — +341 LOC (hero / sections / subsystems / custody / code / footer scoped under existing `.life-landing__` namespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)