### PR TITLE
ci: harden multimedia guardrails so the next regression fails loudly in PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,55 @@ jobs:
       - name: Validate content quality
         run: bun run check:content
 
+      # Hit real production URLs without auth headers to make sure no
+      # public asset (audio / image / video / api/audio-playback) is being
+      # accidentally gated behind the auth proxy. Catches the exact bug
+      # class shipped in #147 where the proxy matcher missed `.mp3` and
+      # silently redirected every audio request to /login.
+      #
+      # Probe target is configurable via TARGET_BASE_URL; default is
+      # https://broomva.tech so PR builds catch production regressions
+      # before a merge piles on top of them. On PR builds we keep
+      # PROBE_MAX_ATTEMPTS=1 (production should already be stable, no
+      # reason to retry); the post-deploy smoke job runs the full retry.
+      - name: Probe public asset routes
+        env:
+          PROBE_MAX_ATTEMPTS: "1"
+        run: bun run check:public-asset-routes
+
+  smoke-test-deploy:
+    name: Smoke-test production after deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [validate, sync-assets]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Give Vercel a moment to start flipping the production alias after
+      # sync-assets finishes. The probe itself retries up to 6 times with
+      # 15s back-off (configured below), so we only need a small head-start
+      # here. The combined wait covers the typical 3-7min Vercel build that
+      # the git push triggered in parallel with this workflow.
+      - name: Wait for production deploy to start
+        run: sleep 60
+
+      - name: Probe public asset routes (production)
+        env:
+          TARGET_BASE_URL: https://broomva.tech
+          PROBE_MAX_ATTEMPTS: "6"
+          PROBE_RETRY_DELAY_MS: "15000"
+        run: bun run check:public-asset-routes
+
   sync-assets:
     name: Sync assets to Lago
     runs-on: ubuntu-latest

--- a/apps/broomva/next.config.ts
+++ b/apps/broomva/next.config.ts
@@ -82,20 +82,42 @@ const nextConfig: NextConfig = {
         ],
       },
       {
+        // Path-level cache: short and revalidatable, because /images/:path*
+        // is rewritten to /api/assets/images/:path* which returns a 302 to a
+        // content-addressed Lago blob URL. If we marked these responses
+        // `immutable, max-age=1y` (the previous behaviour), any transient
+        // failure response — e.g. an auth proxy 307→/login during a
+        // migration — would be pinned in every visitor's browser cache for
+        // a year. The blob URL it redirects to is itself immutable, so the
+        // long-lived caching belongs on the blob, not on this redirect.
         source: "/images/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: "public, max-age=3600, must-revalidate",
           },
         ],
       },
       {
+        // Same reasoning as /images/:path* above. The audio narration files
+        // are large (10+ MB), so we still want the eventual blob URL cached
+        // aggressively — but that caching lives on the blob response itself,
+        // not on this path-level redirect.
         source: "/audio/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
+            value: "public, max-age=3600, must-revalidate",
+          },
+        ],
+      },
+      {
+        // Video parallels audio.
+        source: "/video/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, must-revalidate",
           },
         ],
       },

--- a/apps/broomva/package.json
+++ b/apps/broomva/package.json
@@ -45,6 +45,7 @@
     "fetch:models": "bun scripts/fetch-models.ts && bun format",
     "check:links": "node scripts/check-links.mjs",
     "check:content": "node scripts/check-content.mjs",
+    "check:public-asset-routes": "node scripts/verify-public-asset-routes.mjs",
     "generate:audio": "bun scripts/generate-audio.ts"
   },
   "dependencies": {

--- a/apps/broomva/scripts/check-content.mjs
+++ b/apps/broomva/scripts/check-content.mjs
@@ -242,6 +242,57 @@ for (const kind of KINDS) {
         warnings++;
       }
     }
