### PR TITLE
fix(proxy): bypass auth proxy for .mp3/.wav/.m4a (Lago audio assets)

### DIFF
--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -234,7 +234,13 @@ export async function proxy(req: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|opengraph-image|manifest|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|json|webmanifest|txt|mp4|webm|ogg|pdf)$).*)",
+    // Skip the proxy for static assets and build artifacts. The extension
+    // list intentionally includes audio (mp3/wav/m4a) and video (mp4/webm/ogg)
+    // because those resources are public — they were originally served as
+    // committed static files under public/, and after the Lago migration
+    // (apps/broomva/app/api/assets) they need to keep bypassing auth so the
+    // /audio/* and /video/* rewrites in next.config.ts can reach /api/assets.
+    "/((?!_next/static|_next/image|favicon.ico|opengraph-image|manifest|.*\\.(?:svg|png|jpg|jpeg|gif|webp|avif|ico|json|webmanifest|txt|mp4|webm|ogg|mp3|wav|m4a|pdf)$).*)",
   ],
 };
 


### PR DESCRIPTION
## Problem

After #147 landed, audio narration broke on every blog post:

```
$ curl -I https://broomva.tech/audio/writing/bstack-portable-harness-metalayer.mp3
HTTP/2 307
location: /login
```

Discovered by browsing https://broomva.tech/writing/bstack-portable-harness-metalayer and clicking "Listen to post" — the audio fetch returned 307 instead of streaming.

## Root cause

`apps/broomva/proxy.ts` matcher excluded video (`mp4|webm|ogg`) and image (`png|jpg|jpeg|gif|webp|svg|ico`) extensions so those static-file requests skip the proxy entirely. But it did NOT exclude `.mp3`.

Before the Lago migration this gap was invisible: the audio files at `/audio/{writing,projects}/*.mp3` were served as committed static files by Vercel's CDN *before* the proxy ran. After the migration, those static files don't exist on the Vercel build. The request now falls through to Next.js, hits the proxy, fails both the `isPublicPage` and `isPublicApiRoute` checks (the audio path is neither — it's a top-level `/audio/...` URL, not `/api/assets/audio/...`), and gets redirected to `/login` at line 225 of `proxy.ts`. The `/audio/writing/:path* → /api/assets/...` rewrite in `next.config.ts` never gets a chance to run, because middleware runs first.

## Fix

Add `mp3`, `wav`, `m4a` to the proxy matcher exclusion. Audio is public content (the podcast narration for every blog post and project page); the auth wall doesn't belong on it. Also added `avif` while in there — Next.js Image generates AVIF variants by default and they had the same hidden gap.

## Verification

Local validation:
- `bun run turbo test:types` ✓
- `bun run turbo lint` ✓ (warnings only)

After deploy, expect:
```
$ curl -I https://broomva.tech/audio/writing/bstack-portable-harness-metalayer.mp3
HTTP/2 302
location: https://api.lago.arcan.la/v1/public/blobs/...
```

(matching the existing behavior for `/images/writing/*.png` and `/video/writing/*.mp4` which already worked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated middleware configuration to exclude additional audio file formats (mp3, wav, m4a) from proxy handling, alongside existing media and document types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->