### PR TITLE
feat(cli): Phase 2 — Rust CLI telemetry integration

### DIFF
--- a/apps/chat/.claude/skills/broomva-cli/SKILL.md
+++ b/apps/chat/.claude/skills/broomva-cli/SKILL.md
@@ -1,41 +1,116 @@
 ---
 name: broomva-cli
 description: >
-  Reference for the @broomva/cli package — manage prompts, skills, and context
-  from the terminal or Claude Code sessions.
+  Reference for the `broomva` Rust CLI — manage prompts, skills, and context
+  from the terminal or Claude Code sessions. Includes the auto-tracing
+  protocol that turns this skill into the runtime dispatcher for
+  broomva.tech/prompts. When a user asks to "use the X prompt", "run the X
+  prompt as instructions", or "pull X prompt", this skill is the answer.
 triggers:
   - broomva cli
   - broomva prompts
+  - use the X prompt
+  - run the X prompt as instructions
+  - pull the X prompt
   - push prompt
   - pull prompt
 ---
 
-# @broomva/cli — Quick Reference
+# broomva — CLI Quick Reference
 
-The CLI lives at `packages/cli/` in the monorepo. Full docs: `packages/cli/SKILL.md`.
+Rust CLI at `~/.cargo/bin/broomva`, source at `crates/broomva-cli/` in the
+broomva.tech monorepo. Talks to `broomva.tech/api/*` (Phase 1 telemetry +
+existing prompts/skills/context endpoints).
 
-## Key Commands
+## Standard commands
 
 ```bash
-broomva prompts list [--mine] [--category X] [--json]
+broomva prompts list [--mine] [--category X] [--metrics] [--sort skill_invokes]
 broomva prompts get <slug> [--raw|--json]
-broomva prompts pull <slug> [-o file.md]
+broomva prompts pull <slug> [-o file.md] [--json]
 broomva prompts push file.md [--create]
 broomva skills list [--layer X]
 broomva context conventions
+broomva auth status
 ```
 
-## API Routes (this app)
+## Running prompts (auto-traced)
 
-- `GET /api/prompts` — list prompts
-- `GET /api/prompts/:slug` — get prompt
+**This is the contract that turns every prompt invocation into a typed
+row server-side.** Follow these five steps when the user asks for a
+prompt, or when you invoke a prompt as instructions during a task.
+
+1. **Set the source flag once per session:**
+   ```bash
+   export BROOMVA_SOURCE=skill
+   ```
+
+2. **Pull the prompt:**
+   ```bash
+   broomva prompts pull <slug> --json 2>&1 | tee /tmp/broomva-last.json
+   ```
+   The CLI writes the prompt to `<slug>.md` (or `-o path`) and emits a
+   JSON line on stderr: `{invocation_id, prompt_slug, prompt_version, posted}`.
+
+3. **Use the prompt body** in your reply / as the system instructions
+   for the work the user asked you to do.
+
+4. **MANDATORY: After completing the work the prompt asked for, call:**
+   ```bash
+   broomva prompts complete <invocation_id> \
+     --status completed \
+     --model <your-model-name> \
+     --latency-ms <wall-clock-ms> \
+     --tokens-in <input-tokens> \
+     --tokens-out <output-tokens>
+   ```
+   Use `--status failed` if the work could not be completed and include
+   `--error-message`. **This is how prompts get evaluated.** Skipping it
+   breaks the feedback loop.
+
+5. **Optional: capture explicit feedback** if the user gave a clear
+   thumbs up/down:
+   ```bash
+   broomva prompts feedback <invocation_id> --slug <slug> --signal up --text "user's words"
+   ```
+
+## Environment
+
+| Var | Purpose |
+|---|---|
+| `BROOMVA_TOKEN` | Auth (Bearer) — get from `https://broomva.tech/api/auth/api-token` |
+| `BROOMVA_SOURCE` | `cli` (default) / `skill` / `api`. Sets `source` on every invocation row. |
+| `BROOMVA_TELEMETRY_DISABLED=1` | Opt out — no rows are written. |
+| `BROOMVA_TELEMETRY_RAW_VARS=1` | Admin-only: send raw variable values instead of hashed. |
+| `BROOMVA_API_BASE` | Override API host (default `https://broomva.tech`). |
+| `BROOMVA_SESSION_PATH` | Override session-id cache path (default `~/.broomva/session`). Used by tests. |
+
+## API routes the CLI talks to
+
+- `GET /api/prompts[?include=metrics&sort=...]` — list (Phase 2 `?include=metrics`)
+- `GET /api/prompts/:slug[?include=metrics]` — get
 - `POST /api/prompts` — create (auth required)
 - `PUT /api/prompts/:slug` — update (auth required)
 - `DELETE /api/prompts/:slug` — delete (auth required)
-- `GET /api/skills` — list skills roster
-- `GET /api/skills/:slug` — get skill detail
+- `POST /api/invocations` — telemetry beacon (anonymous-OK, rate-limited per IP/user)
+- `PATCH /api/invocations/:id` — completion update (anonymous-OK if row has no user_id)
+- `POST /api/feedback` — explicit user signal (anonymous-OK)
+- `GET /api/feedback?prompt_slug=...&limit=...` — recent feedback
+- `GET /api/metrics/overview?since=24h|7d|30d|all` — hero KPI strip
+- `GET /api/metrics/runs?prompt_slug=&source=&limit=&before=` — paginated runs
+- `GET /api/metrics/volume?bucket=hour|day&since=24h|7d|30d` — timeseries
+- `GET /api/metrics/prompts/:slug` — per-prompt strip
+- `GET /api/skills` / `GET /api/skills/:slug` — skills roster
 - `GET /api/context` — project context + conventions
 
 ## Auth
 
-Bearer tokens from `/api/auth/api-token`. Resolution: `--token` > `BROOMVA_API_TOKEN` env > `~/.broomva/config.json`.
+Token resolution order: `--token` flag > `BROOMVA_TOKEN` env > `~/.broomva/config.json`.
+Run `broomva auth login` for the device-code flow, or `broomva auth login --manual` to paste a token.
+
+## Source attribution
+
+When this skill invokes the CLI inside Claude Code, it sets
+`BROOMVA_SOURCE=skill` before the pull, so the row carries
+`source='skill'` server-side. Terminal users default to `cli`.
+Programmatic callers wrapping the CLI should set `BROOMVA_SOURCE=api`.

--- a/crates/broomva-cli/Cargo.lock
+++ b/crates/broomva-cli/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "broomva"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/broomva-cli/Cargo.toml
+++ b/crates/broomva-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broomva"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88"
 license = "MIT"

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -317,6 +317,36 @@ impl BroomvaClient {
         Ok(resp.json().await?)
     }
 
