### PR TITLE
Broomva AI-OS — Plan B-4c: Session lens right rail (In context · Memory · Recent ops)

### DIFF
--- a/apps/broomva/components/lenses/session/SceneContext.tsx
+++ b/apps/broomva/components/lenses/session/SceneContext.tsx
@@ -2,6 +2,7 @@
 
 import type { ProsoponEvent, Scene } from "@broomva/prosopon";
 import { createContext, useContext } from "react";
+import { EMPTY_SCENE } from "./useSessionStream";
 
 export interface SceneContextValue {
   scene: Scene;
@@ -23,4 +24,21 @@ export function useSceneContext(): SceneContextValue {
     throw new Error("useSceneContext must be inside <SceneContextProvider>");
   }
   return ctx;
+}
+
+const FALLBACK_SCENE_CONTEXT: SceneContextValue = {
+  scene: EMPTY_SCENE,
+  dispatch: () => {},
+  connected: false,
+  lastSeq: 0n,
+};
+
+/**
+ * Like useSceneContext but returns a safe default (empty scene, disconnected)
+ * when no provider is mounted. Use this in right-rail panels that may be
+ * rendered outside a session route (e.g. on /workspace landing).
+ */
+export function useSceneContextOptional(): SceneContextValue {
+  const ctx = useContext(SceneContext);
+  return ctx ?? FALLBACK_SCENE_CONTEXT;
 }

--- a/apps/broomva/components/lenses/session/__tests__/right-rail/InContextCards.test.tsx
+++ b/apps/broomva/components/lenses/session/__tests__/right-rail/InContextCards.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SceneContextProvider } from "../../SceneContext";
+import { InContextCards } from "../../right-rail/InContextCards";
+
+afterEach(() => cleanup());
+
+const wrap = (scene: unknown) =>
+  render(
+    <SceneContextProvider
+      value={{
+        scene: scene as never,
+        dispatch: () => {},
+        connected: true,
+        lastSeq: 1n,
+      }}
+    >
+      <InContextCards />
+    </SceneContextProvider>,
+  );
+
+describe("InContextCards", () => {
+  it("shows empty-state when no references in scene", () => {
+    wrap({ id: "s", root: { id: "root", intent: { type: "section" } } });
+    expect(screen.getByText(/start a session to populate/i)).toBeTruthy();
+  });
+
+  it("derives one card per fs.* tool_call with a path arg", () => {
+    wrap({
+      id: "s",
+      root: {
+        id: "root",
+        intent: { type: "section" },
+        children: [
+          {
+            id: "a",
+            intent: {
+              type: "tool_call",
+              name: "fs.read",
+              args: { path: "notes/x.md" },
+            },
+          },
+          {
+            id: "b",
+            intent: {
+              type: "tool_call",
+              name: "fs.write",
+              args: { path: "welcome.md" },
+            },
+          },
+        ],
+      },
+    });
+    expect(screen.getByText("notes/x.md")).toBeTruthy();
+    expect(screen.getByText("welcome.md")).toBeTruthy();
+  });
+
+  it("dedupes references to the same path", () => {
+    wrap({
+      id: "s",
+      root: {
+        id: "root",
+        intent: { type: "section" },
+        children: [
+          {
+            id: "a",
+            intent: {
+              type: "tool_call",
+              name: "fs.read",
+              args: { path: "x.md" },
+            },
+          },
+          {
+            id: "b",
+            intent: {
+              type: "tool_call",
+              name: "fs.read",
+              args: { path: "x.md" },
+            },
+          },
+        ],
+      },
+    });
+    expect(screen.getAllByText("x.md")).toHaveLength(1);
+  });
+});

