### PR TITLE
fix(auth): rename JWKS folder /jwks + rewrite /jwks.json

### DIFF
--- a/apps/chat/app/api/auth/jwks/route.ts
+++ b/apps/chat/app/api/auth/jwks/route.ts
@@ -1,11 +1,14 @@
 /**
- * GET /api/auth/jwks.json
+ * GET /api/auth/jwks   (also reachable via /api/auth/jwks.json rewrite)
  *
  * Publishes the public half of the lifegw Tier-1 signing key so lifegw
- * can verify Tier-1 JWTs minted by `mintTier1ForConsumer()`. Path is
- * the canonical default referenced by lifegw's `auth.jwks_url` config
- * — see `core/life/crates/life-runtime/lifegw/src/config.rs`
- * (`default_jwks_url() = "https://broomva.tech/api/auth/jwks.json"`).
+ * can verify Tier-1 JWTs minted by `mintTier1ForConsumer()`. The
+ * canonical lifegw URL is `/api/auth/jwks.json` (see
+ * `core/life/crates/life-runtime/lifegw/src/config.rs`,
+ * `default_jwks_url()`); a rewrite in `next.config.ts` maps that path
+ * to this folder. We can't use a literal `jwks.json` folder because
+ * Next.js routes folder-names-with-dots through the Neon Auth
+ * `[...path]` catch-all instead of the literal segment.
  *
  * Cache headers match lifegw's default JWKS cache TTL (5 minutes,
  * `default_jwks_cache_ttl()`). The 30-min `s-maxage` lets the Vercel

--- a/apps/chat/next.config.ts
+++ b/apps/chat/next.config.ts
@@ -17,6 +17,13 @@ const nextConfig: NextConfig = {
     return [
       { source: "/llms.txt", destination: "/api/llms" },
       { source: "/llms-full.txt", destination: "/api/llms-full" },
+      // lifegw's default `auth.jwks_url` points at `/api/auth/jwks.json`
+      // (see `core/life/crates/life-runtime/lifegw/src/config.rs`). The
+      // Neon Auth catch-all `[...path]` ate the literal-folder version
+      // because Next.js routes folders-with-dots through the catch-all,
+      // so we serve the JWKS from `/api/auth/jwks` and rewrite the
+      // canonical `.json` URL in.
+      { source: "/api/auth/jwks.json", destination: "/api/auth/jwks" },
     ];
   },
 


### PR DESCRIPTION
## Summary

The newly-shipped \`/api/auth/jwks.json/route.ts\` (#139) returned 404 in production because the Neon Auth \`/api/auth/[...path]\` catch-all matched first — Next.js routes folder-names-with-dots through the catch-all instead of the literal segment.

Fix: serve from \`/api/auth/jwks\` (no dot, literal segment wins) and add a rewrite in \`next.config.ts\` so lifegw's default \`auth.jwks_url\` (\`https://broomva.tech/api/auth/jwks.json\`) still resolves to the same handler.

## Test plan

- [x] biome lint clean.
- [x] tsc clean.
- [ ] After deploy: \`curl https://broomva.tech/api/auth/jwks.json\` returns the JWKS doc.
- [ ] \`curl https://broomva.tech/api/auth/jwks\` also returns the JWKS doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)