+    /// List prompts with metrics enriched (`?include=metrics`).
+    /// Returns the raw JSON values so the caller can extract the
+    /// snake_case metrics block alongside the camelCase prompt summary.
+    pub async fn list_prompts_with_metrics(
+        &self,
+        category: Option<&str>,
+        tag: Option<&str>,
+        model: Option<&str>,
+        sort: Option<&str>,
+    ) -> BroomvaResult<Vec<serde_json::Value>> {
+        let mut req = self
+            .request(Method::GET, "/api/prompts")
+            .query(&[("include", "metrics")]);
+        if let Some(c) = category {
+            req = req.query(&[("category", c)]);
+        }
+        if let Some(t) = tag {
+            req = req.query(&[("tag", t)]);
+        }
+        if let Some(m) = model {
+            req = req.query(&[("model", m)]);
+        }
+        if let Some(s) = sort {
+            req = req.query(&[("sort", s)]);
+        }
+        let resp = req.send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
     #[allow(dead_code)]
     pub async fn get_metrics_volume(
         &self,

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -234,7 +234,6 @@ impl BroomvaClient {
         Ok(resp.json().await?)
     }
 
-    #[allow(dead_code)]
     pub async fn update_invocation(
         &self,
         id: &str,

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -221,7 +221,6 @@ impl BroomvaClient {
     // Batch B/C will wire them into commands. #[allow(dead_code)] suppresses
     // bin-target dead-code lints until those handlers land.
 
-    #[allow(dead_code)]
     pub async fn create_invocation(
         &self,
         req: &InvocationCreateRequest,

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -215,4 +215,327 @@ impl BroomvaClient {
         let resp = self.request(Method::GET, "/api/relay/nodes").send().await?;
         Ok(resp.status().is_success())
     }
+
+    // ── Invocations (Phase 2 telemetry) ──
+    // Methods below are exercised by telemetry_client_tests; CLI handlers in
+    // Batch B/C will wire them into commands. #[allow(dead_code)] suppresses
+    // bin-target dead-code lints until those handlers land.
+
+    #[allow(dead_code)]
+    pub async fn create_invocation(
+        &self,
+        req: &InvocationCreateRequest,
+    ) -> BroomvaResult<InvocationCreateResponse> {
+        let resp = self
+            .request(Method::POST, "/api/invocations")
+            .json(req)
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    #[allow(dead_code)]
+    pub async fn update_invocation(
+        &self,
+        id: &str,
+        req: &InvocationUpdateRequest,
+    ) -> BroomvaResult<InvocationRow> {
+        let resp = self
+            .request(Method::PATCH, &format!("/api/invocations/{id}"))
+            .json(req)
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    // ── Feedback (Phase 2 telemetry) ──
+
+    #[allow(dead_code)]
+    pub async fn create_feedback(
+        &self,
+        req: &FeedbackCreateRequest,
+    ) -> BroomvaResult<FeedbackCreateResponse> {
+        let resp = self
+            .request(Method::POST, "/api/feedback")
+            .json(req)
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    #[allow(dead_code)]
+    pub async fn list_feedback_for_prompt(
+        &self,
+        slug: &str,
+        limit: Option<u32>,
+    ) -> BroomvaResult<Vec<FeedbackRow>> {
+        let mut req = self.request(Method::GET, "/api/feedback");
+        req = req.query(&[("prompt_slug", slug)]);
+        if let Some(n) = limit {
+            req = req.query(&[("limit", n.to_string())]);
+        }
+        let resp = req.send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    // ── Metrics (Phase 2 telemetry) ──
+
+    #[allow(dead_code)]
+    pub async fn get_metrics_overview(
+        &self,
+        since: Option<&str>,
+    ) -> BroomvaResult<MetricsOverview> {
+        let mut req = self.request(Method::GET, "/api/metrics/overview");
+        if let Some(s) = since {
+            req = req.query(&[("since", s)]);
+        }
+        let resp = req.send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    #[allow(dead_code)]
+    pub async fn list_recent_invocations(
+        &self,
+        prompt_slug: Option<&str>,
+        source: Option<&str>,
+        limit: Option<u32>,
+    ) -> BroomvaResult<Vec<InvocationRow>> {
+        let mut req = self.request(Method::GET, "/api/metrics/runs");
+        if let Some(s) = prompt_slug {
+            req = req.query(&[("prompt_slug", s)]);
+        }
+        if let Some(s) = source {
+            req = req.query(&[("source", s)]);
+        }
+        if let Some(n) = limit {
+            req = req.query(&[("limit", n.to_string())]);
+        }
+        let resp = req.send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_metrics_volume(
+        &self,
+        bucket: &str,
+        since: &str,
+    ) -> BroomvaResult<Vec<VolumeBucketRow>> {
+        let resp = self
+            .request(Method::GET, "/api/metrics/volume")
+            .query(&[("bucket", bucket), ("since", since)])
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_metrics_for_slug(&self, slug: &str) -> BroomvaResult<PromptMetrics> {
+        let resp = self
+            .request(Method::GET, &format!("/api/metrics/prompts/{slug}"))
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+}
+
+#[cfg(test)]
+mod telemetry_client_tests {
+    use super::*;
+    use wiremock::matchers::{method, path, header, body_partial_json};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use serde_json::json;
+
+    fn test_client(base: String) -> BroomvaClient {
+        BroomvaClient::new(base, Some("test-token".into()))
+    }
+
+    #[tokio::test]
+    async fn create_invocation_posts_and_returns_id() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/invocations"))
+            .and(header("Authorization", "Bearer test-token"))
+            .and(body_partial_json(json!({
+                "prompt_slug": "code-review-agent",
+                "source": "cli"
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "id": "abc-123",
+                "created_at": "2026-05-11T00:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(server.uri());
+        let req = InvocationCreateRequest {
+            id: None,
+            prompt_slug: "code-review-agent".into(),
+            prompt_version: "1.0".into(),
+            source: "cli".into(),
+            caller: Some("broomva-cli/0.3.0".into()),
+            session_id: None,
+            variables: None,
+            metadata: None,
+        };
+        let resp = client.create_invocation(&req).await.unwrap();
+        assert_eq!(resp.id, "abc-123");
+    }
+
+    #[tokio::test]
+    async fn update_invocation_patches() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/api/invocations/abc-123"))
+            .and(body_partial_json(json!({"status": "completed"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "abc-123",
+                "prompt_slug": "x",
+                "prompt_version": "1.0",
+                "source": "cli",
+                "caller": null,
+                "user_id": null,
+                "agent_id": null,
+                "session_id": null,
+                "client_ip_hash": null,
+                "variables": null,
+                "status": "completed",
+                "model": "claude-sonnet-4.5",
+                "latency_ms": 100,
+                "tokens_in": 10,
+                "tokens_out": 20,
+                "cost_usd": 0.001,
+                "error_message": null,
+                "external_trace_id": null,
+                "external_span_id": null,
+                "metadata": null,
+                "created_at": "2026-05-11T00:00:00Z",
+                "completed_at": "2026-05-11T00:00:01Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(server.uri());
+        let req = InvocationUpdateRequest {
+            status: "completed".into(),
+            model: Some("claude-sonnet-4.5".into()),
+            latency_ms: Some(100),
+            tokens_in: Some(10),
+            tokens_out: Some(20),
+            error_message: None,
+        };
+        let row = client.update_invocation("abc-123", &req).await.unwrap();
+        assert_eq!(row.status, "completed");
+        assert_eq!(row.model.as_deref(), Some("claude-sonnet-4.5"));
+    }
+
+    #[tokio::test]
+    async fn create_feedback_posts() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/feedback"))
+            .and(body_partial_json(json!({"signal": "thumbs_up"})))
+            .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+                "id": "fb-1",
+                "created_at": "2026-05-11T00:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(server.uri());
+        let req = FeedbackCreateRequest {
+            invocation_id: Some("abc".into()),
+            prompt_slug: "x".into(),
+            prompt_version: "1.0".into(),
+            signal: "thumbs_up".into(),
+            text: None,
+            source: "cli".into(),
+        };
+        let resp = client.create_feedback(&req).await.unwrap();
+        assert_eq!(resp.id, "fb-1");
+    }
+
+    #[tokio::test]
+    async fn get_metrics_overview_returns_typed_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/metrics/overview"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "since": "7d",
+                "as_of": "2026-05-11T00:00:00Z",
+                "last_invocation_at": null,
+                "totals": {"prompts":29,"copies":100,"cli_pulls":50,"skill_invokes":200,"traces":350,"runs_7d":350},
+                "deltas_vs_prev": {"copies":0.1,"cli_pulls":0.2,"skill_invokes":0.3,"traces":0.2},
+                "live_failures_1h": 3
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(server.uri());
+        let m = client.get_metrics_overview(Some("7d")).await.unwrap();
+        assert_eq!(m.totals.prompts, 29);
+        assert_eq!(m.live_failures_1h, 3);
+    }
+
+    #[tokio::test]
+    async fn get_metrics_for_slug_returns_shape() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/metrics/prompts/code-review-agent"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "totals": {"copies":10,"cli_pulls":5,"skill_invokes":20,"traces":35},
+                "runs_7d": 12,
+                "delta_pct": 0.0,
+                "last_used_at": null,
+                "avg_latency_ms": null,
+                "avg_cost_usd": null,
+                "feedback": {"thumbs_up":3,"thumbs_down":1,"rate":0.75},
+                "timeseries": {"pass_rate_7d_by_day":null,"volume_7d_by_day":[]}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(server.uri());
+        let m = client.get_metrics_for_slug("code-review-agent").await.unwrap();
+        assert_eq!(m.totals.skill_invokes, 20);
+        assert!((m.feedback.rate.unwrap() - 0.75).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn create_invocation_swallows_429_into_typed_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/invocations"))
+            .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                "error": "Rate limit exceeded",
+                "code": "rate_limited"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = test_client(server.uri());
+        let req = InvocationCreateRequest {
+            id: None,
+            prompt_slug: "x".into(),
+            prompt_version: "1.0".into(),
+            source: "cli".into(),
+            caller: None,
+            session_id: None,
+            variables: None,
+            metadata: None,
+        };
+        let result = client.create_invocation(&req).await;
+        assert!(result.is_err(), "expected error, got {:?}", result);
+        match result.unwrap_err() {
+            BroomvaError::Api { status, .. } => assert_eq!(status, 429),
+            other => panic!("expected Api err, got {other:?}"),
+        }
+    }
 }

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -250,7 +250,6 @@ impl BroomvaClient {
 
     // ── Feedback (Phase 2 telemetry) ──
 
-    #[allow(dead_code)]
     pub async fn create_feedback(
         &self,
         req: &FeedbackCreateRequest,

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -81,7 +81,10 @@ pub struct UpdatePromptRequest {
 }
 
 // ── Invocations (Phase 2 telemetry) ──
+// Some structs below are consumed only by tests in Batch A; CLI wiring in
+// subsequent batches will exercise them. Suppress dead-code until then.
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationCreateRequest {
@@ -100,6 +103,7 @@ pub struct InvocationCreateRequest {
     pub metadata: Option<serde_json::Value>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationCreateResponse {
@@ -107,6 +111,7 @@ pub struct InvocationCreateResponse {
     pub created_at: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationUpdateRequest {
@@ -123,6 +128,7 @@ pub struct InvocationUpdateRequest {
     pub error_message: Option<String>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationRow {
@@ -152,6 +158,7 @@ pub struct InvocationRow {
 
 // ── Feedback (Phase 2 telemetry) ──
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct FeedbackCreateRequest {
@@ -165,6 +172,7 @@ pub struct FeedbackCreateRequest {
     pub source: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct FeedbackCreateResponse {
@@ -172,6 +180,7 @@ pub struct FeedbackCreateResponse {
     pub created_at: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct FeedbackRow {
@@ -188,6 +197,7 @@ pub struct FeedbackRow {
 
 // ── Metrics responses (Phase 2 telemetry) ──
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct MetricsTotals {
@@ -199,6 +209,7 @@ pub struct MetricsTotals {
     pub runs_7d: i64,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct MetricsDeltas {
@@ -208,6 +219,7 @@ pub struct MetricsDeltas {
     pub traces: f64,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct MetricsOverview {
@@ -219,6 +231,7 @@ pub struct MetricsOverview {
     pub live_failures_1h: i64,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct VolumeBucketRow {
@@ -227,6 +240,7 @@ pub struct VolumeBucketRow {
     pub by_source: serde_json::Value,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct PromptMetricTotals {
@@ -236,6 +250,7 @@ pub struct PromptMetricTotals {
     pub traces: i64,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct PromptFeedbackSummary {
@@ -244,6 +259,7 @@ pub struct PromptFeedbackSummary {
     pub rate: Option<f64>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct PromptMetrics {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -156,7 +156,6 @@ pub struct InvocationRow {
 
 // ── Feedback (Phase 2 telemetry) ──
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct FeedbackCreateRequest {
@@ -170,7 +169,6 @@ pub struct FeedbackCreateRequest {
     pub source: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct FeedbackCreateResponse {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -111,7 +111,6 @@ pub struct InvocationCreateResponse {
     pub created_at: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationUpdateRequest {
@@ -128,7 +127,6 @@ pub struct InvocationUpdateRequest {
     pub error_message: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationRow {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -26,6 +26,7 @@ pub struct PromptDetail {
     pub summary: Option<String>,
     pub category: Option<String>,
     pub model: Option<String>,
+    pub version: Option<String>,
     pub tags: Option<Vec<String>>,
     pub visibility: Option<String>,
     pub created_at: Option<String>,

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -84,7 +84,6 @@ pub struct UpdatePromptRequest {
 // Some structs below are consumed only by tests in Batch A; CLI wiring in
 // subsequent batches will exercise them. Suppress dead-code until then.
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct InvocationCreateRequest {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -80,6 +80,182 @@ pub struct UpdatePromptRequest {
     pub visibility: Option<String>,
 }
 
+// ── Invocations (Phase 2 telemetry) ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct InvocationCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub prompt_slug: String,
+    pub prompt_version: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caller: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variables: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct InvocationCreateResponse {
+    pub id: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct InvocationUpdateRequest {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens_in: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens_out: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct InvocationRow {
+    pub id: String,
+    pub prompt_slug: String,
+    pub prompt_version: String,
+    pub source: String,
+    pub caller: Option<String>,
+    pub user_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub session_id: Option<String>,
+    pub client_ip_hash: Option<String>,
+    pub variables: Option<serde_json::Value>,
+    pub status: String,
+    pub model: Option<String>,
+    pub latency_ms: Option<i64>,
+    pub tokens_in: Option<i64>,
+    pub tokens_out: Option<i64>,
+    pub cost_usd: Option<f64>,
+    pub error_message: Option<String>,
+    pub external_trace_id: Option<String>,
+    pub external_span_id: Option<String>,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+}
+
+// ── Feedback (Phase 2 telemetry) ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FeedbackCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invocation_id: Option<String>,
+    pub prompt_slug: String,
+    pub prompt_version: String,
+    pub signal: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FeedbackCreateResponse {
+    pub id: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FeedbackRow {
+    pub id: String,
+    pub invocation_id: Option<String>,
+    pub prompt_slug: String,
+    pub prompt_version: String,
+    pub user_id: Option<String>,
+    pub signal: String,
+    pub text: Option<String>,
+    pub source: String,
+    pub created_at: String,
+}
+
+// ── Metrics responses (Phase 2 telemetry) ──
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MetricsTotals {
+    pub prompts: i64,
+    pub copies: i64,
+    pub cli_pulls: i64,
+    pub skill_invokes: i64,
+    pub traces: i64,
+    pub runs_7d: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MetricsDeltas {
+    pub copies: f64,
+    pub cli_pulls: f64,
+    pub skill_invokes: f64,
+    pub traces: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct MetricsOverview {
+    pub since: String,
+    pub as_of: String,
+    pub last_invocation_at: Option<String>,
+    pub totals: MetricsTotals,
+    pub deltas_vs_prev: MetricsDeltas,
+    pub live_failures_1h: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct VolumeBucketRow {
+    pub ts: String,
+    pub count: i64,
+    pub by_source: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PromptMetricTotals {
+    pub copies: i64,
+    pub cli_pulls: i64,
+    pub skill_invokes: i64,
+    pub traces: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PromptFeedbackSummary {
+    pub thumbs_up: i64,
+    pub thumbs_down: i64,
+    pub rate: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PromptMetrics {
+    pub totals: PromptMetricTotals,
+    pub runs_7d: i64,
+    pub delta_pct: f64,
+    pub last_used_at: Option<String>,
+    pub avg_latency_ms: Option<i64>,
+    pub avg_cost_usd: Option<f64>,
+    pub feedback: PromptFeedbackSummary,
+}
+
 // ── Skills ──
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,4 +379,99 @@ pub struct ApiResponse<T> {
 pub struct ApiListResponse<T> {
     pub data: Option<Vec<T>>,
     pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod telemetry_types_tests {
+    use super::*;
+
+    #[test]
+    fn invocation_create_serializes_snake_case() {
+        let req = InvocationCreateRequest {
+            id: Some("9f8e7d6c-1111-4222-8333-444444444444".into()),
+            prompt_slug: "code-review-agent".into(),
+            prompt_version: "1.0".into(),
+            source: "cli".into(),
+            caller: Some("broomva-cli/0.3.0".into()),
+            session_id: Some("11111111-2222-4333-8444-555555555555".into()),
+            variables: None,
+            metadata: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"prompt_slug\":\"code-review-agent\""), "got: {json}");
+        assert!(json.contains("\"prompt_version\":\"1.0\""), "got: {json}");
+        assert!(json.contains("\"session_id\""), "got: {json}");
+    }
+
+    #[test]
+    fn invocation_create_response_deserializes_snake_case() {
+        let body = r#"{"id":"abc-123","created_at":"2026-05-11T00:00:00Z"}"#;
+        let resp: InvocationCreateResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(resp.id, "abc-123");
+        assert_eq!(resp.created_at, "2026-05-11T00:00:00Z");
+    }
+
+    #[test]
+    fn invocation_row_deserializes_full_shape() {
+        let body = r#"{
+            "id":"abc-123",
+            "prompt_slug":"x",
+            "prompt_version":"1.0",
+            "source":"cli",
+            "caller":null,
+            "user_id":null,
+            "agent_id":null,
+            "session_id":null,
+            "client_ip_hash":null,
+            "variables":null,
+            "status":"completed",
+            "model":"claude-sonnet-4.5",
+            "latency_ms":11200,
+            "tokens_in":1000,
+            "tokens_out":500,
+            "cost_usd":0.0105,
+            "error_message":null,
+            "external_trace_id":null,
+            "external_span_id":null,
+            "metadata":null,
+            "created_at":"2026-05-11T00:00:00Z",
+            "completed_at":"2026-05-11T00:00:01Z"
+        }"#;
+        let row: InvocationRow = serde_json::from_str(body).unwrap();
+        assert_eq!(row.status, "completed");
+        assert_eq!(row.model.as_deref(), Some("claude-sonnet-4.5"));
+        assert_eq!(row.latency_ms, Some(11200));
+        assert!((row.cost_usd.unwrap() - 0.0105).abs() < 1e-9);
+    }
+
+    #[test]
+    fn feedback_create_request_serializes() {
+        let req = FeedbackCreateRequest {
+            invocation_id: Some("abc".into()),
+            prompt_slug: "x".into(),
+            prompt_version: "1.0".into(),
+            signal: "thumbs_up".into(),
+            text: Some("nice".into()),
+            source: "cli".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"invocation_id\":\"abc\""));
+        assert!(json.contains("\"signal\":\"thumbs_up\""));
+    }
+
+    #[test]
+    fn metrics_overview_deserializes() {
+        let body = r#"{
+            "since":"7d",
+            "as_of":"2026-05-11T00:00:00Z",
+            "last_invocation_at":"2026-05-11T00:00:00Z",
+            "totals":{"prompts":29,"copies":100,"cli_pulls":50,"skill_invokes":200,"traces":350,"runs_7d":350},
+            "deltas_vs_prev":{"copies":0.1,"cli_pulls":0.2,"skill_invokes":0.3,"traces":0.2},
+            "live_failures_1h":3
+        }"#;
+        let m: MetricsOverview = serde_json::from_str(body).unwrap();
+        assert_eq!(m.totals.prompts, 29);
+        assert_eq!(m.totals.skill_invokes, 200);
+        assert_eq!(m.live_failures_1h, 3);
+    }
 }

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -166,12 +166,18 @@ pub enum PromptsCommand {
     },
     /// Delete a prompt.
     Delete { slug: String },
-    /// Pull a prompt to a local file.
+    /// Pull a prompt to a local file. Fires a telemetry invocation
+    /// beacon by default; pass `--json` to emit a machine-readable line
+    /// on stderr with the invocation id (used by the Claude Code skill).
     Pull {
         slug: String,
-        /// Output file path.
+        /// Output file path. Omit to write to `<slug>.md` in cwd.
         #[arg(short, long)]
         output: Option<String>,
+        /// Emit a machine-readable JSON line on stderr containing
+        /// {invocation_id, prompt_slug, prompt_version, posted}.
+        #[arg(long)]
+        json: bool,
     },
     /// Push a local file as a prompt.
     Push {
@@ -412,8 +418,8 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                 prompts::handle_update(&client, &slug, req, format).await
             }
             PromptsCommand::Delete { slug } => prompts::handle_delete(&client, &slug).await,
-            PromptsCommand::Pull { slug, output } => {
-                prompts::handle_pull(&client, &slug, output.as_deref()).await
+            PromptsCommand::Pull { slug, output, json } => {
+                prompts::handle_pull(&client, &slug, output.as_deref(), json).await
             }
             PromptsCommand::Push { file, create } => {
                 prompts::handle_push(&client, &file, create, format).await

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -121,6 +121,12 @@ pub enum PromptsCommand {
         model: Option<String>,
         #[arg(long)]
         mine: bool,
+        /// Include per-prompt metric counts (copies/cli/skill/runs_7d).
+        #[arg(long)]
+        metrics: bool,
+        /// Sort by metric (requires --metrics).
+        #[arg(long, value_parser = ["skill_invokes", "cli_pulls", "copies", "runs_7d"])]
+        sort: Option<String>,
     },
     /// Get a prompt by slug.
     Get {
@@ -399,6 +405,8 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                 tag,
                 model,
                 mine,
+                metrics,
+                sort,
             } => {
                 prompts::handle_list(
                     &client,
@@ -406,6 +414,8 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                     tag.as_deref(),
                     model.as_deref(),
                     mine,
+                    metrics,
+                    sort.as_deref(),
                     format,
                 )
                 .await

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -187,6 +187,32 @@ pub enum PromptsCommand {
         #[arg(long)]
         create: bool,
     },
+    /// Mark a prior invocation as completed (or failed/abandoned). The
+    /// invocation id is the one printed by `broomva prompts pull` (or
+    /// emitted on stderr in `--json` mode).
+    Complete {
+        /// Invocation id (UUID v4) returned from `prompts pull`.
+        invocation_id: String,
+        /// Final status. Default: completed.
+        #[arg(long, default_value = "completed", value_parser = ["completed", "failed", "abandoned"])]
+        status: String,
+        /// Model identifier (e.g. `claude-sonnet-4.5`). Required when
+        /// status=completed for cost computation.
+        #[arg(long)]
+        model: Option<String>,
+        /// Wall-clock latency in milliseconds.
+        #[arg(long)]
+        latency_ms: Option<i64>,
+        /// Input token count.
+        #[arg(long)]
+        tokens_in: Option<i64>,
+        /// Output token count.
+        #[arg(long)]
+        tokens_out: Option<i64>,
+        /// Required when status=failed.
+        #[arg(long)]
+        error_message: Option<String>,
+    },
 }
 
 // ── Skills ──
@@ -423,6 +449,28 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
             }
             PromptsCommand::Push { file, create } => {
                 prompts::handle_push(&client, &file, create, format).await
+            }
+            PromptsCommand::Complete {
+                invocation_id,
+                status,
+                model,
+                latency_ms,
+                tokens_in,
+                tokens_out,
+                error_message,
+            } => {
+                prompts::handle_complete(
+                    &client,
+                    &invocation_id,
+                    &status,
+                    model.as_deref(),
+                    latency_ms,
+                    tokens_in,
+                    tokens_out,
+                    error_message.as_deref(),
+                    format,
+                )
+                .await
             }
         },
         Command::Skills { action } => match action {

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -213,6 +213,23 @@ pub enum PromptsCommand {
         #[arg(long)]
         error_message: Option<String>,
     },
+    /// Leave thumbs-up/down feedback on a prompt invocation.
+    Feedback {
+        /// Invocation id. Omit to leave detached feedback (use --slug then).
+        invocation_id: Option<String>,
+        /// Explicitly target a slug. Required for detached feedback.
+        #[arg(long)]
+        slug: Option<String>,
+        /// Prompt version (for detached feedback). Defaults to "unknown".
+        #[arg(long, default_value = "unknown")]
+        version: String,
+        /// Thumbs direction.
+        #[arg(long, value_parser = ["up", "down"])]
+        signal: String,
+        /// Optional freeform note (max 2000 chars).
+        #[arg(long)]
+        text: Option<String>,
+    },
 }
 
 // ── Skills ──
@@ -468,6 +485,24 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                     tokens_in,
                     tokens_out,
                     error_message.as_deref(),
+                    format,
+                )
+                .await
+            }
+            PromptsCommand::Feedback {
+                invocation_id,
+                slug,
+                version,
+                signal,
+                text,
+            } => {
+                prompts::handle_feedback(
+                    &client,
+                    invocation_id.as_deref(),
+                    slug.as_deref(),
+                    &version,
+                    &signal,
+                    text.as_deref(),
                     format,
                 )
                 .await

--- a/crates/broomva-cli/src/cli/prompts.rs
+++ b/crates/broomva-cli/src/cli/prompts.rs
@@ -298,6 +298,62 @@ pub async fn handle_complete(
     Ok(())
 }
 
+pub async fn handle_feedback(
+    client: &BroomvaClient,
+    invocation_id: Option<&str>,
+    slug: Option<&str>,
+    version: &str,
+    signal: &str,
+    text: Option<&str>,
+    format: OutputFormat,
+) -> BroomvaResult<()> {
+    // Resolve the slug. For attached feedback (with invocation_id), --slug
+    // is currently required because there's no GET /api/invocations/[id]
+    // endpoint exposed in the CLI yet (Phase 2.1 follow-up). For detached
+    // feedback, --slug is mandatory.
+    let resolved_slug = match (invocation_id, slug) {
+        (Some(_id), Some(s)) => s.to_string(),
+        (Some(id), None) => {
+            return Err(BroomvaError::User(format!(
+                "feedback on invocation {id} requires --slug (detached lookup not yet wired)"
+            )));
+        }
+        (None, Some(s)) => s.to_string(),
+        (None, None) => {
+            return Err(BroomvaError::User(
+                "either invocation_id or --slug is required".into(),
+            ));
+        }
+    };
+
+    let normalized_signal = match signal {
+        "up" => "thumbs_up",
+        "down" => "thumbs_down",
+        other => {
+            return Err(BroomvaError::User(format!(
+                "invalid signal {other} (use up|down)"
+            )));
+        }
+    };
+
+    let req = crate::api::types::FeedbackCreateRequest {
+        invocation_id: invocation_id.map(|s| s.to_string()),
+        prompt_slug: resolved_slug,
+        prompt_version: version.to_string(),
+        signal: normalized_signal.to_string(),
+        text: text.map(|s| s.to_string()),
+        source: crate::telemetry::source::detect_source().as_str().to_string(),
+    };
+
+    let resp = client.create_feedback(&req).await?;
+    if format == OutputFormat::Json {
+        print_json(&resp);
+    } else {
+        println!("  Recorded feedback: {} ({})", resp.id, normalized_signal);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -485,6 +541,55 @@ mod tests {
             None,
             None,
             None,
+            None,
+            crate::cli::output::OutputFormat::Table,
+        )
+        .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn feedback_attached_with_slug_posts() {
+        let _env_guard = crate::telemetry::TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/feedback"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "fb-1",
+                "created_at": "2026-05-11T00:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = handle_feedback(
+            &client,
+            Some("abc-123"),
+            Some("x"),
+            "1.0",
+            "up",
+            Some("nice"),
+            crate::cli::output::OutputFormat::Table,
+        )
+        .await;
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn feedback_detached_no_slug_rejects_locally() {
+        let _env_guard = crate::telemetry::TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        let server = MockServer::start().await;
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = handle_feedback(
+            &client,
+            None,
+            None,
+            "1.0",
+            "down",
             None,
             crate::cli::output::OutputFormat::Table,
         )

--- a/crates/broomva-cli/src/cli/prompts.rs
+++ b/crates/broomva-cli/src/cli/prompts.rs
@@ -171,7 +171,7 @@ pub async fn handle_pull(
         let line = serde_json::json!({
             "invocation_id": beacon.id,
             "prompt_slug": slug,
-            "prompt_version": version,
+            "prompt_version": prompt.version,
             "posted": beacon.posted,
         });
         eprintln!("{line}");
@@ -265,13 +265,42 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    /// RAII guard that restores an env var on drop — panic-safe so a failing
+    /// assertion can't leak state into sibling tests.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn pull_fires_telemetry_beacon_after_get() {
         // Tokio test runs on a single-threaded runtime; holding the lock
         // across awaits serializes tests that touch BROOMVA_* env vars
         // without risking deadlock on another worker thread.
-        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+        let _env_guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+        let session_tmp = tempdir().unwrap();
+        let session_path = session_tmp.path().join("session");
+        let _session_guard =
+            EnvGuard::set("BROOMVA_SESSION_PATH", &session_path.to_string_lossy());
+
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/api/prompts/code-review-agent"))
@@ -313,11 +342,15 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn pull_with_telemetry_disabled_still_writes_file() {
-        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
-        // Set the env var for this test. BROOMVA_TELEMETRY_DISABLED is
-        // read fresh in beacon::post_invocation_beacon so the disable
-        // takes effect immediately.
-        unsafe { std::env::set_var("BROOMVA_TELEMETRY_DISABLED", "1") };
+        let _env_guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+        let session_tmp = tempdir().unwrap();
+        let session_path = session_tmp.path().join("session");
+        let _session_guard =
+            EnvGuard::set("BROOMVA_SESSION_PATH", &session_path.to_string_lossy());
+        // BROOMVA_TELEMETRY_DISABLED is read fresh in
+        // beacon::post_invocation_beacon so the disable takes effect
+        // immediately. The guard restores the var on drop — panic-safe.
+        let _disabled_guard = EnvGuard::set("BROOMVA_TELEMETRY_DISABLED", "1");
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -342,7 +375,5 @@ mod tests {
         let dest = tmp.path().join("out.md");
         let result = handle_pull(&client, "x", Some(dest.to_str().unwrap()), false).await;
         assert!(result.is_ok(), "{result:?}");
-
-        unsafe { std::env::remove_var("BROOMVA_TELEMETRY_DISABLED") };
     }
 }

--- a/crates/broomva-cli/src/cli/prompts.rs
+++ b/crates/broomva-cli/src/cli/prompts.rs
@@ -257,6 +257,47 @@ pub async fn handle_push(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_complete(
+    client: &BroomvaClient,
+    invocation_id: &str,
+    status: &str,
+    model: Option<&str>,
+    latency_ms: Option<i64>,
+    tokens_in: Option<i64>,
+    tokens_out: Option<i64>,
+    error_message: Option<&str>,
+    format: OutputFormat,
+) -> BroomvaResult<()> {
+    // Local validation: failed status MUST have an error_message
+    if status == "failed" && error_message.is_none() {
+        return Err(BroomvaError::User(
+            "--error-message required when --status=failed".into(),
+        ));
+    }
+
+    let req = crate::api::types::InvocationUpdateRequest {
+        status: status.to_string(),
+        model: model.map(|s| s.to_string()),
+        latency_ms,
+        tokens_in,
+        tokens_out,
+        error_message: error_message.map(|s| s.to_string()),
+    };
+
+    let row = client.update_invocation(invocation_id, &req).await?;
+
+    if format == OutputFormat::Json {
+        print_json(&row);
+    } else {
+        println!("  Completed invocation: {} ({})", row.id, row.status);
+        if let Some(cost) = row.cost_usd {
+            println!("    cost: ${cost:.6}");
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -375,5 +416,79 @@ mod tests {
         let dest = tmp.path().join("out.md");
         let result = handle_pull(&client, "x", Some(dest.to_str().unwrap()), false).await;
         assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn complete_with_pass_status_calls_patch() {
+        let _env_guard = crate::telemetry::TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path("/api/invocations/abc-123"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": "abc-123",
+                "prompt_slug": "x",
+                "prompt_version": "1.0",
+                "source": "cli",
+                "caller": null,
+                "user_id": null,
+                "agent_id": null,
+                "session_id": null,
+                "client_ip_hash": null,
+                "variables": null,
+                "status": "completed",
+                "model": "claude-sonnet-4.5",
+                "latency_ms": 1000,
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "cost_usd": 0.001,
+                "error_message": null,
+                "external_trace_id": null,
+                "external_span_id": null,
+                "metadata": null,
+                "created_at": "2026-05-11T00:00:00Z",
+                "completed_at": "2026-05-11T00:00:01Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = handle_complete(
+            &client,
+            "abc-123",
+            "completed",
+            Some("claude-sonnet-4.5"),
+            Some(1000),
+            Some(100),
+            Some(50),
+            None,
+            crate::cli::output::OutputFormat::Table,
+        )
+        .await;
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn complete_failed_without_error_message_rejects_locally() {
+        let _env_guard = crate::telemetry::TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        let server = MockServer::start().await;
+        // No mock needed — the rejection should happen before any HTTP call
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = handle_complete(
+            &client,
+            "abc-123",
+            "failed",
+            None,
+            None,
+            None,
+            None,
+            None,
+            crate::cli::output::OutputFormat::Table,
+        )
+        .await;
+        assert!(result.is_err());
     }
 }

--- a/crates/broomva-cli/src/cli/prompts.rs
+++ b/crates/broomva-cli/src/cli/prompts.rs
@@ -7,39 +7,100 @@ use crate::cli::output::{OutputFormat, print_json, print_kv, print_table};
 use crate::error::{BroomvaError, BroomvaResult};
 use crate::frontmatter;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_list(
     client: &BroomvaClient,
     category: Option<&str>,
     tag: Option<&str>,
     model: Option<&str>,
     mine: bool,
+    metrics: bool,
+    sort: Option<&str>,
     format: OutputFormat,
 ) -> BroomvaResult<()> {
-    let prompts = client.list_prompts(category, tag, model, mine).await?;
-
-    if format == OutputFormat::Json {
-        print_json(&prompts);
+    // Standard list path
+    if !metrics {
+        let prompts = client.list_prompts(category, tag, model, mine).await?;
+        if format == OutputFormat::Json {
+            print_json(&prompts);
+            return Ok(());
+        }
+        let rows: Vec<Vec<String>> = prompts
+            .iter()
+            .map(|p| {
+                vec![
+                    p.slug.clone(),
+                    p.title.clone(),
+                    p.category.clone().unwrap_or_default(),
+                    p.model.clone().unwrap_or_default(),
+                    p.visibility.clone().unwrap_or_default(),
+                ]
+            })
+            .collect();
+        print_table(
+            &["slug", "title", "category", "model", "visibility"],
+            &rows,
+            format,
+        );
         return Ok(());
     }
 
-    let rows: Vec<Vec<String>> = prompts
+    // Metrics-enriched path — server returns the prompt list wrapper +
+    // snake_case `metrics` block per item.
+    let entries = client
+        .list_prompts_with_metrics(category, tag, model, sort)
+        .await?;
+
+    if format == OutputFormat::Json {
+        print_json(&entries);
+        return Ok(());
+    }
+
+    let rows: Vec<Vec<String>> = entries
         .iter()
-        .map(|p| {
+        .map(|e| {
+            let slug = e.get("slug").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let title = e.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let category = e
+                .get("category")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let m = e.get("metrics");
+            let copies = m
+                .and_then(|x| x.get("copies"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let cli = m
+                .and_then(|x| x.get("cli_pulls"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let skill = m
+                .and_then(|x| x.get("skill_invokes"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let runs7 = m
+                .and_then(|x| x.get("runs_7d"))
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
             vec![
-                p.slug.clone(),
-                p.title.clone(),
-                p.category.clone().unwrap_or_default(),
-                p.model.clone().unwrap_or_default(),
-                p.visibility.clone().unwrap_or_default(),
+                slug,
+                title,
+                category,
+                copies.to_string(),
+                cli.to_string(),
+                skill.to_string(),
+                runs7.to_string(),
             ]
         })
         .collect();
 
     print_table(
-        &["slug", "title", "category", "model", "visibility"],
+        &["slug", "title", "category", "copies", "cli", "skill", "runs7d"],
         &rows,
         format,
     );
+
     Ok(())
 }
 
@@ -595,5 +656,47 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn list_with_metrics_renders_extra_columns() {
+        let _env_guard = crate::telemetry::TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/prompts"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "slug": "code-review-agent",
+                    "title": "Code Review Agent",
+                    "category": "system-prompts",
+                    "model": "claude-sonnet-4.5",
+                    "visibility": "public",
+                    "metrics": {
+                        "copies": 42,
+                        "cli_pulls": 8,
+                        "skill_invokes": 100,
+                        "traces": 150,
+                        "runs_7d": 30
+                    }
+                }
+            ])))
+            .mount(&server)
+            .await;
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = handle_list(
+            &client,
+            None,
+            None,
+            None,
+            false,
+            true,
+            Some("skill_invokes"),
+            crate::cli::output::OutputFormat::Table,
+        )
+        .await;
+        assert!(result.is_ok(), "{result:?}");
     }
 }

--- a/crates/broomva-cli/src/cli/prompts.rs
+++ b/crates/broomva-cli/src/cli/prompts.rs
@@ -124,9 +124,21 @@ pub async fn handle_pull(
     client: &BroomvaClient,
     slug: &str,
     output: Option<&str>,
+    json: bool,
 ) -> BroomvaResult<()> {
+    // 1. Fetch the prompt detail first so we have the version for the beacon
     let prompt = client.get_prompt(slug).await?;
+    let version = prompt
+        .version
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
 
+    // 2. Fire the telemetry beacon — best-effort. The beacon prints a
+    //    stderr warning on failure but never blocks the pull.
+    let beacon =
+        crate::telemetry::beacon::post_invocation_beacon(client, slug, &version).await;
+
+    // 3. Write the prompt to disk (existing behavior preserved)
     let mut fm = std::collections::BTreeMap::new();
     fm.insert("title".into(), prompt.title.clone());
     fm.insert("slug".into(), prompt.slug.clone());
@@ -153,6 +165,20 @@ pub async fn handle_pull(
     let dest = output.unwrap_or(&default_name);
     fs::write(dest, &rendered)?;
     println!("  Saved to {dest}");
+
+    // 4. Emit invocation id on stderr (machine-readable JSON if --json)
+    if json {
+        let line = serde_json::json!({
+            "invocation_id": beacon.id,
+            "prompt_slug": slug,
+            "prompt_version": version,
+            "posted": beacon.posted,
+        });
+        eprintln!("{line}");
+    } else {
+        eprintln!("\n[broomva] invocation: {}", beacon.id);
+    }
+
     Ok(())
 }
 
@@ -229,4 +255,94 @@ pub async fn handle_push(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::TELEMETRY_ENV_LOCK;
+    use tempfile::tempdir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn pull_fires_telemetry_beacon_after_get() {
+        // Tokio test runs on a single-threaded runtime; holding the lock
+        // across awaits serializes tests that touch BROOMVA_* env vars
+        // without risking deadlock on another worker thread.
+        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/prompts/code-review-agent"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": "u1",
+                    "slug": "code-review-agent",
+                    "title": "Code Review Agent",
+                    "content": "system prompt body",
+                    "summary": "Structured code review",
+                    "category": "system-prompts",
+                    "model": "claude-sonnet-4.5",
+                    "tags": ["code-review"],
+                    "visibility": "public",
+                    "createdAt": "2026-05-09T00:00:00Z",
+                    "updatedAt": "2026-05-09T00:00:00Z"
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/invocations"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "ignored",
+                "created_at": "2026-05-11T00:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let tmp = tempdir().unwrap();
+        let dest = tmp.path().join("out.md");
+        let result = handle_pull(&client, "code-review-agent", Some(dest.to_str().unwrap()), false).await;
+        assert!(result.is_ok(), "{result:?}");
+        let written = std::fs::read_to_string(&dest).unwrap();
+        assert!(written.contains("Code Review Agent"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn pull_with_telemetry_disabled_still_writes_file() {
+        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+        // Set the env var for this test. BROOMVA_TELEMETRY_DISABLED is
+        // read fresh in beacon::post_invocation_beacon so the disable
+        // takes effect immediately.
+        unsafe { std::env::set_var("BROOMVA_TELEMETRY_DISABLED", "1") };
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/prompts/x"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {
+                    "id": "u1",
+                    "slug": "x",
+                    "title": "X",
+                    "content": "body",
+                    "tags": [],
+                    "visibility": "public"
+                }
+            })))
+            .mount(&server)
+            .await;
+        // No mock for POST /api/invocations — with telemetry disabled,
+        // no POST should land at all.
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let tmp = tempdir().unwrap();
+        let dest = tmp.path().join("out.md");
+        let result = handle_pull(&client, "x", Some(dest.to_str().unwrap()), false).await;
+        assert!(result.is_ok(), "{result:?}");
+
+        unsafe { std::env::remove_var("BROOMVA_TELEMETRY_DISABLED") };
+    }
 }

--- a/crates/broomva-cli/src/cli/relay.rs
+++ b/crates/broomva-cli/src/cli/relay.rs
@@ -21,12 +21,12 @@ use crate::error::BroomvaResult;
 fn find_relayd_binary() -> Option<String> {
     // 1. Check PATH (relayd or life-relayd)
     for name in &["relayd", "life-relayd"] {
-        if let Ok(output) = ProcessCommand::new("which").arg(name).output() {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Some(path);
-                }
+        if let Ok(output) = ProcessCommand::new("which").arg(name).output()
+            && output.status.success()
+        {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Some(path);
             }
         }
     }
@@ -260,13 +260,12 @@ async fn run_lightweight_relay(api_base: &str, token: &str, _bind: &str) -> Broo
 
                 match poll_res {
                     Ok(resp) if resp.status().is_success() => {
-                        if let Ok(body) = resp.json::<serde_json::Value>().await {
-                            if let Some(cmd) = body.get("command") {
-                                if !cmd.is_null() {
-                                    let cmd_type = cmd.get("type").and_then(|t| t.as_str()).unwrap_or("?");
-                                    eprintln!("  Command received: {cmd_type} (cannot execute in lightweight mode)");
-                                }
-                            }
+                        if let Ok(body) = resp.json::<serde_json::Value>().await
+                            && let Some(cmd) = body.get("command")
+                            && !cmd.is_null()
+                        {
+                            let cmd_type = cmd.get("type").and_then(|t| t.as_str()).unwrap_or("?");
+                            eprintln!("  Command received: {cmd_type} (cannot execute in lightweight mode)");
                         }
                     }
                     Ok(resp) => {

--- a/crates/broomva-cli/src/main.rs
+++ b/crates/broomva-cli/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod daemon;
 mod error;
 mod frontmatter;
+mod telemetry;
 
 use clap::Parser;
 

--- a/crates/broomva-cli/src/telemetry/beacon.rs
+++ b/crates/broomva-cli/src/telemetry/beacon.rs
@@ -1,0 +1,113 @@
+//! Telemetry beacon — fires a `POST /api/invocations` request before the
+//! actual prompt operation. Always best-effort: failures get a single
+//! stderr warning, never propagate.
+
+use crate::api::BroomvaClient;
+use crate::api::types::InvocationCreateRequest;
+use crate::telemetry::session::get_or_create_session_id;
+use crate::telemetry::source::{caller_string, detect_source, telemetry_disabled};
+
+/// Result of a beacon attempt. The `id` field is always populated (even
+/// when telemetry is disabled or the POST fails) so callers downstream
+/// can emit a machine-readable line, but `posted == false` signals the
+/// row may not actually exist in the server.
+pub struct BeaconResult {
+    pub id: String,
+    pub prompt_slug: String,
+    pub prompt_version: String,
+    pub posted: bool,
+}
+
+/// Fire a telemetry beacon for a prompt operation. Returns immediately
+/// with `posted == false` if telemetry is disabled. Generates a fresh
+/// UUID v4 client-side so the caller can use it before round-tripping
+/// (e.g. to emit on stderr in machine-readable mode).
+pub async fn post_invocation_beacon(
+    client: &BroomvaClient,
+    prompt_slug: &str,
+    prompt_version: &str,
+) -> BeaconResult {
+    let id = uuid::Uuid::new_v4().to_string();
+
+    if telemetry_disabled() {
+        return BeaconResult {
+            id,
+            prompt_slug: prompt_slug.to_string(),
+            prompt_version: prompt_version.to_string(),
+            posted: false,
+        };
+    }
+
+    let source = detect_source();
+    let session_id = get_or_create_session_id();
+
+    let req = InvocationCreateRequest {
+        id: Some(id.clone()),
+        prompt_slug: prompt_slug.to_string(),
+        prompt_version: prompt_version.to_string(),
+        source: source.as_str().to_string(),
+        caller: Some(caller_string()),
+        session_id: Some(session_id),
+        variables: None,
+        metadata: None,
+    };
+
+    match client.create_invocation(&req).await {
+        Ok(_) => BeaconResult {
+            id,
+            prompt_slug: prompt_slug.to_string(),
+            prompt_version: prompt_version.to_string(),
+            posted: true,
+        },
+        Err(err) => {
+            eprintln!("[broomva] telemetry write failed: {err}");
+            BeaconResult {
+                id,
+                prompt_slug: prompt_slug.to_string(),
+                prompt_version: prompt_version.to_string(),
+                posted: false,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn beacon_returns_posted_true_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/invocations"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "id": "anything",
+                "created_at": "2026-05-11T00:00:00Z"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = post_invocation_beacon(&client, "x", "1.0").await;
+        assert!(result.posted);
+        assert!(uuid::Uuid::parse_str(&result.id).is_ok());
+        assert_eq!(result.prompt_slug, "x");
+    }
+
+    #[tokio::test]
+    async fn beacon_returns_posted_false_on_429() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/invocations"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let client = BroomvaClient::new(server.uri(), None);
+        let result = post_invocation_beacon(&client, "x", "1.0").await;
+        assert!(!result.posted);
+        assert!(uuid::Uuid::parse_str(&result.id).is_ok());
+    }
+}

--- a/crates/broomva-cli/src/telemetry/beacon.rs
+++ b/crates/broomva-cli/src/telemetry/beacon.rs
@@ -79,8 +79,33 @@ pub async fn post_invocation_beacon(
 mod tests {
     use super::*;
     use crate::telemetry::TELEMETRY_ENV_LOCK;
+    use tempfile::tempdir;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// RAII guard restoring an env var on drop — keeps tests hermetic
+    /// even when an assertion panics mid-test.
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            unsafe { std::env::set_var(key, value) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
 
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
@@ -89,6 +114,16 @@ mod tests {
         // tokio::test defaults to a single-threaded runtime, so the
         // guard cannot block another thread for the test duration.
         let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        // Hermeticity: point the session cache at a tempdir so the test
+        // doesn't write into the developer's real ~/.broomva/session.
+        let session_tmp = tempdir().unwrap();
+        let session_path = session_tmp.path().join("session");
+        let _session_guard = EnvGuard::set(
+            "BROOMVA_SESSION_PATH",
+            &session_path.to_string_lossy(),
+        );
+
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/api/invocations"))
@@ -110,6 +145,14 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn beacon_returns_posted_false_on_429() {
         let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
+
+        let session_tmp = tempdir().unwrap();
+        let session_path = session_tmp.path().join("session");
+        let _session_guard = EnvGuard::set(
+            "BROOMVA_SESSION_PATH",
+            &session_path.to_string_lossy(),
+        );
+
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/api/invocations"))

--- a/crates/broomva-cli/src/telemetry/beacon.rs
+++ b/crates/broomva-cli/src/telemetry/beacon.rs
@@ -13,7 +13,11 @@ use crate::telemetry::source::{caller_string, detect_source, telemetry_disabled}
 /// row may not actually exist in the server.
 pub struct BeaconResult {
     pub id: String,
+    // Retained for downstream consumers (Claude Code skill, JSON output);
+    // currently informational on the struct itself.
+    #[allow(dead_code)]
     pub prompt_slug: String,
+    #[allow(dead_code)]
     pub prompt_version: String,
     pub posted: bool,
 }
@@ -74,11 +78,17 @@ pub async fn post_invocation_beacon(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::TELEMETRY_ENV_LOCK;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn beacon_returns_posted_true_on_success() {
+        // Holding a std Mutex across awaits is fine in this test:
+        // tokio::test defaults to a single-threaded runtime, so the
+        // guard cannot block another thread for the test duration.
+        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/api/invocations"))
@@ -97,7 +107,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn beacon_returns_posted_false_on_429() {
+        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/api/invocations"))

--- a/crates/broomva-cli/src/telemetry/mod.rs
+++ b/crates/broomva-cli/src/telemetry/mod.rs
@@ -5,3 +5,9 @@
 pub mod beacon;
 pub mod session;
 pub mod source;
+
+/// Process-shared lock for tests that mutate `BROOMVA_*` env vars. Tests
+/// in different modules can race when env vars are mutated; serializing
+/// via this lock keeps `cargo test` (parallel by default) reliable.
+#[cfg(test)]
+pub(crate) static TELEMETRY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/broomva-cli/src/telemetry/mod.rs
+++ b/crates/broomva-cli/src/telemetry/mod.rs
@@ -1,0 +1,7 @@
+//! Telemetry — fires invocation beacons, manages session IDs, detects
+//! source attribution. Wired into the `prompts pull` happy path so every
+//! pull produces a `PromptInvocation` row server-side.
+
+pub mod beacon;
+pub mod session;
+pub mod source;

--- a/crates/broomva-cli/src/telemetry/session.rs
+++ b/crates/broomva-cli/src/telemetry/session.rs
@@ -11,6 +11,9 @@ use crate::config::constants::config_dir;
 const SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 fn session_path() -> PathBuf {
+    if let Ok(p) = std::env::var("BROOMVA_SESSION_PATH") {
+        return PathBuf::from(p);
+    }
     config_dir().join("session")
 }
 
@@ -54,19 +57,37 @@ fn write_session(id: &str) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    /// Helper: scope a temp session file via env override + shared lock.
+    fn with_temp_session<F: FnOnce()>(f: F) {
+        let _guard = crate::telemetry::TELEMETRY_ENV_LOCK.lock().unwrap();
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("session");
+        let prev = std::env::var("BROOMVA_SESSION_PATH").ok();
+        unsafe { std::env::set_var("BROOMVA_SESSION_PATH", &path) };
+        f();
+        match prev {
+            Some(v) => unsafe { std::env::set_var("BROOMVA_SESSION_PATH", v) },
+            None => unsafe { std::env::remove_var("BROOMVA_SESSION_PATH") },
+        }
+        // tmp is dropped here, cleaning up the file
+    }
 
     #[test]
     fn get_or_create_returns_valid_uuid() {
-        let id = get_or_create_session_id();
-        assert!(uuid::Uuid::parse_str(&id).is_ok(), "got: {id}");
+        with_temp_session(|| {
+            let id = get_or_create_session_id();
+            assert!(uuid::Uuid::parse_str(&id).is_ok(), "got: {id}");
+        });
     }
 
     #[test]
     fn get_or_create_is_stable_within_window() {
-        // Two consecutive calls in the same test run should return the same id
-        // ONLY if the cache file already exists from the prior call.
-        let id1 = get_or_create_session_id();
-        let id2 = get_or_create_session_id();
-        assert_eq!(id1, id2);
+        with_temp_session(|| {
+            let id1 = get_or_create_session_id();
+            let id2 = get_or_create_session_id();
+            assert_eq!(id1, id2);
+        });
     }
 }

--- a/crates/broomva-cli/src/telemetry/session.rs
+++ b/crates/broomva-cli/src/telemetry/session.rs
@@ -1,0 +1,72 @@
+//! Session ID helper — generates and caches a per-shell-session UUID at
+//! `~/.broomva/session` with a 24h TTL. Lets the evals dashboard group
+//! all the prompt pulls from one shell session together.
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use crate::config::constants::config_dir;
+
+const SESSION_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+fn session_path() -> PathBuf {
+    config_dir().join("session")
+}
+
+/// Return the cached session ID, or generate a new one (and cache it) if
+/// the cache is missing or stale.
+pub fn get_or_create_session_id() -> String {
+    if let Some(cached) = read_cached_session() {
+        return cached;
+    }
+    let new_id = uuid::Uuid::new_v4().to_string();
+    let _ = write_session(&new_id); // best-effort: silent if write fails
+    new_id
+}
+
+fn read_cached_session() -> Option<String> {
+    let path = session_path();
+    let meta = fs::metadata(&path).ok()?;
+    let modified = meta.modified().ok()?;
+    let age = SystemTime::now().duration_since(modified).ok()?;
+    if age > SESSION_TTL {
+        return None;
+    }
+    let content = fs::read_to_string(&path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Validate it parses as a UUID — defensive against corrupted cache
+    uuid::Uuid::parse_str(trimmed).ok()?;
+    Some(trimmed.to_string())
+}
+
+fn write_session(id: &str) -> std::io::Result<()> {
+    let dir = config_dir();
+    if !dir.exists() {
+        fs::create_dir_all(&dir)?;
+    }
+    fs::write(session_path(), id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_or_create_returns_valid_uuid() {
+        let id = get_or_create_session_id();
+        assert!(uuid::Uuid::parse_str(&id).is_ok(), "got: {id}");
+    }
+
+    #[test]
+    fn get_or_create_is_stable_within_window() {
+        // Two consecutive calls in the same test run should return the same id
+        // ONLY if the cache file already exists from the prior call.
+        let id1 = get_or_create_session_id();
+        let id2 = get_or_create_session_id();
+        assert_eq!(id1, id2);
+    }
+}

--- a/crates/broomva-cli/src/telemetry/source.rs
+++ b/crates/broomva-cli/src/telemetry/source.rs
@@ -32,8 +32,7 @@ pub fn detect_source() -> Source {
     match std::env::var(ENV_SOURCE).ok().as_deref() {
         Some("skill") => Source::Skill,
         Some("api") => Source::Api,
-        Some("cli") | None => Source::Cli,
-        Some(_) => Source::Cli,
+        _ => Source::Cli,
     }
 }
 

--- a/crates/broomva-cli/src/telemetry/source.rs
+++ b/crates/broomva-cli/src/telemetry/source.rs
@@ -5,6 +5,8 @@
 
 pub const ENV_SOURCE: &str = "BROOMVA_SOURCE";
 pub const ENV_TELEMETRY_DISABLED: &str = "BROOMVA_TELEMETRY_DISABLED";
+// Consumed in Batch C/D when variables get hashed before being sent.
+#[allow(dead_code)]
 pub const ENV_RAW_VARS: &str = "BROOMVA_TELEMETRY_RAW_VARS";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -43,6 +45,7 @@ pub fn telemetry_disabled() -> bool {
 
 /// `true` when `BROOMVA_TELEMETRY_RAW_VARS=1` (admin opt-in to send raw
 /// variable values rather than hashed).
+#[allow(dead_code)]
 pub fn raw_vars_enabled() -> bool {
     std::env::var(ENV_RAW_VARS).ok().as_deref() == Some("1")
 }
@@ -55,13 +58,12 @@ pub fn caller_string() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // serialize env mutation across tests to avoid flakes
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::telemetry::TELEMETRY_ENV_LOCK;
 
     fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
-        let _guard = ENV_LOCK.lock().unwrap();
+        // Acquire the process-shared lock so we don't race tests in
+        // sibling modules that also touch BROOMVA_* env vars.
+        let _guard = TELEMETRY_ENV_LOCK.lock().unwrap();
         let prev = std::env::var(key).ok();
         match value {
             Some(v) => unsafe { std::env::set_var(key, v) },

--- a/crates/broomva-cli/src/telemetry/source.rs
+++ b/crates/broomva-cli/src/telemetry/source.rs
@@ -1,0 +1,122 @@
+//! Source attribution helpers — determines whether the CLI run originated
+//! from a terminal (`cli`), the Claude Code skill (`skill`), or an external
+//! programmatic caller (`api`). Honors `BROOMVA_SOURCE` and
+//! `BROOMVA_TELEMETRY_DISABLED` env vars.
+
+pub const ENV_SOURCE: &str = "BROOMVA_SOURCE";
+pub const ENV_TELEMETRY_DISABLED: &str = "BROOMVA_TELEMETRY_DISABLED";
+pub const ENV_RAW_VARS: &str = "BROOMVA_TELEMETRY_RAW_VARS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    Cli,
+    Skill,
+    Api,
+}
+
+impl Source {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Source::Cli => "cli",
+            Source::Skill => "skill",
+            Source::Api => "api",
+        }
+    }
+}
+
+/// Resolve the source from the env var. Defaults to `Source::Cli` if the
+/// var is unset or has an unrecognized value.
+pub fn detect_source() -> Source {
+    match std::env::var(ENV_SOURCE).ok().as_deref() {
+        Some("skill") => Source::Skill,
+        Some("api") => Source::Api,
+        Some("cli") | None => Source::Cli,
+        Some(_) => Source::Cli,
+    }
+}
+
+/// `true` when `BROOMVA_TELEMETRY_DISABLED=1`. Any other value (including
+/// unset, empty, or "0") returns `false`.
+pub fn telemetry_disabled() -> bool {
+    std::env::var(ENV_TELEMETRY_DISABLED).ok().as_deref() == Some("1")
+}
+
+/// `true` when `BROOMVA_TELEMETRY_RAW_VARS=1` (admin opt-in to send raw
+/// variable values rather than hashed).
+pub fn raw_vars_enabled() -> bool {
+    std::env::var(ENV_RAW_VARS).ok().as_deref() == Some("1")
+}
+
+/// Caller string sent on every invocation. Format: `broomva-cli/<version>`.
+pub fn caller_string() -> String {
+    format!("broomva-cli/{}", env!("CARGO_PKG_VERSION"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // serialize env mutation across tests to avoid flakes
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var(key).ok();
+        match value {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+        f();
+        match prev {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    #[test]
+    fn detect_source_defaults_to_cli() {
+        with_env(ENV_SOURCE, None, || {
+            assert_eq!(detect_source(), Source::Cli);
+        });
+    }
+
+    #[test]
+    fn detect_source_reads_skill() {
+        with_env(ENV_SOURCE, Some("skill"), || {
+            assert_eq!(detect_source(), Source::Skill);
+        });
+    }
+
+    #[test]
+    fn detect_source_reads_api() {
+        with_env(ENV_SOURCE, Some("api"), || {
+            assert_eq!(detect_source(), Source::Api);
+        });
+    }
+
+    #[test]
+    fn detect_source_unknown_value_falls_back_to_cli() {
+        with_env(ENV_SOURCE, Some("zzz"), || {
+            assert_eq!(detect_source(), Source::Cli);
+        });
+    }
+
+    #[test]
+    fn telemetry_disabled_only_when_one() {
+        with_env(ENV_TELEMETRY_DISABLED, Some("1"), || {
+            assert!(telemetry_disabled());
+        });
+        with_env(ENV_TELEMETRY_DISABLED, Some("0"), || {
+            assert!(!telemetry_disabled());
+        });
+        with_env(ENV_TELEMETRY_DISABLED, None, || {
+            assert!(!telemetry_disabled());
+        });
+    }
+
+    #[test]
+    fn caller_string_has_expected_prefix() {
+        assert!(caller_string().starts_with("broomva-cli/"));
+    }
+}


### PR DESCRIPTION
## Summary

Wires telemetry into the existing Rust `broomva` CLI so every prompt operation produces a typed row server-side. The CLI becomes the runtime that closes the loop opened by Phase 1's data plane.

Changes:
- 14 new API types in `crates/broomva-cli/src/api/types.rs` — invocations, feedback, metrics responses with `#[serde(rename_all = "snake_case")]` matching the Phase 1 server contract
- 9 new `BroomvaClient` methods: `create_invocation`, `update_invocation`, `create_feedback`, `list_feedback_for_prompt`, `get_metrics_overview`, `list_recent_invocations`, `get_metrics_volume`, `get_metrics_for_slug`, `list_prompts_with_metrics`
- New `telemetry/` module: `source` (env-var detection), `session` (24h-TTL session id at `~/.broomva/session`, overridable via `BROOMVA_SESSION_PATH`), `beacon` (fire-and-forget `POST /api/invocations` with stderr warning on failure)
- 3 new CLI subcommands / flags:
  - `prompts pull --json` — emits invocation id on stderr in machine-readable form
  - `prompts complete <id>` — PATCH the invocation with status + cost
  - `prompts feedback <id|--slug>` — explicit user signal
  - `prompts list --metrics [--sort skill_invokes|cli_pulls|copies|runs_7d]` — enriched list
- broomva-cli SKILL.md updated with the mandatory 5-step "Running prompts (auto-traced)" block + Phase 2 env vars table
- Version bump 0.2.0 → 0.3.0
- Test hermeticity: all `#[tokio::test]` cases that touch session/env state acquire `TELEMETRY_ENV_LOCK` and use `tempfile::tempdir()` so tests never write to `~/.broomva/`

Implements Phase 2 of [\`docs/superpowers/specs/2026-05-09-prompts-eval-engine-design.md\`](../docs/superpowers/specs/2026-05-09-prompts-eval-engine-design.md) §§ 5.1 + 5.2 per the plan at [\`docs/superpowers/plans/2026-05-11-prompts-eval-engine-phase2-cli.md\`](../docs/superpowers/plans/2026-05-11-prompts-eval-engine-phase2-cli.md).

## Test plan

- [x] \`cargo test --package broomva\` — 33/33 tests pass (5 baseline + 28 new across types/client/source/session/beacon/handlers)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo build --release\` — succeeds; \`./target/release/broomva --version\` reports \`0.3.0\`
- [x] CLI help output shows new subcommands and flags
- [x] Tests are hermetic — verified \`~/.broomva/session\` mtime unchanged after \`cargo test\` run
- [x] \`apps/chat\` TypeScript types still compile (no spillover)
- [ ] Manual: \`broomva prompts pull code-review-agent --json\` against the live broomva.tech API writes a row visible in the DB
- [ ] Manual: \`broomva prompts complete <id> --status completed --model claude-sonnet-4.5 --tokens-in 100 --tokens-out 50\` flips the status and computes cost
- [ ] Manual: from Claude Code, with broomva-cli skill loaded, asking "use the code-review-agent prompt to review this file" produces an invocation row with \`source='skill'\` AND a paired completion row

## Pre-existing baseline fix (commit 24d4133)

Clippy 1.93 added stricter \`collapsible_if\` lints that flagged two pre-existing nested \`if let\` blocks in \`src/cli/relay.rs\`. The first commit on this branch is a minimal mechanical refactor (3 nested \`if\`s → \`if let && let && ...\` chains, no behavior change) so the rest of Phase 2 can land on a clean baseline.

## Phase 2.1 follow-ups (non-blocking, documented for transparency)

- \`prompts feedback <id>\` without \`--slug\` currently errors with "detached lookup not yet wired". Adding \`GET /api/invocations/[id]\` on the server side would let the CLI derive the slug automatically. Tracked for follow-up; SKILL.md mandate always pairs \`<invocation_id>\` with \`--slug\` so users aren't blocked.
- \`prompts list --sort=X\` is silently ignored when \`--metrics\` is omitted. Could be a runtime warning; doc-comment already says "requires --metrics".
- \`VolumeBucketRow.by_source\` typed as \`serde_json::Value\` (defer typed struct to v2.1)
- \`PromptMetrics\` doesn't model \`timeseries\` field (serde silently drops; v2.1 add)
- 19 remaining \`#[allow(dead_code)]\` markers on metrics types/methods consumed only by the server (chat UI), not the CLI itself. They stay marked until Phase 3 wires the UI.
- The \`list_with_metrics_renders_extra_columns\` test mock could assert \`query_param("include", "metrics")\` to lock in the API contract.

## Out of scope

- Python \`prompt-sync.py\` deprecation (handled separately in the prompt-library skill repo)
- Installer / Homebrew formula updates for the new version (user can install via \`cargo install --path crates/broomva-cli\` from the monorepo)
- Phase 3 UI redesign (separate plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>