+
+    // ── Body media references (inline <audio>/<video>/<img> + markdown img) ──
+    // Frontmatter covers the canonical hero image and audio narration, but
+    // longer posts inline additional images, videos, and audio clips inside
+    // the body. Validate every one of those that points at a local path so
+    // a missing-from-Lago asset gets caught in CI rather than at production
+    // render time.
+    const body = bodyLines.join("\n");
+    const seenSrcs = new Set();
+    const BODY_REFS = [
+      // <video src="/...">, <audio src="/...">, <img src="/...">
+      ...body.matchAll(/<(?:audio|video|img)\b[^>]*\bsrc=["']([^"']+)["']/gi),
+      // Markdown image: ![alt](path) or ![alt](path "title")
+      ...body.matchAll(/!\[[^\]]*\]\(([^)\s"']+)/g),
+      // <source src="/..."> inside <video>/<audio>
+      ...body.matchAll(/<source\b[^>]*\bsrc=["']([^"']+)["']/gi),
+      // <video poster="/..."> — poster images are common on the bstack post
+      ...body.matchAll(/<video\b[^>]*\bposter=["']([^"']+)["']/gi),
+    ];
+    for (const match of BODY_REFS) {
+      const src = match[1];
+      // Skip remote URLs (http/https/data:/protocol-relative).
+      if (!src.startsWith("/")) continue;
+      // Skip Next.js optimized image URLs — the actual underlying asset
+      // gets verified via the frontmatter `image:` field above and via the
+      // dedicated URL probe (scripts/verify-public-asset-routes.mjs).
+      if (src.startsWith("/_next/")) continue;
+      // De-duplicate within the same file — many posts reference the same
+      // hero image in multiple sizes.
+      if (seenSrcs.has(src)) continue;
+      seenSrcs.add(src);
+
+      const res = await resolveAsset(src);
+      if (res.kind === "missing-lago") {
+        console.error(
+          `✗  ${kind}/${file} — body asset missing in Lago manifest: ${src}`
+        );
+        errors++;
+      } else if (res.kind === "missing-local") {
+        // Non-Lago-managed prefix and not on disk: hard miss
+        console.error(
+          `✗  ${kind}/${file} — body asset missing on disk: ${src}`
+        );
+        errors++;
+      } else if (res.kind === "lago-unknown") {
+        console.warn(
+          `⚠  ${kind}/${file} — body asset not on disk and Lago manifest unreachable; assumed present: ${src}`
+        );
+        warnings++;
+      }
+    }
   }
 }
 

