### PR TITLE
fix(prompts): unblock production telemetry — proxy allowlist + CLI envelope (Phase 2.1)

### DIFF
--- a/apps/chat/proxy.ts
+++ b/apps/chat/proxy.ts
@@ -52,6 +52,13 @@ const PUBLIC_API_PREFIXES = [
   // with 402 Payment Required when payment is needed. Middleware must let
   // the request through so the handler can pick the right path.
   "/api/life",
+  // Prompts eval engine (Phase 1 telemetry plane). These endpoints are
+  // anonymous-OK by design — the CLI and Claude Code skill emit
+  // invocation beacons from terminals that may have no session cookie.
+  // Per-IP and per-user rate limits enforced inside each handler.
+  "/api/invocations",
+  "/api/feedback",
+  "/api/metrics",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -88,8 +88,9 @@ impl BroomvaClient {
         }
         let resp = req.send().await?;
         let resp = self.check_response(resp).await?;
-        let body: ApiListResponse<PromptSummary> = resp.json().await?;
-        Ok(body.data.unwrap_or_default())
+        // Server emits a bare array (apps/chat/app/api/prompts/route.ts).
+        // The legacy ApiListResponse<T> envelope was removed; parse the array directly.
+        Ok(resp.json().await?)
     }
 
     pub async fn get_prompt(&self, slug: &str) -> BroomvaResult<PromptDetail> {
@@ -98,12 +99,8 @@ impl BroomvaClient {
             .send()
             .await?;
         let resp = self.check_response(resp).await?;
-        let body: ApiResponse<PromptDetail> = resp.json().await?;
-        body.data.ok_or_else(|| BroomvaError::Api {
-            status: 404,
-            message: format!("prompt not found: {slug}"),
-            body: None,
-        })
+        // Server emits a bare PromptDetail (apps/chat/app/api/prompts/[slug]/route.ts).
+        Ok(resp.json().await?)
     }
 
     pub async fn create_prompt(&self, req: CreatePromptRequest) -> BroomvaResult<PromptDetail> {
@@ -113,12 +110,8 @@ impl BroomvaClient {
             .send()
             .await?;
         let resp = self.check_response(resp).await?;
-        let body: ApiResponse<PromptDetail> = resp.json().await?;
-        body.data.ok_or_else(|| BroomvaError::Api {
-            status: 500,
-            message: "create returned no data".into(),
-            body: None,
-        })
+        // Server emits a bare prompt row on 201 (no { data } wrapper).
+        Ok(resp.json().await?)
     }
 
     pub async fn update_prompt(
@@ -132,12 +125,8 @@ impl BroomvaClient {
             .send()
             .await?;
         let resp = self.check_response(resp).await?;
-        let body: ApiResponse<PromptDetail> = resp.json().await?;
-        body.data.ok_or_else(|| BroomvaError::Api {
-            status: 500,
-            message: "update returned no data".into(),
-            body: None,
-        })
+        // Server emits a bare prompt row on 200 (no { data } wrapper).
+        Ok(resp.json().await?)
     }
 
     pub async fn delete_prompt(&self, slug: &str) -> BroomvaResult<()> {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -2,24 +2,37 @@ use serde::{Deserialize, Serialize};
 
 // ── Prompts ──
 
+/// PromptSummary matches the shape emitted by `GET /api/prompts`
+/// (`apps/chat/app/api/prompts/route.ts`). Server uses the slug as the
+/// stable identifier and omits `id` from the response — match accordingly.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptSummary {
-    pub id: String,
+    #[serde(default)]
+    pub id: Option<String>,
     pub slug: String,
     pub title: String,
     pub summary: Option<String>,
     pub category: Option<String>,
     pub model: Option<String>,
+    #[serde(default)]
     pub visibility: Option<String>,
+    /// Server emits this as `date` (mirrors updatedAt). camelCase fallback
+    /// accepted so we tolerate either source without churn.
+    #[serde(default, alias = "date")]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
+/// PromptDetail matches `GET /api/prompts/[slug]`
+/// (`apps/chat/app/api/prompts/[slug]/route.ts`). Same caveat as
+/// PromptSummary: `id` is omitted server-side.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptDetail {
-    pub id: String,
+    #[serde(default)]
+    pub id: Option<String>,
     pub slug: String,
     pub title: String,
     pub content: String,
@@ -29,7 +42,9 @@ pub struct PromptDetail {
     pub version: Option<String>,
     pub tags: Option<Vec<String>>,
     pub visibility: Option<String>,
+    #[serde(default, alias = "date")]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/crates/broomva-cli/src/cli/prompts.rs
+++ b/crates/broomva-cli/src/cli/prompts.rs
@@ -460,22 +460,22 @@ mod tests {
             EnvGuard::set("BROOMVA_SESSION_PATH", &session_path.to_string_lossy());
 
         let server = MockServer::start().await;
+        // Server emits a bare PromptDetail (no { data } wrapper) since the
+        // Phase 2.1 envelope-mismatch fix.
         Mock::given(method("GET"))
             .and(path("/api/prompts/code-review-agent"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "data": {
-                    "id": "u1",
-                    "slug": "code-review-agent",
-                    "title": "Code Review Agent",
-                    "content": "system prompt body",
-                    "summary": "Structured code review",
-                    "category": "system-prompts",
-                    "model": "claude-sonnet-4.5",
-                    "tags": ["code-review"],
-                    "visibility": "public",
-                    "createdAt": "2026-05-09T00:00:00Z",
-                    "updatedAt": "2026-05-09T00:00:00Z"
-                }
+                "id": "u1",
+                "slug": "code-review-agent",
+                "title": "Code Review Agent",
+                "content": "system prompt body",
+                "summary": "Structured code review",
+                "category": "system-prompts",
+                "model": "claude-sonnet-4.5",
+                "tags": ["code-review"],
+                "visibility": "public",
+                "createdAt": "2026-05-09T00:00:00Z",
+                "updatedAt": "2026-05-09T00:00:00Z"
             })))
             .mount(&server)
             .await;
@@ -511,17 +511,16 @@ mod tests {
         let _disabled_guard = EnvGuard::set("BROOMVA_TELEMETRY_DISABLED", "1");
 
         let server = MockServer::start().await;
+        // Server emits a bare PromptDetail (no { data } wrapper).
         Mock::given(method("GET"))
             .and(path("/api/prompts/x"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "data": {
-                    "id": "u1",
-                    "slug": "x",
-                    "title": "X",
-                    "content": "body",
-                    "tags": [],
-                    "visibility": "public"
-                }
+                "id": "u1",
+                "slug": "x",
+                "title": "X",
+                "content": "body",
+                "tags": [],
+                "visibility": "public"
             })))
             .mount(&server)
             .await;


### PR DESCRIPTION
## Summary

Two production blockers discovered while running the first real end-to-end smoke test of the Phase 1+2 prompts-eval loop:

1. **Production middleware blocked the new Phase 1 endpoints.** \`apps/chat/proxy.ts\` PUBLIC_API_PREFIXES allowlist was missing \`/api/invocations\`, \`/api/feedback\`, and \`/api/metrics\`. PR #143 created the routes but didn't update the proxy. **All Phase 1 telemetry has been silently 307→/login since b320e5d merged.** Smoke test reproduced this in <30 seconds.

2. **CLI was parsing a stale response envelope.** \`BroomvaClient::{list_prompts, get_prompt, create_prompt, update_prompt}\` expected \`{ data: T }\` wrapper. The server emits bare objects/arrays. Three pre-Phase-2 methods always failed with misleading errors ("create returned no data", "prompt not found", "error decoding response body"). Fixed all four to parse the response directly.

3. **\`PromptDetail\` and \`PromptSummary\` field shapes** updated to match what the server actually emits: \`id\` is now \`Option<String>\` (server omits it; slug is the identifier), and \`date\` is accepted as an alias for \`createdAt\` (server emits \`date\`).

## Validation

- \`cargo test\` — 33/33 pass (existing wiremock mocks updated to non-envelope shape)
- \`cargo clippy --all-targets -- -D warnings\` — clean
- \`cargo build --release\` — succeeds; v0.3.0 binary installed locally
- \`apps/chat\` types generation — passes
- Smoke test (will run post-merge once production deploys this fix):
  - \`broomva prompts pull ai-native-platform-architect --json\` → file saved + invocation beacon posts to \`POST /api/invocations\` (currently 405; will be 201 after merge)
  - \`broomva prompts complete <id> --status completed ...\` → PATCH succeeds
  - \`broomva.tech/api/metrics/overview\` → returns real telemetry data

## Files changed (4)

- \`apps/chat/proxy.ts\` — add 3 paths to PUBLIC_API_PREFIXES with explanatory comment
- \`crates/broomva-cli/src/api/mod.rs\` — remove envelope unwrap from 4 methods
- \`crates/broomva-cli/src/api/types.rs\` — \`id: Option<String>\`, \`date\` alias on PromptDetail + PromptSummary
- \`crates/broomva-cli/src/cli/prompts.rs\` — update 2 test mocks to non-envelope shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>