### PR TITLE
fix(audio): cache-bust audio URLs to unstick browsers with bad /login redirect

### DIFF
--- a/apps/broomva/providers/audio-playback-provider.tsx
+++ b/apps/broomva/providers/audio-playback-provider.tsx
@@ -36,6 +36,28 @@ const COOKIE_KEY = "audio-playback";
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 const SYNC_DEBOUNCE_MS = 5000;
 
+/**
+ * Cache-bust audio URLs after the Lago migration.
+ *
+ * Before the migration, /audio/writing/*.mp3 was served as a committed static
+ * file. While the proxy didn't yet allow .mp3 through, the path silently
+ * redirected to /login with `Cache-Control: max-age=31536000, immutable` —
+ * which browsers cached for a year. Even after the proxy fix shipped, those
+ * users keep hitting their stuck cached redirect instead of the live 302→Lago.
+ *
+ * Appending a query string forces a fresh request that misses the bad cache
+ * entry. Bump this value if a future migration creates a similar stuck-cache
+ * scenario.
+ */
+const AUDIO_CACHE_VERSION = "lago-2026-05-12";
+
+function withCacheBust(audioSrc: string): string {
+  if (!audioSrc) return audioSrc;
+  // Don't append if the caller already supplied a query string.
+  if (audioSrc.includes("?")) return audioSrc;
+  return `${audioSrc}?v=${AUDIO_CACHE_VERSION}`;
+}
+
 const AudioPlaybackContext = createContext<AudioPlaybackContextValue | null>(
   null,
 );
@@ -159,7 +181,7 @@ export function AudioPlaybackProvider({
         title: cookieState.title,
       });
       const audio = getAudio();
-      audio.src = cookieState.audioSrc;
+      audio.src = withCacheBust(cookieState.audioSrc);
       audio.currentTime = cookieState.currentTime || 0;
       setCurrentTime(cookieState.currentTime || 0);
       setDuration(cookieState.duration || 0);
@@ -180,8 +202,9 @@ export function AudioPlaybackProvider({
           title: serverState.title,
         });
         const audio = getAudio();
-        if (audio.src !== serverState.audioSrc) {
-          audio.src = serverState.audioSrc;
+        const targetSrc = withCacheBust(serverState.audioSrc);
+        if (audio.src !== targetSrc) {
+          audio.src = targetSrc;
         }
         audio.currentTime = serverState.currentTime || 0;
         setCurrentTime(serverState.currentTime || 0);
@@ -254,7 +277,7 @@ export function AudioPlaybackProvider({
       setTrack(newTrack);
 
       if (!sameSrc) {
-        audio.src = newTrack.audioSrc;
+        audio.src = withCacheBust(newTrack.audioSrc);
         audio.load();
       }
 


### PR DESCRIPTION
## Problem reported

> "did you click on the play button for the audio transcripts? on broomva.tech, I see its not working"

## Diagnosis

The audio infrastructure is healthy on the server side after #147/#148/#150 — verified end-to-end in a headless browser with React-Fiber inspection of the detached \`<audio>\` element:

```
src: …broomva.tech/audio/writing/bstack-portable-harness-metalayer.mp3
paused: false
currentTime: "7.6"      (advancing in real time)
duration: 1187          (full 20-min podcast metadata loaded)
readyState: 4           (HAVE_ENOUGH_DATA)
error: null
```

So new visitors work. But **visitors who hit broomva.tech during the bad window** still see broken audio because their browser cached the failure: when \`.mp3\` requests returned \`307 → /login\` before #148, Vercel decorated those responses with \`Cache-Control: public, max-age=31536000, immutable\` from the \`/audio/:path*\` rule in \`next.config.ts\`. Browsers stored that bad redirect locally for a year as immutable. When the user clicks "Listen to post" today, the player sets \`audio.src = /audio/writing/foo.mp3\`, the browser serves the stale 307 from disk, follows it to \`/login\` (HTML), and the audio element fails silently with no source.

## Fix

Append a static \`?v=lago-2026-05-12\` query string to the audio src in \`apps/broomva/providers/audio-playback-provider.tsx\`. The distinct URL misses the stuck cache entry and falls through to the live \`302 → Lago\` path.

Touches three \`audio.src\` assignments:
- the cookie-restore path (line 162)
- the server-state-restore path (line 184)  
- the active \`play()\` path (line 257)

The version string is a one-shot bumper. Only bump again if a future migration creates a similar stuck-cache scenario.

## Verification

- \`bun run turbo test:types --filter=@broomva/web\` ✓ 2/2

After deploy, affected users hit \`/audio/writing/foo.mp3?v=lago-2026-05-12\` instead of \`/audio/writing/foo.mp3\` — fresh URL, fresh cache key, live 302→Lago response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio playback reliability by ensuring fresh audio content is loaded after app updates and migrations, preventing playback of stale cached versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/152)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->