--- a/apps/broomva/components/lenses/session/__tests__/right-rail/MemoryMiniGraph.test.tsx
+++ b/apps/broomva/components/lenses/session/__tests__/right-rail/MemoryMiniGraph.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SceneContextProvider } from "../../SceneContext";
+import { MemoryMiniGraph } from "../../right-rail/MemoryMiniGraph";
+
+afterEach(() => cleanup());
+
+const wrap = (scene: unknown) =>
+  render(
+    <SceneContextProvider
+      value={{
+        scene: scene as never,
+        dispatch: () => {},
+        connected: true,
+        lastSeq: 1n,
+      }}
+    >
+      <MemoryMiniGraph />
+    </SceneContextProvider>,
+  );
+
+describe("MemoryMiniGraph", () => {
+  it("renders empty state when no memory events", () => {
+    wrap({ id: "s", root: { id: "root", intent: { type: "section" } } });
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders touched labels from memory.* tool_calls", () => {
+    wrap({
+      id: "s",
+      root: {
+        id: "root",
+        intent: { type: "section" },
+        children: [
+          {
+            id: "a",
+            intent: {
+              type: "tool_call",
+              name: "memory.query",
+              args: { scope: "aios-proposal" },
+            },
+          },
+          {
+            id: "b",
+            intent: {
+              type: "tool_call",
+              name: "memory.write",
+              args: { node: { label: "primitives" } },
+            },
+          },
+        ],
+      },
+    });
+    expect(screen.getByText("aios-proposal")).toBeTruthy();
+    expect(screen.getByText("primitives")).toBeTruthy();
+  });
+});

--- a/apps/broomva/components/lenses/session/__tests__/right-rail/RecentOpsFeed.test.tsx
+++ b/apps/broomva/components/lenses/session/__tests__/right-rail/RecentOpsFeed.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SceneContextProvider } from "../../SceneContext";
+import { RecentOpsFeed } from "../../right-rail/RecentOpsFeed";
+
+afterEach(() => cleanup());
+
+const wrap = (scene: unknown) =>
+  render(
+    <SceneContextProvider
+      value={{
+        scene: scene as never,
+        dispatch: () => {},
+        connected: true,
+        lastSeq: 1n,
+      }}
+    >
+      <RecentOpsFeed />
+    </SceneContextProvider>,
+  );
+
+describe("RecentOpsFeed", () => {
+  it("shows empty state with no tool_calls", () => {
+    wrap({ id: "s", root: { id: "root", intent: { type: "section" } } });
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders fs/memory tool_calls and not other intents", () => {
+    wrap({
+      id: "s",
+      root: {
+        id: "root",
+        intent: { type: "section" },
+        children: [
+          {
+            id: "a",
+            intent: {
+              type: "tool_call",
+              name: "fs.read",
+              args: { path: "x.md" },
+            },
+          },
+          {
+            id: "b",
+            intent: {
+              type: "tool_call",
+              name: "memory.query",
+              args: { scope: "s" },
+            },
+          },
+          { id: "c", intent: { type: "prose", text: "hello" } },
+        ],
+      },
+    });
+    expect(screen.getByText("fs.read")).toBeTruthy();
+    expect(screen.getByText("memory.query")).toBeTruthy();
+  });
+
+  it("caps the rendered list at 14 entries (newest first)", () => {
+    // 20 fs.read tool_calls pre-order. useRecentOps pushes in pre-order
+    // (op-0 … op-19), then reverses (op-19 … op-0), then slice(0, 14).
+    // Result: op-19 … op-6 are visible; op-5 and below are dropped.
+    const ops = Array.from({ length: 20 }, (_, i) => ({
+      id: `op-${i}`,
+      intent: {
+        type: "tool_call",
+        name: "fs.read",
+        args: { path: `f${i}.md` },
+      },
+    }));
+    wrap({
+      id: "s",
+      root: { id: "root", intent: { type: "section" }, children: ops },
+    });
+    // Newest entry is visible.
+    expect(screen.getByText("f19.md")).toBeTruthy();
+    // 15th-newest (op-5, path f5.md) falls outside the cap.
+    expect(screen.queryByText("f5.md")).toBeNull();
+  });
+});

