### PR TITLE
feat(life): wire LifedWsAgentSessionClient.createSession() (Stage 3a)

### DIFF
--- a/apps/chat/lib/life-runtime/agent-session/lifed-ws-client.test.ts
+++ b/apps/chat/lib/life-runtime/agent-session/lifed-ws-client.test.ts
@@ -274,6 +274,234 @@ describe("decodeAgentEvent — UNKNOWN", () => {
   });
 });
 
+describe("createSession (Stage 3a)", () => {
+  // Setup: import the class lazily here so the `vi.mock("server-only")`
+  // above takes effect before module evaluation, then construct an
+  // instance with an injected `fetch` so we can probe the request shape
+  // and stub responses without a network call.
+  const importClient = async () => {
+    const m = await import("./lifed-ws-client");
+    return m.LifedWsAgentSessionClient;
+  };
+
+  // No-op WebSocket factory so the constructor doesn't trip the
+  // "no WebSocket impl" guard when `globalThis.WebSocket` is missing.
+  const noopWsFactory = () =>
+    ({
+      readyState: 0,
+      send: () => {},
+      close: () => {},
+      addEventListener: () => {},
+    }) as unknown as ReturnType<typeof Object>;
+
+  it("POSTs to /v1/agent/create_session with the Tier-1 bearer + JSON body", async () => {
+    const Cls = await importClient();
+    const captured: { url?: string; init?: RequestInit } = {};
+    const stubFetch: typeof fetch = async (url, init) => {
+      captured.url = url as string;
+      captured.init = init;
+      return new Response(
+        JSON.stringify({
+          sid: "lifed_sid_001",
+          agent_id: "agent_x",
+          user_id: "alice",
+          project_id: "sentinel",
+          created_at_unix: 1_777_900_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    };
+    const client = new Cls({
+      baseUrl: "https://lifegw.test",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    const out = await client.createSession({
+      capability: { token: "tok_xyz" },
+      userId: "alice",
+      projectSlug: "sentinel",
+      label: "smoke",
+    });
+    expect(out.sid).toBe("lifed_sid_001");
+    expect(out.agentId).toBe("agent_x");
+    expect(out.userId).toBe("alice");
+    expect(out.projectId).toBe("sentinel");
+    expect(out.createdAtUnix).toBe(1_777_900_000);
+
+    // Wire-shape assertions.
+    expect(captured.url).toBe(
+      "https://lifegw.test/v1/agent/create_session",
+    );
+    expect(captured.init?.method).toBe("POST");
+    const headers = captured.init?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok_xyz");
+    expect(headers["Content-Type"]).toBe("application/json");
+    const body = JSON.parse(captured.init?.body as string);
+    expect(body).toEqual({
+      user_id: "alice",
+      project_id: "sentinel",
+      label: "smoke",
+    });
+  });
+
+  it("omits empty optional fields from the request body", async () => {
+    const Cls = await importClient();
+    const captured: { body?: string } = {};
+    const stubFetch: typeof fetch = async (_url, init) => {
+      captured.body = init?.body as string;
+      return new Response(
+        JSON.stringify({ sid: "x", agent_id: "y" }),
+        { status: 200 },
+      );
+    };
+    const client = new Cls({
+      baseUrl: "https://lifegw.test",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    await client.createSession({
+      capability: { token: "t" },
+      userId: "alice",
+      projectSlug: "sentinel",
+      // no label, no resumeSid
+    });
+    const body = JSON.parse(captured.body as string);
+    expect(body).toEqual({ user_id: "alice", project_id: "sentinel" });
+    expect(body).not.toHaveProperty("label");
+    expect(body).not.toHaveProperty("resume_sid");
+  });
+
+  it("throws LifedCreateSessionError on non-2xx with httpStatus + code populated", async () => {
+    const Cls = await importClient();
+    const { LifedCreateSessionError } = await import("./lifed-ws-client");
+    const stubFetch: typeof fetch = async () =>
+      new Response(JSON.stringify({ error: "missing Tier-1 bearer" }), {
+        status: 401,
+      });
+    const client = new Cls({
+      baseUrl: "https://lifegw.test",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    await expect(
+      client.createSession({
+        capability: { token: "stale" },
+        userId: "alice",
+        projectSlug: "sentinel",
+      }),
+    ).rejects.toMatchObject({
+      name: "LifedCreateSessionError",
+      code: "lifed-ws.create_session.http_401",
+      httpStatus: 401,
+    });
+    // `instanceof` check for completeness — the import path is unique
+    // even with hot-reload.
+    try {
+      await client.createSession({
+        capability: { token: "stale" },
+        userId: "alice",
+        projectSlug: "sentinel",
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(LifedCreateSessionError);
+    }
+  });
+
+  it("throws on network failure with code='fetch_failed'", async () => {
+    const Cls = await importClient();
+    const stubFetch: typeof fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const client = new Cls({
+      baseUrl: "https://lifegw.test",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    await expect(
+      client.createSession({
+        capability: { token: "t" },
+        userId: "alice",
+        projectSlug: "sentinel",
+      }),
+    ).rejects.toMatchObject({
+      name: "LifedCreateSessionError",
+      code: "lifed-ws.create_session.fetch_failed",
+    });
+  });
+
+  it("throws on missing 'sid' in the response body", async () => {
+    const Cls = await importClient();
+    const stubFetch: typeof fetch = async () =>
+      new Response(JSON.stringify({ agent_id: "no-sid-here" }), {
+        status: 200,
+      });
+    const client = new Cls({
+      baseUrl: "https://lifegw.test",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    await expect(
+      client.createSession({
+        capability: { token: "t" },
+        userId: "alice",
+        projectSlug: "sentinel",
+      }),
+    ).rejects.toMatchObject({
+      code: "lifed-ws.create_session.missing_sid",
+    });
+  });
+
+  it("throws on non-JSON response with code='bad_response_body'", async () => {
+    const Cls = await importClient();
+    const stubFetch: typeof fetch = async () =>
+      new Response("not json at all", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      });
+    const client = new Cls({
+      baseUrl: "https://lifegw.test",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    await expect(
+      client.createSession({
+        capability: { token: "t" },
+        userId: "alice",
+        projectSlug: "sentinel",
+      }),
+    ).rejects.toMatchObject({
+      code: "lifed-ws.create_session.bad_response_body",
+    });
+  });
+
+  it("strips trailing slashes from baseUrl when constructing the URL", async () => {
+    const Cls = await importClient();
+    const captured: { url?: string } = {};
+    const stubFetch: typeof fetch = async (url) => {
+      captured.url = url as string;
+      return new Response(JSON.stringify({ sid: "x" }), { status: 200 });
+    };
+    const client = new Cls({
+      baseUrl: "https://lifegw.test///",
+      fetchFn: stubFetch,
+      // biome-ignore lint/suspicious/noExplicitAny: test-only factory
+      webSocketFactory: noopWsFactory as any,
+    });
+    await client.createSession({
+      capability: { token: "t" },
+      userId: "alice",
+      projectSlug: "sentinel",
+    });
+    expect(captured.url).toBe("https://lifegw.test/v1/agent/create_session");
+  });
+});
+
 describe("TRANSIENT_CLOSE_CODES", () => {
   it("includes the 4 codes Spec C₃ §6.5 marks as transient", () => {
     // 4002 — backpressure

--- a/apps/chat/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/chat/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -148,6 +148,39 @@ const TRANSIENT_CLOSE_CODES: ReadonlySet<number> = new Set([
 ]);
 
 // ---------------------------------------------------------------------------
+// Errors surfaced from the unary `createSession` helper. Stage 3a.
+// ---------------------------------------------------------------------------
+
+export interface LifedCreateSessionErrorOpts {
+  /** Stable error code — caller switches on this for retry policy. */
+  code: string;
+  /** Underlying cause for `.cause` chaining. */
+  cause?: unknown;
+  /** HTTP status when the failure came from a non-2xx response. */
+  httpStatus?: number;
+}
+
+/**
+ * Error thrown from `LifedWsAgentSessionClient.createSession`.
+ *
+ * Distinct from the `error` events the WS stream yields — this is a
+ * synchronous failure of the unary HTTP call (network, 4xx/5xx,
+ * malformed body). Callers translate it into a Prosopon
+ * envelope or a route-level 5xx response.
+ */
+export class LifedCreateSessionError extends Error {
+  readonly code: string;
+  readonly httpStatus?: number;
+
+  constructor(message: string, opts: LifedCreateSessionErrorOpts) {
+    super(message, { cause: opts.cause });
+    this.name = "LifedCreateSessionError";
+    this.code = opts.code;
+    this.httpStatus = opts.httpStatus;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
 
@@ -187,6 +220,109 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
     this.healthTimeoutMs = deps.healthTimeoutMs ?? 2_000;
     this.healthTokenProducer = deps.healthTokenProducer;
     this.fetchFn = deps.fetchFn ?? fetch;
+  }
+
+  /**
+   * Create a lifed-side session (Stage 3a — May 2026).
+   *
+   * lifed's `Agent.StreamSession` returns `not_found` when the sid
+   * isn't already in its routing cache. The cache populates only after
+   * a successful `Agent.CreateSession` (4-step saga: arcan create_agent
+   * + lago open_namespace + haima bind_wallet + anima register_session).
+   *
+   * This helper POSTs to lifegw's `/v1/agent/create_session` HTTP/JSON
+   * wrapper (see `core/life/crates/life-runtime/lifegw/src/services/agent_http.rs`).
+   * Callers (canonical runtime) invoke this BEFORE `stream()` and use
+   * the returned sid for the WS upgrade. The Tier-1 cap on `input.capability`
+   * authenticates the call; lifegw verifies it via the same JWKS the
+   * AuthLayer uses, mints a Tier-2 cap internally, and forwards to lifed.
+   */
+  async createSession(input: {
+    capability: { token: string };
+    userId: string;
+    projectSlug: string;
+    label?: string;
+    resumeSid?: string;
+    signal?: AbortSignal;
+  }): Promise<{
+    sid: string;
+    agentId: string;
+    userId: string;
+    projectId: string;
+    createdAtUnix: number;
+  }> {
+    const url = `${this.baseUrl}/v1/agent/create_session`;
+    const body: Record<string, unknown> = {
+      user_id: input.userId,
+      project_id: input.projectSlug,
+    };
+    if (input.label && input.label.length > 0) body.label = input.label;
+    if (input.resumeSid && input.resumeSid.length > 0)
+      body.resume_sid = input.resumeSid;
+    let resp: Response;
+    try {
+      resp = await this.fetchFn(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${input.capability.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: input.signal,
+      });
+    } catch (err) {
+      const e = err as Error;
+      throw new LifedCreateSessionError(
+        `network error reaching ${url}: ${e.message}`,
+        { code: "lifed-ws.create_session.fetch_failed", cause: e },
+      );
+    }
+    if (!resp.ok) {
+      let detail = "";
+      try {
+        detail = await resp.text();
+      } catch {
+        // swallow — surface the status code regardless
+      }
+      throw new LifedCreateSessionError(
+        `lifegw create_session returned HTTP ${resp.status}${
+          detail ? ` — ${detail.slice(0, 256)}` : ""
+        }`,
+        {
+          code: `lifed-ws.create_session.http_${resp.status}`,
+          httpStatus: resp.status,
+        },
+      );
+    }
+    let parsed: {
+      sid?: string;
+      agent_id?: string;
+      user_id?: string;
+      project_id?: string;
+      created_at_unix?: number;
+    };
+    try {
+      parsed = (await resp.json()) as typeof parsed;
+    } catch (err) {
+      const e = err as Error;
+      throw new LifedCreateSessionError(
+        `lifegw create_session returned non-JSON body: ${e.message}`,
+        { code: "lifed-ws.create_session.bad_response_body", cause: e },
+      );
+    }
+    if (!parsed.sid || parsed.sid.length === 0) {
+      throw new LifedCreateSessionError(
+        "lifegw create_session response missing 'sid'",
+        { code: "lifed-ws.create_session.missing_sid" },
+      );
+    }
+    return {
+      sid: parsed.sid,
+      agentId: parsed.agent_id ?? "",
+      userId: parsed.user_id ?? input.userId,
+      projectId: parsed.project_id ?? input.projectSlug,
+      createdAtUnix: parsed.created_at_unix ?? 0,
+    };
   }
 
   async health(): Promise<AgentSessionHealth> {

--- a/apps/chat/lib/life-runtime/canonical.ts
+++ b/apps/chat/lib/life-runtime/canonical.ts
@@ -194,9 +194,65 @@ export function createLifeRuntime(deps: LifeRuntimeDeps = {}): LifeRuntime {
             : `user:${input.consumer.id}`,
       };
 
+      // 3.5. Stage 3a (May 2026): for the lifed-ws backend, the WS
+      // upgrade lands on `Agent.StreamSession` which requires the sid
+      // to already exist in lifed's routing cache. The cache populates
+      // only after a successful `Agent.CreateSession`. lifed's
+      // routing-cache idle-eviction is 1h (configurable) so within a
+      // chat we'd ideally reuse the lifed sid — but persisting it is
+      // a separate concern (Stage 3a-bis); for now we mint a fresh
+      // lifed session per turn. The CreateSession saga is cheap
+      // against mock substrates (~1 ms) and well within budget against
+      // real ones (~100 ms).
+      //
+      // The InProcess backend is a no-op for this step — it doesn't
+      // route through lifegw and ignores the lifed sid.
+      let wsSid: string = lifeSession.id;
+      if (
+        sessionClient.backendId === "lifed-ws" &&
+        input.capability &&
+        typeof (
+          sessionClient as unknown as {
+            createSession?: (
+              x: unknown,
+            ) => Promise<{ sid: string }>;
+          }
+        ).createSession === "function"
+      ) {
+        const createSessionFn = (
+          sessionClient as unknown as {
+            createSession: (x: {
+              capability: { token: string };
+              userId: string;
+              projectSlug: string;
+              label?: string;
+            }) => Promise<{ sid: string }>;
+          }
+        ).createSession;
+        try {
+          const created = await createSessionFn({
+            capability: input.capability,
+            userId: input.consumer.id,
+            projectSlug: input.projectSlug,
+            label: lifeSession.id, // human-debuggable cross-ref
+          });
+          wsSid = created.sid;
+        } catch (err) {
+          // Surface the failure as a typed envelope rather than a 500
+          // — the route handler emits this through the SSE stream so
+          // the client can react. Falling back to the broomva-side
+          // `lifeSession.id` would just reproduce the boot-race
+          // "internal_error" we're trying to fix; better to fail loud.
+          const e = err as Error;
+          throw new Error(
+            `Failed to create lifed session before WS upgrade: ${e.message}`,
+          );
+        }
+      }
+
       // 4. Build the canonical event stream from the agent-session client.
       const canonicalStream = sessionClient.stream({
-        sessionId: lifeSession.id,
+        sessionId: wsSid,
         agentId: kernelCtx.agentId,
         projectSlug: input.projectSlug,
         userMessage: input.userMessage,


### PR DESCRIPTION
## Summary

The broomva.tech-side half of Stage 3a — pairs with [life#1089](https://github.com/broomva/life/pull/1089).

After Stage 2's boot-race fix landed, the WS smoke test still closed with \`{"kind":"closing","reason":"internal_error"}\`. Root cause: lifed's \`Agent.StreamSession\` returns \`not_found\` when the sid isn't in the routing cache, and lifegw maps that to a 1011 close. The cache populates only after \`Agent.CreateSession\` (the 4-step saga). broomva.tech's WS client opened the WS with the broomva.tech-side \`LifeSession.id\` without ever calling \`CreateSession\` first.

## What's added

- \`LifedWsAgentSessionClient.createSession({ capability, userId, projectSlug, label?, resumeSid? })\` — POSTs to \`\${baseUrl}/v1/agent/create_session\` (the new HTTP/JSON wrapper from life#1089), parses the JSON response, returns \`{ sid, agentId, userId, projectId, createdAtUnix }\`.

- \`LifedCreateSessionError\` — typed error class with stable \`code\` strings + optional \`httpStatus\` for caller retry logic:
  - \`lifed-ws.create_session.fetch_failed\` (network)
  - \`lifed-ws.create_session.http_<status>\` (4xx/5xx upstream)
  - \`lifed-ws.create_session.bad_response_body\` (non-JSON)
  - \`lifed-ws.create_session.missing_sid\` (200 with no sid)

- \`canonical.ts\` calls \`sessionClient.createSession()\` before \`stream()\` only when:
  - the active backend is \`lifed-ws\` (in-process is a no-op)
  - a Tier-1 capability is present
  - the client exposes the method (defensive — pre-Stage-3a deployments don't)

  …and uses the returned lifed sid for the WS handshake. broomva.tech's \`lifeSession.id\` is preserved for chat-row linking; the lifed sid is used only for the WS surface.

## Persistence

Not yet — Stage 3a-bis. We mint a fresh lifed session per turn. The CreateSession saga is cheap against mock substrates (~1 ms) and well within budget against real ones (~100 ms). Persistence becomes meaningful once Stage 3b lands real arcan substrate so the routing-cache entry carries useful state across turns.

## Test plan

- [x] 7 new vitest tests in \`lifed-ws-client.test.ts\` — wire shape (URL + body), optional field omission, 401/non-2xx → typed error with \`httpStatus\`, network-failure → \`fetch_failed\`, missing-sid → \`missing_sid\`, non-JSON → \`bad_response_body\`, baseUrl trailing-slash normalisation
- [x] Full vitest suite: 233/233 (was 226)
- [x] \`tsc --noEmit\` clean
- [x] \`biome lint\` clean
- [ ] After both PRs land + lifegw redeploys: smoke test shows \`internal_error\` is gone (mock-arcan canned \`Token\` + \`Finish\` flows back through the WS)

## Coordination

Land [life#1089](https://github.com/broomva/life/pull/1089) and redeploy lifegw on Railway **first** so the \`/v1/agent/create_session\` route exists when this PR's Vercel deploy goes live. The \`canonical.ts\` change is back-compat: it only calls \`createSession\` when the method is present on the client, so a lifegw without the route would just see the old \`internal_error\` regression — no worse than today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)