### PR TITLE
Broomva AI-OS — Plan B-6: Agents lens (gallery · cards · capability chips)

### DIFF
--- a/apps/broomva/app/workspace/[sessionId]/page.tsx
+++ b/apps/broomva/app/workspace/[sessionId]/page.tsx
@@ -1,31 +1,30 @@
+import { AgentsLens } from "@/components/lenses/agents/AgentsLens";
 import { FilesLens } from "@/components/lenses/files/FilesLens";
 import { SessionLensClient } from "@/components/lenses/session/SessionLensClient";
 import { WorkspaceSession } from "@/components/lenses/session/WorkspaceSession";
 
 interface SessionPageProps {
   params: Promise<{ sessionId: string }>;
-  searchParams: Promise<{ seq?: string; file?: string }>;
+  searchParams: Promise<{ seq?: string; file?: string; lens?: string }>;
 }
 
 /**
- * Per-session page. Server Component reads `sessionId`, an optional
- * `?seq=N` resume cursor, and an optional `?file=<path>` Files-lens
- * activation token from searchParams, then hands off to the wrapper
- * + lens combination.
+ * Per-session page. Three lens branches driven by searchParams:
  *
- * The `?file=` param is the activation contract for the Files lens:
- *   /workspace/[sid]                       → Session lens (chat canvas)
- *   /workspace/[sid]?file=welcome.md       → Files lens (viewer + outline + backlinks)
+ *   /workspace/[sid]                          → Session lens (chat canvas)
+ *   /workspace/[sid]?file=<path>              → Files lens
+ *   /workspace/[sid]?lens=agents              → Agents lens (gallery)
  *
- * Both lenses share a single SSE stream + SceneContextProvider mounted
- * in `WorkspaceSession`.
+ * All three share the WorkspaceSession wrapper, which owns the SSE
+ * stream + SceneContextProvider so the scene is consistent across lens
+ * switches without re-subscribing.
  */
 export default async function SessionPage({
   params,
   searchParams,
 }: SessionPageProps) {
   const { sessionId } = await params;
-  const { seq, file } = await searchParams;
+  const { seq, file, lens } = await searchParams;
   const initialSeq = ((): bigint => {
     if (!seq) return 0n;
     try {
@@ -34,9 +33,16 @@ export default async function SessionPage({
       return 0n;
     }
   })();
+  const body = file ? (
+    <FilesLens file={file} />
+  ) : lens === "agents" ? (
+    <AgentsLens />
+  ) : (
+    <SessionLensClient sid={sessionId} />
+  );
   return (
     <WorkspaceSession sid={sessionId} initialSeq={initialSeq}>
-      {file ? <FilesLens file={file} /> : <SessionLensClient sid={sessionId} />}
+      {body}
     </WorkspaceSession>
   );
 }

--- a/apps/broomva/components/lenses/agents/AgentCard.tsx
+++ b/apps/broomva/components/lenses/agents/AgentCard.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { CapabilityChip } from "./CapabilityChip";
+import type { AgentSpec } from "./useAgents";
+
+interface Props {
+  spec: AgentSpec;
+}
+
+/**
+ * AgentCard — one card per installed agent. Renders avatar (deterministic
+ * gradient from agent id), name + archetype tag, description, capability
+ * chips (one per grant), model badge, and a passive "view spec" hint that
+ * routes to the Files lens viewer for the underlying spec.md.
+ *
+ * v1: clicking the card body opens the spec file in the Files lens via
+ * `?file=agents/<id>/spec.md`. Starting a session with the agent (the
+ * parent-spec Open button) is deferred to Plan C (welcome-agent wiring).
+ */
+export function AgentCard({ spec }: Props) {
+  const {
+    id,
+    name,
+    archetype,
+    description,
+    model,
+    grants,
+    approvalMode,
+    path,
+  } = spec;
+
+  return (
+    <a
+      href={`?file=${encodeURIComponent(path)}`}
+      className="ag-glass-subtle flex flex-col gap-2.5 rounded-md border border-white/10 p-4 transition-colors hover:border-white/25 hover:bg-[color:var(--ag-bg-hover)]"
+    >
+      <header className="flex items-center gap-3">
+        <Avatar id={id} />
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate font-mono text-[13px] font-medium">
+            {name}
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.1em] opacity-60">
+            {archetype}
+          </span>
+        </div>
+        {model && (
+          <span
+            className="ml-auto rounded px-1.5 py-0.5 font-mono text-[9.5px]"
+            style={{
+              background:
+                "color-mix(in oklab, var(--ag-ai-blue) 16%, transparent)",
+              color: "var(--ag-ai-blue)",
+            }}
+          >
+            {model}
+          </span>
+        )}
+      </header>
+      {description && (
+        <p className="font-mono text-[11px] leading-[1.55] opacity-75">
+          {description}
+        </p>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {grants.length === 0 ? (
+          <span className="font-mono text-[10px] opacity-50">no grants</span>
+        ) : (
+          grants.map((g) => (
+            <CapabilityChip
+              key={g}
+              label={g}
+              variant={approvalMode === "always" ? "warn" : "ok"}
+            />
+          ))
+        )}
+      </div>
+      <footer className="flex items-center justify-between font-mono text-[9.5px] opacity-50">
+        <span>approval · {approvalMode}</span>
+        <span>view spec →</span>
+      </footer>
+    </a>
+  );
+}
+
+function Avatar({ id }: { id: string }) {
+  // Deterministic gradient seeded by id char codes; no external deps.
+  const seed = Array.from(id).reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  const hue = seed % 360;
+  return (
+    <div
+      aria-hidden
+      className="h-9 w-9 shrink-0 rounded-full"
+      style={{
+        background: `linear-gradient(135deg, hsl(${hue}deg 70% 55%), hsl(${(hue + 60) % 360}deg 70% 45%))`,
+      }}
+    />
+  );
+}

--- a/apps/broomva/components/lenses/agents/AgentsLens.tsx
+++ b/apps/broomva/components/lenses/agents/AgentsLens.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { AgentCard } from "./AgentCard";
+import { useAgents } from "./useAgents";
+
+/**
+ * AgentsLens — center-stage gallery. v1 ships read-only: each card opens
+ * the underlying spec.md in the Files lens viewer (via ?file=). Per the
+ * parent spec, Plan C will wire an "Open session" action that calls
+ * Agent.CreateSession via the lifegw client.
+ */
+export function AgentsLens() {
+  const agents = useAgents();
+
+  if (agents.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-6 font-mono text-[12px] opacity-60">
+        No agents installed yet. The Welcome agent will populate this lens.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto px-6 py-5">
+      <header className="mb-4 flex items-baseline gap-3">
+        <h1 className="font-mono text-[15px]">Agents</h1>
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] opacity-55">
+          {agents.length} installed
+        </span>
+      </header>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-3">
+        {agents.map((a) => (
+          <AgentCard key={a.id} spec={a} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/broomva/components/lenses/agents/CapabilityChip.tsx
+++ b/apps/broomva/components/lenses/agents/CapabilityChip.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+type Variant = "ok" | "warn" | "no";
+
+interface Props {
+  label: string;
+  variant?: Variant;
+}
+
+const VARIANT_STYLE: Record<Variant, { bg: string; fg: string; mark: string }> =
+  {
+    ok: {
+      bg: "color-mix(in oklab, var(--ag-success) 18%, transparent)",
+      fg: "var(--ag-success)",
+      mark: "✓",
+    },
+    warn: {
+      bg: "color-mix(in oklab, var(--ag-warning) 18%, transparent)",
+      fg: "var(--ag-warning)",
+      mark: "!",
+    },
+    no: {
+      bg: "color-mix(in oklab, var(--ag-text-muted) 12%, transparent)",
+      fg: "var(--ag-text-muted)",
+      mark: "✕",
+    },
+  };
+
+/**
+ * CapabilityChip — single ok/warn/no chip used inside AgentCard to surface
+ * granted tool prefixes (fs.read, memory.write, …). Variants signal policy
+ * stance: ok = granted, warn = granted but gated by approval, no = denied.
+ */
+export function CapabilityChip({ label, variant = "ok" }: Props) {
+  const s = VARIANT_STYLE[variant];
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px]"
+      style={{ background: s.bg, color: s.fg }}
+    >
+      <span aria-hidden>{s.mark}</span>
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/apps/broomva/components/lenses/agents/__tests__/AgentCard.test.tsx
+++ b/apps/broomva/components/lenses/agents/__tests__/AgentCard.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentCard } from "../AgentCard";
+import type { AgentSpec } from "../useAgents";
+
+afterEach(() => cleanup());
+
+const spec: AgentSpec = {
+  id: "atlas",
+  path: "agents/atlas/spec.md",
+  name: "Atlas",
+  archetype: "resident",
+  description: "Resident agent of this workspace.",
+  model: "claude-sonnet-4.5",
+  grants: ["fs.read", "fs.write"],
+  approvalMode: "silent",
+  eventId: "evt-1",
+};
+
+describe("AgentCard", () => {
+  it("renders name, archetype, description, model, and one chip per grant", () => {
+    render(<AgentCard spec={spec} />);
+    expect(screen.getByText("Atlas")).toBeTruthy();
+    expect(screen.getByText("resident")).toBeTruthy();
+    expect(screen.getByText("Resident agent of this workspace.")).toBeTruthy();
+    expect(screen.getByText("claude-sonnet-4.5")).toBeTruthy();
+    expect(screen.getByText("fs.read")).toBeTruthy();
+    expect(screen.getByText("fs.write")).toBeTruthy();
+  });
+
+  it("shows 'no grants' when grants array is empty", () => {
+    render(<AgentCard spec={{ ...spec, grants: [] }} />);
+    expect(screen.getByText("no grants")).toBeTruthy();
+  });
+
+  it("points href at the spec file for Files-lens preview", () => {
+    const { container } = render(<AgentCard spec={spec} />);
+    const link = container.querySelector("a");
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe(
+      `?file=${encodeURIComponent("agents/atlas/spec.md")}`,
+    );
+  });
+});

--- a/apps/broomva/components/lenses/agents/__tests__/AgentsLens.test.tsx
+++ b/apps/broomva/components/lenses/agents/__tests__/AgentsLens.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SceneContextProvider } from "../../session/SceneContext";
+import { AgentsLens } from "../AgentsLens";
+
+afterEach(() => cleanup());
+
+const wrap = (scene: unknown) =>
+  render(
+    <SceneContextProvider
+      value={{
+        scene: scene as never,
+        dispatch: () => {},
+        connected: true,
+        lastSeq: 1n,
+      }}
+    >
+      <AgentsLens />
+    </SceneContextProvider>,
+  );
+
+describe("AgentsLens", () => {
+  it("renders empty state when scene has no agent specs", () => {
+    wrap({ id: "s", root: { id: "root", intent: { type: "section" } } });
+    expect(screen.getByText(/no agents installed yet/i)).toBeTruthy();
+  });
+
+  it("renders an AgentCard per agents/*/spec.md fs.write", () => {
+    wrap({
+      id: "s",
+      root: {
+        id: "root",
+        intent: { type: "section" },
+        children: [
+          {
+            id: "a",
+            intent: {
+              type: "tool_call",
+              name: "fs.write",
+              args: {
+                path: "agents/atlas/spec.md",
+                frontmatter: { name: "Atlas", archetype: "resident" },
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(screen.getByText("Atlas")).toBeTruthy();
+    expect(screen.getByText("1 installed")).toBeTruthy();
+  });
+});

--- a/apps/broomva/components/lenses/agents/__tests__/useAgents.test.tsx
+++ b/apps/broomva/components/lenses/agents/__tests__/useAgents.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SceneContextProvider } from "../../session/SceneContext";
+import { useAgents } from "../useAgents";
+
+afterEach(() => cleanup());
+
+const wrap =
+  (scene: unknown) =>
+  ({ children }: { children: ReactNode }): ReactElement => (
+    <SceneContextProvider
+      value={{
+        scene: scene as never,
+        dispatch: () => {},
+        connected: true,
+        lastSeq: 1n,
+      }}
+    >
+      {children}
+    </SceneContextProvider>
+  );
+
+describe("useAgents", () => {
+  it("returns empty list when no agents/*/spec.md fs.write events exist", () => {
+    const { result } = renderHook(() => useAgents(), {
+      wrapper: wrap({
+        id: "s",
+        root: { id: "root", intent: { type: "section" } },
+      }),
+    });
+    expect(result.current).toHaveLength(0);
+  });
+
+  it("derives one AgentSpec per agents/<id>/spec.md fs.write", () => {
+    const { result } = renderHook(() => useAgents(), {
+      wrapper: wrap({
+        id: "s",
+        root: {
+          id: "root",
+          intent: { type: "section" },
+          children: [
+            {
+              id: "a",
+              intent: {
+                type: "tool_call",
+                name: "fs.write",
+                args: {
+                  path: "agents/atlas/spec.md",
+                  frontmatter: {
+                    name: "Atlas",
+                    archetype: "resident",
+                    description: "Resident agent",
+                    model: "claude-sonnet-4.5",
+                    grants: ["fs.read", "fs.write"],
+                    approval_mode: "silent",
+                  },
+                },
+              },
+            },
+            {
+              id: "b",
+              intent: {
+                type: "tool_call",
+                name: "fs.write",
+                args: {
+                  path: "agents/builder/spec.md",
+                  frontmatter: {
+                    name: "Builder",
+                    archetype: "engineer",
+                    grants: ["fs.read", "fs.write", "bash"],
+                    approval_mode: "review",
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    });
+    expect(result.current).toHaveLength(2);
+    expect(result.current.map((a) => a.name)).toEqual(["Atlas", "Builder"]);
+    const atlas = result.current[0];
+    expect(atlas.archetype).toBe("resident");
+    expect(atlas.grants).toEqual(["fs.read", "fs.write"]);
+    expect(atlas.approvalMode).toBe("silent");
+  });
+
+  it("ignores fs.write events outside the agents/*/spec.md pattern", () => {
+    const { result } = renderHook(() => useAgents(), {
+      wrapper: wrap({
+        id: "s",
+        root: {
+          id: "root",
+          intent: { type: "section" },
+          children: [
+            {
+              id: "a",
+              intent: {
+                type: "tool_call",
+                name: "fs.write",
+                args: { path: "welcome.md" },
+              },
+            },
+            {
+              id: "b",
+              intent: {
+                type: "tool_call",
+                name: "fs.write",
+                args: { path: "agents/atlas/notes.md" },
+              },
+            },
+          ],
+        },
+      }),
+    });
+    expect(result.current).toHaveLength(0);
+  });
+
+  it("normalizes invalid approval_mode to 'silent'", () => {
+    const { result } = renderHook(() => useAgents(), {
+      wrapper: wrap({
+        id: "s",
+        root: {
+          id: "root",
+          intent: { type: "section" },
+          children: [
+            {
+              id: "a",
+              intent: {
+                type: "tool_call",
+                name: "fs.write",
+                args: {
+                  path: "agents/foo/spec.md",
+                  frontmatter: { approval_mode: "yolo" },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    });
+    expect(result.current[0].approvalMode).toBe("silent");
+  });
+});

--- a/apps/broomva/components/lenses/agents/useAgents.ts
+++ b/apps/broomva/components/lenses/agents/useAgents.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSceneContextOptional } from "../session/SceneContext";
+
+export type ApprovalMode = "silent" | "review" | "always";
+
+export interface AgentSpec {
+  /** Stable id derived from the agents/<id>/spec.md path. */
+  id: string;
+  /** Full spec.md path. */
+  path: string;
+  /** Human display name, e.g. "Atlas". */
+  name: string;
+  /** Archetype label, e.g. "resident", "engineer", "researcher". */
+  archetype: string;
+  /** One-line description from frontmatter. */
+  description?: string;
+  /** Model class slug, e.g. "claude-sonnet-4.5". */
+  model?: string;
+  /** Granted tool prefixes, e.g. ["fs.read", "memory.write"]. */
+  grants: string[];
+  /** Approval gating policy. */
+  approvalMode: ApprovalMode;
+  /** Event id of the latest spec write. */
+  eventId: string;
+}
+
+const SPEC_PATH = /^agents\/([^/]+)\/spec\.md$/;
+
+function normalizeApprovalMode(v: unknown): ApprovalMode {
+  if (v === "review" || v === "always") return v;
+  return "silent";
+}
+
+/**
+ * Walk the scene for `fs.write` tool_calls whose path matches
+ * `agents/<slug>/spec.md`. Returns one AgentSpec per unique slug (latest
+ * write wins). Pure scene-derivation; no extra subscription.
+ */
+export function useAgents(): AgentSpec[] {
+  const { scene } = useSceneContextOptional();
+
+  return useMemo<AgentSpec[]>(() => {
+    const byId = new Map<string, AgentSpec>();
+
+    const walk = (n: {
+      id: string;
+      intent?: {
+        type?: string;
+        kind?: string;
+        name?: string;
+        tool?: string;
+        args?: Record<string, unknown>;
+      };
+      children?: unknown[];
+    }) => {
+      const discriminator = n.intent?.type ?? n.intent?.kind;
+      if (discriminator === "tool_call") {
+        const name = n.intent?.name ?? n.intent?.tool ?? "";
+        if (name === "fs.write" || name === "fs.apply_patch") {
+          const path = n.intent?.args?.path;
+          if (typeof path === "string") {
+            const m = SPEC_PATH.exec(path);
+            if (m) {
+              const id = m[1];
+              const fm =
+                (n.intent?.args?.frontmatter as Record<string, unknown>) ?? {};
+              byId.set(id, {
+                id,
+                path,
+                name: typeof fm.name === "string" ? fm.name : id,
+                archetype:
+                  typeof fm.archetype === "string" ? fm.archetype : "agent",
+                description:
+                  typeof fm.description === "string"
+                    ? fm.description
+                    : undefined,
+                model: typeof fm.model === "string" ? fm.model : undefined,
+                grants: Array.isArray(fm.grants)
+                  ? fm.grants.filter((g): g is string => typeof g === "string")
+                  : [],
+                approvalMode: normalizeApprovalMode(fm.approval_mode),
+                eventId: n.id,
+              });
+            }
+          }
+        }
+      }
+      for (const c of (n.children ?? []) as Array<typeof n>) walk(c);
+    };
+
+    const root = (scene as unknown as { root?: unknown }).root;
+    if (root) walk(root as never);
+    return Array.from(byId.values()).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [scene]);
+}

--- a/apps/broomva/components/workspace-shell/RightRail.tsx
+++ b/apps/broomva/components/workspace-shell/RightRail.tsx
@@ -5,20 +5,28 @@ import { RightRailFiles } from "@/components/lenses/files/RightRailFiles";
 import { RightRailSession } from "@/components/lenses/session/right-rail/RightRailSession";
 
 /**
- * Right rail — lens-aware. When the URL carries `?file=<path>`, the Files
- * lens is active and we mount `RightRailFiles` (Outline + Backlinks).
- * Otherwise we fall back to `RightRailSession` (In context · Memory ·
- * Recent operations).
+ * Right rail — lens-aware. Switches body based on URL searchParams:
+ *
+ *   ?file=<path>      → RightRailFiles (Outline + Backlinks)
+ *   ?lens=agents      → empty (gallery is the whole surface in v1)
+ *   else              → RightRailSession (In context · Memory · Recent ops)
  */
 export function RightRail() {
   const params = useSearchParams();
   const file = params.get("file");
+  const lens = params.get("lens");
   return (
     <aside
       aria-label="Right rail"
       className="overflow-y-auto border-l border-[color:var(--ag-border-subtle)]"
     >
-      {file ? <RightRailFiles path={file} /> : <RightRailSession />}
+      {file ? (
+        <RightRailFiles path={file} />
+      ) : lens === "agents" ? (
+        <div className="px-3 py-4 font-mono text-[11px] opacity-50">—</div>
+      ) : (
+        <RightRailSession />
+      )}
     </aside>
   );
 }

--- a/apps/broomva/lib/life-runtime/session-runtime.ts
+++ b/apps/broomva/lib/life-runtime/session-runtime.ts
@@ -193,6 +193,49 @@ function seedWelcomeFiles(state: SessionState): void {
     },
   });
   emit(state, quickstart);
+  const atlas = makeEnvelope({
+    session_id: state.sid,
+    seq: state.nextSeq,
+    event: {
+      type: "node_added",
+      parent: SCENE_ROOT_ID,
+      node: {
+        id: `seed-atlas-${state.sid}`,
+        intent: {
+          type: "tool_call",
+          name: "fs.write",
+          args: {
+            path: "agents/atlas/spec.md",
+            content: [
+              "# Atlas — Resident agent",
+              "",
+              "You are Atlas, the resident agent of this workspace. You introduce",
+              "the workspace to its user and respond to direct questions.",
+              "",
+              "## Boundaries",
+              "",
+              "- Read and write within this workspace only.",
+              "- Auto-snapshot every fs.write; nothing is destructive.",
+              "- Defer policy-sensitive operations to the user with an approval card.",
+            ].join("\n"),
+            frontmatter: {
+              kind: "agent_spec",
+              name: "Atlas",
+              archetype: "resident",
+              description:
+                "Resident agent of this workspace; introduces the OS and stays available for direct questions.",
+              model: "claude-sonnet-4.5",
+              grants: ["fs.read", "fs.write", "memory.read", "memory.write"],
+              approval_mode: "silent",
+              tags: ["welcome", "resident"],
+              created: new Date().toISOString(),
+            },
+          },
+        },
+      },
+    },
+  });
+  emit(state, atlas);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements Plan B-6 from `docs/superpowers/plans/2026-05-14-broomva-agents-lens.md`. Third lens of the workspace AI-OS — agents are now first-class, browsable.

Descends from `docs/superpowers/specs/2026-05-11-broomva-ai-os-first-slice-design.md` §3 PR 6 and §2 "Agents" workspace primitive.

## What lands

Four new components + one new right-rail branch:

- **AgentsLens** — center-stage gallery. Empty state when no agents installed; grid of AgentCards when populated. Activated by `?lens=agents`.
- **AgentCard** — one card per agent. Avatar (deterministic gradient seeded by agent id), name + archetype tag, description, capability chips, model badge. Card body links to `?file=agents/<id>/spec.md` so users can preview the underlying spec in the Files lens.
- **CapabilityChip** — `ok`/`warn`/`no` grant indicator. Variant determined by approval_mode (`silent`/`review` ⇒ ok, `always` ⇒ warn).
- **useAgents** — hook walking scene for `fs.write` tool_calls whose path matches `agents/<slug>/spec.md`. Parses frontmatter (name/archetype/description/model/grants/approval_mode) and returns one AgentSpec per slug (latest write wins).

## Lens activation

URL search param adds a third case alongside Files:
- `/workspace/[sid]` → Session lens
- `/workspace/[sid]?file=<path>` → Files lens
- `/workspace/[sid]?lens=agents` → Agents lens

Right rail follows: `?lens=agents` renders a minimal em-dash placeholder body (the gallery is busy enough on its own); Files and Session cases are unchanged.

## Atlas seed

`seedWelcomeFiles` is extended to emit `agents/atlas/spec.md` alongside `welcome.md` and `notes/quickstart.md`. The synthetic spec carries full frontmatter (name: Atlas, archetype: resident, model: claude-sonnet-4.5, grants: fs.read/fs.write/memory.read/memory.write, approval_mode: silent). Plan C (welcome agent) will replace this static seed with a real agent runtime.

## Validation

- `bun run turbo lint --filter=@broomva/web`: ✓ 2/2 successful (pre-existing warnings only)
- `bun run turbo test:types --filter=@broomva/web`: ✓ 2/2 successful
- `bun run test:unit components/lenses/`: ✓ **48/48** tests passing (39 from B-5 + 9 new)

## What does NOT land (deferred)

- **Open session action.** AgentCard currently links to the spec viewer. Starting a session with a specific agent (via `Agent.CreateSession`) ships in Plan C.
- **Config editor.** Per parent spec: deferred to v1.1. Card has no Edit button.
- **Avatar uploads.** v1 ships deterministic gradient; user-uploaded avatars deferred.
- **Per-card session counts.** Needs `Events.Read(kind=session.start, actor_anima_id=<id>)` aggregation; deferred until lifegw event RPC is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)