--- a/apps/broomva/components/lenses/session/right-rail/InContextCards.tsx
+++ b/apps/broomva/components/lenses/session/right-rail/InContextCards.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSceneContext } from "../SceneContext";
+
+interface ContextCard {
+  key: string;
+  kind: "file" | "memory" | "agent";
+  name: string;
+  desc?: string;
+}
+
+/**
+ * InContextCards — derives "what's in context right now" from the scene.
+ *
+ * Scans the tree for:
+ *   - tool_call.args.path on fs.* tools     → file card
+ *   - tool_call.args.scope on memory.*     → memory card
+ *   - entity_ref intents                    → memory card
+ *   - session actor (scene.hints.agent)     → agent card
+ *
+ * Dedupes by (kind, name). Shows up to 5; rest collapsed under "+ N more".
+ * Pure client-side derivation; no extra RPCs.
+ */
+export function InContextCards() {
+  const { scene } = useSceneContext();
+
+  const cards = useMemo<ContextCard[]>(() => {
+    const found = new Map<string, ContextCard>();
+    const add = (c: ContextCard) => {
+      if (!found.has(c.key)) found.set(c.key, c);
+    };
+
+    const walk = (n: {
+      id: string;
+      intent?: {
+        type?: string;
+        kind?: string;
+        name?: string;
+        tool?: string;
+        args?: Record<string, unknown>;
+        label?: string;
+        id?: string;
+      };
+      children?: unknown[];
+    }) => {
+      const discriminator = n.intent?.type ?? n.intent?.kind;
+      const intent = n.intent;
+      if (!intent) return;
+
+      if (discriminator === "tool_call") {
+        const name = intent.name ?? intent.tool ?? "";
+        const path = (intent.args?.path as string | undefined) ?? "";
+        if (name.startsWith("fs.") && path) {
+          add({
+            key: `file:${path}`,
+            kind: "file",
+            name: path,
+            desc: `via ${name}`,
+          });
+        }
+        const scope = (intent.args?.scope as string | undefined) ?? "";
+        if (name.startsWith("memory.") && scope) {
+          add({
+            key: `memory:${scope}`,
+            kind: "memory",
+            name: scope,
+            desc: `via ${name}`,
+          });
+        }
+      }
+      if (discriminator === "entity_ref") {
+        const label = intent.label ?? intent.id ?? "";
+        if (label) {
+          add({ key: `memory:${label}`, kind: "memory", name: label });
+        }
+      }
+      for (const c of (n.children ?? []) as Array<typeof n>) walk(c);
+    };
+
+    const root = (
+      scene as unknown as { root?: { intent?: unknown; children?: unknown[] } }
+    ).root;
+    if (root) walk(root as never);
+
+    // Add the session's actor as an agent card if hinted in the scene.
+    const hints = (
+      scene as unknown as { hints?: { agent?: string; agent_role?: string } }
+    ).hints;
+    if (hints?.agent) {
+      add({
+        key: `agent:${hints.agent}`,
+        kind: "agent",
+        name: hints.agent,
+        desc: hints.agent_role,
+      });
+    }
+
+    return Array.from(found.values());
+  }, [scene]);
+
+  if (cards.length === 0) {
+    return (
+      <div className="px-1 py-2 font-mono text-[11px] opacity-60">
+        Start a session to populate context.
+      </div>
+    );
+  }
+
+  const visible = cards.slice(0, 5);
+  const extra = cards.length - visible.length;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {visible.map((c) => (
+        <div
+          key={c.key}
+          className="ag-glass-subtle rounded-md border border-white/10 px-2.5 py-2"
+        >
+          <div className="flex items-center gap-1.5 font-mono text-[11px]">
+            <span
+              aria-hidden
+              style={{
+                color:
+                  c.kind === "file"
+                    ? "var(--ag-ai-blue)"
+                    : c.kind === "memory"
+                      ? "var(--ag-accent-blue)"
+                      : "var(--ag-warning)",
+              }}
+            >
+              {c.kind === "file" ? "▤" : c.kind === "memory" ? "◇" : "◉"}
+            </span>
+            <span className="truncate">{c.name}</span>
+            <span className="ml-auto text-[9.5px] opacity-50">{c.kind}</span>
+          </div>
+          {c.desc && (
+            <div className="mt-1 text-[11px] leading-[1.5] opacity-65">
+              {c.desc}
+            </div>
+          )}
+        </div>
+      ))}
+      {extra > 0 && (
+        <div className="px-1 font-mono text-[10px] opacity-55">
+          + {extra} more
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/broomva/components/lenses/session/right-rail/InContextCards.tsx
+++ b/apps/broomva/components/lenses/session/right-rail/InContextCards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useSceneContext } from "../SceneContext";
+import { useSceneContextOptional } from "../SceneContext";
 
 interface ContextCard {
   key: string;
@@ -23,7 +23,7 @@ interface ContextCard {
  * Pure client-side derivation; no extra RPCs.
  */
 export function InContextCards() {
-  const { scene } = useSceneContext();
+  const { scene } = useSceneContextOptional();
 
   const cards = useMemo<ContextCard[]>(() => {
     const found = new Map<string, ContextCard>();

--- a/apps/broomva/components/lenses/session/right-rail/MemoryMiniGraph.tsx
+++ b/apps/broomva/components/lenses/session/right-rail/MemoryMiniGraph.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSceneContext } from "../SceneContext";
+
+interface Touched {
+  id: string;
+  label: string;
+}
+
+/**
+ * MemoryMiniGraph — small radial graph of memory entities touched in the
+ * current session. Reads memory.touch / memory.query / memory.write
+ * tool_calls and entity_ref intents. Renders up to 7 nodes in a radial
+ * layout with a central node + spokes.
+ *
+ * Pure SVG; no chart library. Empty state when no memory activity yet.
+ */
+export function MemoryMiniGraph() {
+  const { scene } = useSceneContext();
+
+  const touched = useMemo<Touched[]>(() => {
+    const found = new Map<string, Touched>();
+    const walk = (n: {
+      id: string;
+      intent?: {
+        type?: string;
+        kind?: string;
+        name?: string;
+        tool?: string;
+        args?: Record<string, unknown>;
+        label?: string;
+        id?: string;
+      };
+      children?: unknown[];
+    }) => {
+      const discriminator = n.intent?.type ?? n.intent?.kind;
+      const intent = n.intent;
+      if (intent && discriminator === "tool_call") {
+        const name = intent.name ?? intent.tool ?? "";
+        if (name.startsWith("memory.")) {
+          const scope = (intent.args?.scope as string | undefined) ?? "";
+          const node =
+            (intent.args?.node as
+              | { label?: string; id?: string }
+              | undefined) ?? {};
+          const label = node.label ?? node.id ?? scope;
+          if (label && !found.has(label)) {
+            found.set(label, { id: label, label });
+          }
+        }
+      }
+      if (intent && discriminator === "entity_ref") {
+        const label = intent.label ?? intent.id ?? "";
+        if (label && !found.has(label)) {
+          found.set(label, { id: label, label });
+        }
+      }
+      for (const c of (n.children ?? []) as Array<typeof n>) walk(c);
+    };
+    const root = (scene as unknown as { root?: unknown }).root;
+    if (root) walk(root as never);
+    return Array.from(found.values()).slice(0, 7);
+  }, [scene]);
+
+  if (touched.length === 0) {
+    return <div className="px-1 py-2 font-mono text-[11px] opacity-60">—</div>;
+  }
+
+  const center = touched[0];
+  const peripherals = touched.slice(1);
+  const n = peripherals.length;
+  const cx = 50;
+  const cy = 50;
+  const r = 32;
+
+  return (
+    <div className="ag-glass-subtle relative h-[140px] rounded-md border border-white/10 p-3">
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="absolute inset-2 h-[calc(100%-16px)] w-[calc(100%-16px)]"
+        aria-hidden
+      >
+        {peripherals.map((p, i) => {
+          const angle = (i / Math.max(n, 1)) * Math.PI * 2 - Math.PI / 2;
+          const x = cx + Math.cos(angle) * r;
+          const y = cy + Math.sin(angle) * r;
+          return (
+            <line
+              key={p.id}
+              x1={cx}
+              y1={cy}
+              x2={x}
+              y2={y}
+              stroke="rgba(96,165,250,.4)"
+              strokeWidth={0.5}
+              vectorEffect="non-scaling-stroke"
+            />
+          );
+        })}
+      </svg>
+      <div
+        className="absolute font-mono text-[9px]"
+        style={{
+          left: "50%",
+          top: "50%",
+          transform: "translate(-50%, -50%)",
+          background: "var(--ag-ai-blue)",
+          color: "var(--ag-bg-deep)",
+          padding: "3px 6px",
+          borderRadius: "4px",
+          fontWeight: 500,
+          whiteSpace: "nowrap",
+          maxWidth: "12ch",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+      >
+        {center.label}
+      </div>
+      {peripherals.map((p, i) => {
+        const angle = (i / Math.max(n, 1)) * Math.PI * 2 - Math.PI / 2;
+        const x = cx + Math.cos(angle) * r;
+        const y = cy + Math.sin(angle) * r;
+        return (
+          <div
+            key={p.id}
+            className="absolute font-mono text-[8.5px]"
+            style={{
+              left: `${x}%`,
+              top: `${y}%`,
+              transform: "translate(-50%, -50%)",
+              background:
+                "color-mix(in oklab, var(--ag-ai-blue) 20%, transparent)",
+              border:
+                "1px solid color-mix(in oklab, var(--ag-ai-blue) 40%, transparent)",
+              color: "rgba(255,255,255,.85)",
+              padding: "2px 5px",
+              borderRadius: "3px",
+              whiteSpace: "nowrap",
+              maxWidth: "10ch",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {p.label}
+          </div>
+        );
+      })}
+      <div className="absolute bottom-1 left-0 right-0 text-center font-mono text-[9px] opacity-55">
+        {touched.length} node{touched.length === 1 ? "" : "s"} touched
+      </div>
+    </div>
+  );
+}

--- a/apps/broomva/components/lenses/session/right-rail/MemoryMiniGraph.tsx
+++ b/apps/broomva/components/lenses/session/right-rail/MemoryMiniGraph.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useSceneContext } from "../SceneContext";
+import { useSceneContextOptional } from "../SceneContext";
 
 interface Touched {
   id: string;
@@ -17,7 +17,7 @@ interface Touched {
  * Pure SVG; no chart library. Empty state when no memory activity yet.
  */
 export function MemoryMiniGraph() {
-  const { scene } = useSceneContext();
+  const { scene } = useSceneContextOptional();
 
   const touched = useMemo<Touched[]>(() => {
     const found = new Map<string, Touched>();

--- a/apps/broomva/components/lenses/session/right-rail/RecentOpsFeed.tsx
+++ b/apps/broomva/components/lenses/session/right-rail/RecentOpsFeed.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRecentOps } from "./useRecentOps";
+
+const KIND_COLOR: Record<string, string> = {
+  fs: "var(--ag-ai-blue)",
+  memory: "var(--ag-accent-blue)",
+  run: "var(--ag-success)",
+  policy: "var(--ag-warning)",
+  payment: "var(--ag-warning)",
+};
+
+/**
+ * RecentOpsFeed — live-updating list of recent fs/memory/run/policy/
+ * payment events derived from the scene. Color-coded pip per kind, newest
+ * at top.
+ *
+ * The list is a pure derivation of scene state via useRecentOps; new
+ * envelopes from the SSE stream cause the scene reducer to apply, which
+ * re-derives the ops list. No subscription duplication.
+ */
+export function RecentOpsFeed() {
+  const ops = useRecentOps();
+
+  if (ops.length === 0) {
+    return <div className="px-1 py-2 font-mono text-[11px] opacity-60">—</div>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-1 font-mono text-[10.5px]">
+      {ops.map((op) => (
+        <li
+          key={op.id}
+          className="flex items-center gap-1.5 rounded border border-white/[0.06] bg-black/15 px-2 py-1"
+        >
+          <span
+            className="h-1 w-1 shrink-0 rounded-full"
+            style={{
+              background: KIND_COLOR[op.kind] ?? "var(--ag-text-muted)",
+            }}
+            aria-hidden
+          />
+          <span className="truncate">
+            <span className="opacity-90">{op.label}</span>
+            {op.arg && <span className="ml-1 opacity-55">{op.arg}</span>}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/broomva/components/lenses/session/right-rail/RightRailSession.tsx
+++ b/apps/broomva/components/lenses/session/right-rail/RightRailSession.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { InContextCards } from "./InContextCards";
+import { MemoryMiniGraph } from "./MemoryMiniGraph";
+import { RecentOpsFeed } from "./RecentOpsFeed";
+
+function RailHeading({ children, hint }: { children: string; hint?: string }) {
+  return (
+    <h6 className="mt-5 mb-2 flex items-center gap-2 px-1 font-mono text-[10px] uppercase tracking-[0.16em] opacity-60">
+      <span>{children}</span>
+      {hint && <span className="opacity-70">{hint}</span>}
+    </h6>
+  );
+}
+
+/**
+ * RightRailSession — three stacked panels surfaced when the Session lens
+ * is active. Replaces the B-4a placeholder content of RightRail when the
+ * workspace lens is `session`.
+ */
+export function RightRailSession() {
+  return (
+    <div className="px-3 pb-3">
+      <RailHeading>In context</RailHeading>
+      <InContextCards />
+
+      <RailHeading>Memory · this session</RailHeading>
+      <MemoryMiniGraph />
+
+      <RailHeading hint="· live">Recent operations</RailHeading>
+      <RecentOpsFeed />
+    </div>
+  );
+}

--- a/apps/broomva/components/lenses/session/right-rail/useRecentOps.ts
+++ b/apps/broomva/components/lenses/session/right-rail/useRecentOps.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useSceneContext } from "../SceneContext";
+import { useSceneContextOptional } from "../SceneContext";
 
 export interface OpEntry {
   id: string;
@@ -52,7 +52,7 @@ function kindOf(name: string): OpEntry["kind"] {
  * subscription.
  */
 export function useRecentOps(): OpEntry[] {
-  const { scene } = useSceneContext();
+  const { scene } = useSceneContextOptional();
   return useMemo<OpEntry[]>(() => {
     const out: OpEntry[] = [];
     const walk = (n: {

--- a/apps/broomva/components/lenses/session/right-rail/useRecentOps.ts
+++ b/apps/broomva/components/lenses/session/right-rail/useRecentOps.ts
@@ -1,0 +1,108 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSceneContext } from "../SceneContext";
+
+export interface OpEntry {
+  id: string;
+  kind: "fs" | "memory" | "run" | "policy" | "payment";
+  label: string;
+  arg?: string;
+  ts?: number;
+  source?: string;
+}
+
+const OPS_FILTER = new Set([
+  "fs.read",
+  "fs.write",
+  "fs.list",
+  "fs.search",
+  "fs.apply_patch",
+  "memory.query",
+  "memory.write",
+  "memory.touch",
+  "memory.link",
+  "bash",
+  "run.start",
+  "run.end",
+  "run.heartbeat",
+  "policy.grant",
+  "policy.deny",
+  "policy.review",
+  "payment.debit",
+  "payment.credit",
+]);
+
+function kindOf(name: string): OpEntry["kind"] {
+  if (name.startsWith("fs.") || name === "bash") return "fs";
+  if (name.startsWith("memory.")) return "memory";
+  if (name.startsWith("run.")) return "run";
+  if (name.startsWith("policy.")) return "policy";
+  if (name.startsWith("payment.")) return "payment";
+  return "fs";
+}
+
+/**
+ * Derives a recent-operations list from the current scene by walking the
+ * tree pre-order, finding tool_call intents whose name matches the ops
+ * filter, and emitting an OpEntry per match. Newest-first; capped at 14.
+ *
+ * The list updates reactively when the scene reducer applies new
+ * tool_call envelopes — the hook is a pure derivation, no separate
+ * subscription.
+ */
+export function useRecentOps(): OpEntry[] {
+  const { scene } = useSceneContext();
+  return useMemo<OpEntry[]>(() => {
+    const out: OpEntry[] = [];
+    const walk = (n: {
+      id: string;
+      intent?: {
+        type?: string;
+        kind?: string;
+        name?: string;
+        tool?: string;
+        args?: Record<string, unknown>;
+      };
+      attrs?: { source?: string; ts?: number };
+      children?: unknown[];
+    }) => {
+      const discriminator = n.intent?.type ?? n.intent?.kind;
+      if (discriminator === "tool_call") {
+        const name = n.intent?.name ?? n.intent?.tool ?? "";
+        if (
+          OPS_FILTER.has(name) ||
+          name.startsWith("fs.") ||
+          name.startsWith("memory.")
+        ) {
+          const firstArg = n.intent?.args
+            ? Object.values(n.intent.args).find((v) => typeof v === "string")
+            : undefined;
+          out.push({
+            id: n.id,
+            kind: kindOf(name),
+            label: name,
+            arg:
+              typeof firstArg === "string" ? firstArg.slice(0, 60) : undefined,
+            ts: n.attrs?.ts,
+            source: n.attrs?.source,
+          });
+        }
+      }
+      for (const c of (n.children ?? []) as Array<typeof n>) walk(c);
+    };
+    const root = (
+      scene as unknown as {
+        root?: {
+          id: string;
+          intent?: { type?: string; kind?: string };
+          children?: unknown[];
+        };
+      }
+    ).root;
+    if (root) walk(root as never);
+    // Newest first (reverse pre-order: latest descendants are usually
+    // emitted last, so we reverse the walk result).
+    return out.reverse().slice(0, 14);
+  }, [scene]);
+}

--- a/apps/broomva/components/lenses/session/useSessionStream.ts
+++ b/apps/broomva/components/lenses/session/useSessionStream.ts
@@ -8,7 +8,7 @@ import {
 } from "@broomva/prosopon";
 import { useEffect, useReducer, useRef, useState } from "react";
 
-const EMPTY_SCENE: Scene = {
+export const EMPTY_SCENE: Scene = {
   id: "",
   root: {
     id: "root",

--- a/apps/broomva/components/workspace-shell/RightRail.tsx
+++ b/apps/broomva/components/workspace-shell/RightRail.tsx
@@ -1,32 +1,18 @@
-function RailHeading({ children }: { children: string }) {
-  return (
-    <h6 className="mt-5 mb-2 px-1 font-mono text-[10px] uppercase tracking-[0.16em] opacity-60">
-      {children}
-    </h6>
-  );
-}
+import { RightRailSession } from "@/components/lenses/session/right-rail/RightRailSession";
 
 /**
- * Right rail — context-aware. In the Session lens it shows In-context cards,
- * a this-session memory mini-graph, and a live Recent operations feed. In v1
- * all three sections are placeholders; data binding happens in PR 4.
+ * Right rail — context-aware. In v1, only the Session lens has right-rail
+ * content (three panels: In context, Memory mini-graph, Recent operations).
+ * Other lenses (Files, Agents) will mount their own rail composition when
+ * they ship.
  */
 export function RightRail() {
   return (
     <aside
       aria-label="Right rail"
-      className="overflow-y-auto border-l border-[color:var(--ag-border-subtle)] px-3 pb-3"
+      className="overflow-y-auto border-l border-[color:var(--ag-border-subtle)]"
     >
-      <RailHeading>In context</RailHeading>
-      <div className="px-1 py-2 font-mono text-[11px] opacity-60">
-        Start a session to populate context.
-      </div>
-
-      <RailHeading>Memory · this session</RailHeading>
-      <div className="px-1 py-2 font-mono text-[11px] opacity-60">—</div>
-
-      <RailHeading>Recent operations</RailHeading>
-      <div className="px-1 py-2 font-mono text-[11px] opacity-60">—</div>
+      <RightRailSession />
     </aside>
   );
 }


### PR DESCRIPTION
Implements Plan B-4c from `docs/superpowers/plans/2026-05-13-broomva-session-lens-plan-b4c-right-rail.md`. Final slice of the Session lens — turns on the right rail.

Descends from `docs/superpowers/specs/2026-05-12-broomva-session-lens-design.md` §5.6 and §11 phase B-4c.

## What lands

Three stacked right-rail panels surfaced when the Session lens is active:

- **InContextCards** — derives one card per file/memory/agent referenced in the current scene. Pure client-side; dedupes by (kind, name); shows up to 5 with "+ N more" expander.
- **MemoryMiniGraph** — radial SVG of up to 7 memory entities touched in the session (from `memory.touch` / `memory.query` / `memory.write` tool_calls and `entity_ref` intents). Center + spokes layout.
- **RecentOpsFeed** — live-updating list of fs / memory / run / policy / payment events derived from the same scene (no extra subscription). Color-coded pip per kind, newest at top, capped at 14.

`RightRailSession` composition root stacks the three. `useRecentOps` hook centralizes the ops derivation. The workspace shell's `RightRail` placeholder is replaced with `<RightRailSession />`.

## Provider safety

`useSceneContextOptional` is added alongside the strict `useSceneContext`: returns an empty-scene fallback when no provider is mounted. Right-rail panels use the optional variant because they render on every `/workspace/*` route — including `/workspace` (landing, no session yet) where the `SceneContextProvider` is absent. `EMPTY_SCENE` is now exported from `useSessionStream.ts` so the fallback can reuse it.

## Validation

- `bun run turbo lint --filter=@broomva/web`: ✓ 2/2 successful (pre-existing warnings only)
- `bun run turbo test:types --filter=@broomva/web`: ✓ 2/2 successful
- `bun run test:unit components/lenses/session/`: ✓ 28/28 tests passing (20 from B-4b + 8 new)

## What does NOT land (deferred)

- Entity inspector overlay (clicking a memory mini-graph node or an `entity_ref` intent) — needs the Memory lens (v1.1 spec)
- Live "fade-in" animation on new ops entries — visual polish for v1.1
- Pinned items section (the workspace shell left rail has a placeholder; not in B-4c scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)