### PR TITLE
feat(install): dynamic bstack skill count + /autonomous mode in footer

### DIFF
--- a/crates/broomva-cli/install.sh
+++ b/crates/broomva-cli/install.sh
@@ -5,6 +5,46 @@ REPO="broomva/broomva.tech"
 INSTALL_DIR="${BROOMVA_INSTALL_DIR:-/usr/local/bin}"
 SKIP_SKILLS="${BROOMVA_SKIP_SKILLS:-}"
 
+# ── Dynamic skill-count discovery ──
+#
+# The Broomva Stack is a living roster. Rather than hardcode a count that
+# drifts every time we add or rename a skill, we fetch the authoritative
+# source — the ROSTER array in bstack's own SKILL.md — at install time.
+#
+# Falls back gracefully to a generic phrasing if the network is unavailable
+# or the bstack repo's SKILL.md layout changes.
+BSTACK_SKILL_MD_URL="${BSTACK_SKILL_MD_URL:-https://raw.githubusercontent.com/broomva/bstack/main/SKILL.md}"
+
+get_bstack_skill_count() {
+  # Pull bstack/SKILL.md, extract the ROSTER=( … ) array, count entries.
+  # ROSTER tokens are bare lowercase identifiers separated by whitespace.
+  local count
+  count=$(
+    curl -fsSL "$BSTACK_SKILL_MD_URL" 2>/dev/null \
+      | awk '/^ROSTER=\(/{flag=1} flag{print} /\)/{if (flag) {flag=0}}' \
+      | tr -d '\n' \
+      | sed 's/.*ROSTER=(//; s/).*//' \
+      | tr ' ' '\n' \
+      | grep -cE '^[a-z][a-z0-9-]*$' \
+      || true
+  )
+  # Sanity bound — never claim < 10 or > 200 even if parsing goes sideways.
+  if [ -n "$count" ] && [ "$count" -ge 10 ] && [ "$count" -le 200 ]; then
+    echo "$count"
+  else
+    echo ""
+  fi
+}
+
+# Resolved once at script start so all three install_bstack call sites
+# use the same number (or the same fallback phrasing).
+BSTACK_SKILL_COUNT="$(get_bstack_skill_count)"
+if [ -n "$BSTACK_SKILL_COUNT" ]; then
+  BSTACK_SKILL_PHRASE="${BSTACK_SKILL_COUNT} Broomva Stack skills"
+else
+  BSTACK_SKILL_PHRASE="the Broomva Stack skill roster"
+fi
+
 # ── Colored banner ──
 
 print_banner() {
@@ -126,7 +166,7 @@ install_broomva_skill() {
   fi
 }
 
-# ── Step 3: Install bstack (Broomva Stack — 24 skills) ──
+# ── Step 3: Install bstack (Broomva Stack — count resolved dynamically) ──
 
 install_bstack() {
   if [ -n "$SKIP_SKILLS" ]; then
@@ -144,7 +184,7 @@ install_bstack() {
       # Run bootstrap to install all 24 skills
       if [ -f "$BSTACK_DIR/scripts/bootstrap.sh" ]; then
         echo ""
-        echo "  Bootstrapping 24 Broomva Stack skills..."
+        echo "  Bootstrapping ${BSTACK_SKILL_PHRASE}..."
         bash "$BSTACK_DIR/scripts/bootstrap.sh"
       fi
       return 0
@@ -165,7 +205,7 @@ install_bstack() {
       # Run bootstrap
       if [ -f "$BSTACK_DIR/scripts/bootstrap.sh" ]; then
         echo ""
-        echo "  Bootstrapping 24 Broomva Stack skills..."
+        echo "  Bootstrapping ${BSTACK_SKILL_PHRASE}..."
         bash "$BSTACK_DIR/scripts/bootstrap.sh"
       fi
     else
@@ -219,12 +259,16 @@ echo ""
 echo "  ==========================================="
 echo "  Installation complete!"
 echo ""
-echo "  Get started:"
+echo "  Get started — shell:"
 echo "    broomva setup           # Interactive setup wizard"
 echo "    broomva auth login      # Authenticate"
 echo "    broomva prompts list    # Browse prompts"
 echo "    broomva skills list     # Browse skills"
 echo "    broomva daemon start    # Start monitoring"
+echo ""
+echo "  Get started — Claude Code (substrate + canonical mode):"
+echo "    /bstack                 # Verify the substrate (16 primitives + roster)"
+echo "    /autonomous             # Engage the canonical operating mode"
 echo ""
 echo "  Life Agent OS:"
 echo "    life setup              # Configure AI providers"


### PR DESCRIPTION
## Summary

The \`curl https://broomva.tech/api/install | bash\` installer hardcoded "24 Broomva Stack skills" in three places. Today's [broomva/bstack#9](https://github.com/broomva/bstack/pull/9) brought the roster to **29** (adding \`broomva/autonomous\` on top of the previously-drifted count), exposing the staleness.

This PR makes the count **dynamic** — resolved once at install time from the authoritative source (\`bstack/SKILL.md\` ROSTER array on GitHub raw).

## Changes (single file: \`crates/broomva-cli/install.sh\`)

- New \`get_bstack_skill_count()\` function. Curls \`bstack/SKILL.md\`, extracts \`ROSTER=( … )\`, counts entries. Sanity-bounded (10 ≤ count ≤ 200) to fail safely on parse errors.
- Resolved once at script start (\`BSTACK_SKILL_COUNT\`); the three \`install_bstack\` callsites share the same number.
- **Graceful degradation**: if curl fails or the ROSTER format changes, the script falls back to \"Bootstrapping the Broomva Stack skill roster…\" — no empty or wrong count is ever shown.
- Override via \`BSTACK_SKILL_MD_URL\` env var (useful for testing or pinning a specific bstack ref).
- Footer refresh: new \"Claude Code (substrate + canonical mode)\" block pointing at \`/bstack\` (substrate verify) and \`/autonomous\` (canonical operating mode, just published as \`broomva/autonomous\` v0.0.1).

## Why this matters

Every time the bstack roster changes, the installer would have drifted silently. The current install path (\`/api/install\` Next.js route → GitHub raw → user's shell) already revalidates every 5 minutes, so any future ROSTER addition propagates within minutes — no deploy needed, just a cache refresh.

This is the *operational* form of the gates-are-trust principle introduced today: the source of truth (\`bstack/SKILL.md\`) is the gate; the installer trusts it instead of carrying its own (stale) duplicate.

## Test plan

Verified locally before push:

\`\`\`
$ bash test-extract-count.sh  # live URL
Count resolved: 29
Phrase: \"Bootstrapping 29 Broomva Stack skills...\"

$ bash test-extract-count.sh  # invalid URL
Fallback: \"Bootstrapping the Broomva Stack skill roster...\"
\`\`\`

- [ ] CI lint/format checks green
- [ ] \`curl https://broomva.tech/api/install\` returns the new script (after merge + 5min cache window)
- [ ] First-time install on a clean machine renders \"Bootstrapping 29 Broomva Stack skills...\"

## Follow-ups (separate PRs)

- Onboarding wizard in the \`/bstack\` SKILL.md preamble (interactive first-time setup in Claude Code TUI) — proposed earlier this session
- L3 trust gates (G-L3-1, G-L3-2) wired into GitHub Actions for both \`broomva/workspace\` and \`broomva/bstack\` repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation script now dynamically detects configuration values at install time with fallback support.
  * Expanded "Get started" instructions with dedicated guidance for shell commands and Claude Code workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->