### PR TITLE
fix(prompts): metrics-for-slugs IN-clause binding (Phase 2.2)

### DIFF
--- a/apps/chat/lib/db/queries.ts
+++ b/apps/chat/lib/db/queries.ts
@@ -1817,6 +1817,14 @@ export async function getMetricsForSlugs(slugs: string[]) {
     copies: number; cli_pulls: number; skill_invokes: number; traces: number;
     runs_7d: number;
   }>();
+  // Use `IN (...)` with explicit per-value binding via sql.join — the
+  // earlier `= ANY(${slugs})` form matched nothing under
+  // drizzle-orm/postgres-js because a JS array binding doesn't serialize
+  // as a Postgres text[] literal. sql.join produces one bind per slug.
+  const slugList = sql.join(
+    slugs.map((s) => sql`${s}`),
+    sql`, `,
+  );
   const result = (await db.execute<{
     slug: string; web: number; cli: number; skill: number; api: number; runs_7d: number;
   }>(sql`
@@ -1828,7 +1836,7 @@ export async function getMetricsForSlugs(slugs: string[]) {
       COUNT(*) FILTER (WHERE source = 'api')::int AS api,
       COUNT(*) FILTER (WHERE "createdAt" >= now() - interval '7 days')::int AS runs_7d
     FROM "PromptInvocation"
-    WHERE "promptSlug" = ANY(${slugs})
+    WHERE "promptSlug" IN (${slugList})
     GROUP BY "promptSlug"
   `)) as unknown as {
     slug: string; web: number; cli: number; skill: number; api: number; runs_7d: number;


### PR DESCRIPTION
## Summary

\`getMetricsForSlugs\` used \`WHERE "promptSlug" = ANY(\${slugs})\` with a JS array binding. Under drizzle-orm/postgres-js this serializes as a single parameter that doesn't match any text[] coercion, so the query returned no rows and every slug fell back to the zero-metrics default in \`/api/prompts/route.ts\`.

The \`?include=metrics\` enrichment on \`GET /api/prompts\` has been silently returning all zeros since Phase 1 shipped. Caught immediately on the first real \`broomva prompts list --metrics\` smoke test — the per-slug endpoint \`/api/metrics/prompts/[slug]\` was returning correct numbers, the list-enriched endpoint was not.

Fix: \`WHERE "promptSlug" IN (\${sql.join(slugs.map(s => sql\`\${s}\`), sql\`, \`)})\` — one bound parameter per slug, no array coercion required.

## Validation

- \`bun run test:types\` — green
- \`bun run test:unit -- app/api/prompts\` — 10/10 pass
- Manual: after merge, \`broomva prompts list --metrics\` will show real numbers (currently all zeros)

## Files changed (1)

- \`apps/chat/lib/db/queries.ts\` — \`getMetricsForSlugs\` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database query handling for metrics retrieval with enhanced parameter binding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->