--- a/apps/broomva/scripts/verify-public-asset-routes.mjs
+++ b/apps/broomva/scripts/verify-public-asset-routes.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+/**
+ * Probe public-asset endpoints to catch auth/CDN regressions before they
+ * reach users.
+ *
+ * Why: in May 2026 a single missing extension (`.mp3`) in the Next.js
+ * middleware matcher silently broke audio narration site-wide for every
+ * unauthenticated reader. The unit tests, typecheck, and content-link
+ * checker all passed because none of them exercise the live request path.
+ * The only thing that would have caught it is a real HTTP probe: "fetch the
+ * public URL without auth and verify it doesn't redirect to /login."
+ *
+ * What this script does:
+ *   1. Hit a curated list of public asset URLs against the configured base
+ *      URL (https://broomva.tech by default, override with TARGET_BASE_URL).
+ *   2. Assert the response is either a final 2xx OR a 30x to api.lago.arcan.la
+ *      / a Vercel image-optimization URL. Anything that lands on `/login`,
+ *      a 4xx, or a 5xx fails the check.
+ *   3. Print one line per probe so CI logs are obvious to scan.
+ *
+ * Usage:
+ *   node scripts/verify-public-asset-routes.mjs
+ *   TARGET_BASE_URL=https://my-preview.vercel.app node scripts/verify-public-asset-routes.mjs
+ *
+ * Environment variables:
+ *   TARGET_BASE_URL  — base URL to probe (default: https://broomva.tech)
+ *   STRICT_TIMEOUT_MS — per-request timeout in ms (default: 15000)
+ */
+
+const TARGET_BASE_URL = (
+  process.env.TARGET_BASE_URL || "https://broomva.tech"
+).replace(/\/$/, "");
+const TIMEOUT_MS = Number.parseInt(process.env.STRICT_TIMEOUT_MS || "15000", 10);
+
+// Post-deploy probes might race a still-warming Vercel deploy or a brief
+// network blip. Retry each probe up to this many times before giving up;
+// each retry waits RETRY_DELAY_MS. Override with PROBE_MAX_ATTEMPTS=1 in
+// CI flows that should fail fast (e.g. PR builds against stable prod).
+const MAX_ATTEMPTS = Math.max(
+  1,
+  Number.parseInt(process.env.PROBE_MAX_ATTEMPTS || "3", 10)
+);
+const RETRY_DELAY_MS = Number.parseInt(
+  process.env.PROBE_RETRY_DELAY_MS || "10000",
+  10
+);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Each probe is `{ path, kind, expectedStatus, label }`.
+ *
+ * `expectedStatus` is a function over the integer status: returns true if
+ * the response status is acceptable. We accept 200 (cached static / direct
+ * serve), 206 (partial range), and 302 (redirect to Lago blob) for media
+ * assets; only 200 for API endpoints.
+ *
+ * Paths reference real assets that have been committed to the content repo
+ * AND uploaded to Lago (see scripts/sync-assets-to-lago.ts). If those posts
+ * are renamed or deleted, update this list.
+ */
+const PROBES = [
+  // — Audio narration: writing + projects, two distinct files —
+  {
+    path: "/audio/writing/bstack-portable-harness-metalayer.mp3",
+    kind: "audio",
+    expectedStatus: (s) => s === 200 || s === 206 || s === 302,
+    label: "audio (writing)",
+  },
+  {
+    path: "/audio/projects/aios.mp3",
+    kind: "audio",
+    expectedStatus: (s) => s === 200 || s === 206 || s === 302,
+    label: "audio (projects)",
+  },
+  // — Images —
+  {
+    path: "/images/writing/16-patterns-agent-governance/hero-16-patterns.png",
+    kind: "image",
+    expectedStatus: (s) => s === 200 || s === 302,
+    label: "image (writing)",
+  },
+  // — Video —
+  {
+    path: "/video/writing/bstack-portable-harness-metalayer/hero-cinematic.mp4",
+    kind: "video",
+    expectedStatus: (s) => s === 200 || s === 206 || s === 302,
+    label: "video (writing)",
+  },
+  // — Direct /api/assets/* (proves the proxy bypass + Lago route works) —
+  {
+    path: "/api/assets/audio/writing/bstack-portable-harness-metalayer.mp3",
+    kind: "api-asset",
+    expectedStatus: (s) => s === 200 || s === 302,
+    label: "/api/assets/audio/...",
+  },
+  // — /api/audio-playback: the player hits this BEFORE creating the audio
+  //   element; if it gets gated to /login the player silently fails.
+  {
+    path: "/api/audio-playback",
+    kind: "api",
+    expectedStatus: (s) => s === 200,
+    label: "/api/audio-playback (anon)",
+  },
+];
+
+async function probe({ path, kind, expectedStatus, label }) {
+  const url = `${TARGET_BASE_URL}${path}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "manual",
+      signal: controller.signal,
+      // No auth, no cookies — that's the point: simulate a brand-new reader.
+    });
+    const status = res.status;
+    const location = res.headers.get("location") || "";
+
+    // The defining failure mode we want to catch: the middleware proxy
+    // accidentally treats a public asset as a gated route and sends it to
+    // /login. That's never correct for any path in this list.
+    if (location.startsWith("/login") || /\blogin\b/.test(location)) {
+      return {
+        ok: false,
+        status,
+        location,
+        reason: "redirects to /login (auth proxy gated a public asset)",
+      };
+    }
+
+    if (!expectedStatus(status)) {
+      return {
+        ok: false,
+        status,
+        location,
+        reason: `status ${status} not in expected set for ${kind}`,
+      };
+    }
+
+    return { ok: true, status, location };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      location: "",
+      reason: `fetch failed: ${err.message}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function probeWithRetry(p) {
+  let lastResult;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    lastResult = await probe(p);
+    if (lastResult.ok) {
+      if (attempt > 1) lastResult.attempts = attempt;
+      return lastResult;
+    }
+    if (attempt < MAX_ATTEMPTS) await sleep(RETRY_DELAY_MS);
+  }
+  lastResult.attempts = MAX_ATTEMPTS;
+  return lastResult;
+}
+
+let failed = 0;
+console.log(
+  `ℹ  Probing public asset routes on ${TARGET_BASE_URL} (max ${MAX_ATTEMPTS} attempt(s) per probe)`
+);
+for (const p of PROBES) {
+  const r = await probeWithRetry(p);
+  if (r.ok) {
+    const dest = r.location ? ` → ${r.location.slice(0, 80)}` : "";
+    const note = r.attempts ? ` (after ${r.attempts} attempts)` : "";
+    console.log(`✓ ${p.label.padEnd(28)} HTTP ${r.status}${dest}${note}`);
+  } else {
+    failed++;
+    const dest = r.location ? ` → ${r.location.slice(0, 80)}` : "";
+    console.error(
+      `✗ ${p.label.padEnd(28)} HTTP ${r.status}${dest}\n   ${r.reason}\n   url: ${TARGET_BASE_URL}${p.path}`
+    );
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} probe(s) failed.`);
+  process.exit(1);
+}
+console.log("\n✓ All public asset routes resolve.");

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typecheck": "turbo run typecheck",
     "check:links": "turbo run check:links",
     "check:content": "turbo run check:content",
+    "check:public-asset-routes": "turbo run check:public-asset-routes",
     "sync:assets": "bun scripts/sync-assets-to-lago.ts"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -114,6 +114,9 @@
     },
     "check:content": {
       "cache": false
+    },
+    "check:public-asset-routes": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
> "Let's fix the cicd regarding missing audio or multimedia files regardless of whose change it is. Let's make sure it's all green and proper."

Three changes that together make CI catch the bug class we just shipped (public audio assets gated behind \`/login\`, missing-from-Lago references in MDX body, year-long sticky caches of error responses):

## 1. Drop \`immutable, max-age=31536000\` from \`/audio/:path*\` and \`/images/:path*\`

In \`apps/broomva/next.config.ts\` — also add the same shortened rule for \`/video/:path*\` for consistency. New value: \`public, max-age=3600, must-revalidate\`.

Why: the previous rule pinned ANY response — including the 307→\`/login\` shipped during the proxy-matcher gap — into every visitor's browser cache as immutable for a full year. The blob URLs the rewrite redirects to are themselves content-addressed and immutable, so long-lived caching belongs on the blob (which Lago already does), not on the path-to-blob redirect.

## 2. Scan MDX body for inline media references

\`apps/broomva/scripts/check-content.mjs\` now walks every post body for \`<audio src>\`, \`<video src>\`, \`<video poster>\`, \`<source src>\`, \`<img src>\`, and markdown \`![alt](path)\` references — and runs each through the existing Lago-aware resolver. Frontmatter already covered the canonical hero image + audio narration; this catches every additional asset inlined in the post body.

A post that adds a new image without uploading it to Lago first will now fail \`check:content\` instead of rendering as a broken image in production.

## 3. Add \`scripts/verify-public-asset-routes.mjs\` + wire it into CI

Curated probe of 6 public endpoints — audio (writing + projects), image, video, \`/api/assets/audio/…\`, and \`/api/audio-playback\` — against the configured base URL (defaults to \`https://broomva.tech\`). Fails on any redirect to \`/login\`, any 4xx/5xx, or any miss. Has retry-with-backoff for post-deploy runs.

Wired into CI two ways:

- **\`validate\` job (every PR):** single attempt against production. Catches \"production is currently broken.\"
- **new \`smoke-test-deploy\` job (main push only, needs \`validate\` + \`sync-assets\`):** 6 attempts × 15s back-off against production. Catches \"the merge I just shipped broke production\" within minutes of Vercel rollout finishing.

Hooked through \`package.json\` + \`turbo.json\` so \`bun run check:public-asset-routes\` works from anywhere in the monorepo.

## What this catches that the previous CI missed

| Bug class | Caught by |
|-----------|-----------|
| Frontmatter \`audio:\` / \`image:\` field references a file not on disk and not in Lago | check:content (already in place) |
| **MDX body inlines an asset that's not in Lago** | check:content body scan (new) |
| **A proxy matcher / public-API allowlist regression sends a public asset to \`/login\`** | verify-public-asset-routes probe (new) |
| **A merge breaks the live asset serving end-to-end** | smoke-test-deploy job (new) |
| Stale cached error responses sticking around for a year | shortened cache header (new) |

## Local validation

- \`bun run turbo test:types --filter=@broomva/web\` ✓ 2/2
- \`bun run turbo lint --filter=@broomva/web\` ✓ 2/2 (warnings only)
- \`bun run check:links\` ✓
- \`bun run check:content\` ✓ 0 warnings (manifest reachable from local)
- \`bun run check:public-asset-routes\` ✓ all 6 probes return 200 / 302 to api.lago.arcan.la

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Reliability**
  * Added automated smoke tests to validate production asset routes post-deployment
  * Enhanced content validation to detect broken embedded media references
  * Updated cache control headers for asset redirects to improve revalidation behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->