### PR TITLE
fix(proxy): allow /api/audio-playback as public API route

### DIFF
--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -59,6 +59,11 @@ const PUBLIC_API_PREFIXES = [
   "/api/invocations",
   "/api/feedback",
   "/api/metrics",
+  // Audio narration: every blog/project post has a "Listen to post" player.
+  // The handler stores per-user resume position when signed in, but degrades
+  // to no-op for anonymous readers (`NextResponse.json(null)` on GET, 401 on
+  // POST). The proxy must let the request through so the handler can pick.
+  "/api/audio-playback",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */


### PR DESCRIPTION
## Problem

After #148 fixed the `.mp3` matcher gap, the audio narration *still* failed to start on https://broomva.tech/writing/* for anonymous readers. The Listen to post button fired a request to `/api/audio-playback` first (to look up the user's resume position) and got 307 → /login. That redirect short-circuited the player's initialization, so the audio element never received a src and the actual `/audio/writing/*.mp3` request never happened.

## Root cause

`apps/broomva/app/api/audio-playback/route.ts` already degrades safely for anonymous callers:

- `GET` returns `NextResponse.json(null)` (no resume position to load — fine)
- `POST`/`DELETE` return 401 (the user can listen but can't persist position — fine)

But the proxy at `apps/broomva/proxy.ts` doesn't have `/api/audio-playback` in `PUBLIC_API_PREFIXES`, so the request gets redirected to `/login` before reaching the handler.

## Fix

Add `/api/audio-playback` to `PUBLIC_API_PREFIXES`, alongside `/api/assets` and the other public-by-design API routes.

## Verification

After this lands, expect:
```
$ curl -I https://broomva.tech/api/audio-playback
HTTP/2 200
content-type: application/json
```
(was 307 → /login)

And on https://broomva.tech/writing/bstack-portable-harness-metalayer, clicking "Listen to post" should:
1. GET /api/audio-playback → 200 null
2. Player creates <audio> with src = /audio/writing/bstack-portable-harness-metalayer.mp3
3. GET /audio/writing/...mp3 → 302 to api.lago.arcan.la/v1/public/blobs/... → 200 audio bytes
4. Narration plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The audio playback API endpoint is now accessible without authentication checks, allowing unauthenticated requests to proceed with standard security headers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/150)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->