### PR TITLE
Broomva AI-OS — Plan C: Welcome agent (Broomva) + first-session bootstrap

### DIFF
--- a/apps/broomva/app/workspace/page.tsx
+++ b/apps/broomva/app/workspace/page.tsx
@@ -1,33 +1,18 @@
+import { redirect } from "next/navigation";
+
 /**
- * /workspace landing — placeholder until the welcome agent ships (PR 7).
+ * /workspace landing. Bootstraps a fresh session by minting a new UUID
+ * and redirecting to `/workspace/<sid>`. The session-runtime materializes
+ * that sid the first time it's streamed, emits Broomva's welcome arc
+ * (prose intro → fs.write welcome.md → prose follow-up), and the user
+ * lands on the Session lens with content already flowing.
  *
- * Once Plan C lands, this page redirects to the user's most recent session
- * or creates a fresh one with the welcome agent.
+ * Session continuity (re-attaching to a most-recent session per the parent
+ * spec's `Identity.ListSessions` step) is deferred until the lifegw
+ * Identity RPC ships. v1 always opens a new session, which is the honest
+ * stub — `/workspace` is a "begin" gate, not a directory.
  */
-export default function WorkspaceLandingPage() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-6 px-8 py-20">
-      <div
-        aria-hidden
-        className="h-10 w-10 rounded-full"
-        style={{
-          background:
-            "radial-gradient(circle, var(--ag-ai-blue) 0%, transparent 70%)",
-        }}
-      />
-      <h1
-        className="max-w-[26ch] text-center text-[28px] tracking-tight"
-        style={{ fontFamily: "CalSans, ui-sans-serif, system-ui" }}
-      >
-        Welcome. Your workspace is ready.
-      </h1>
-      <p className="max-w-[40ch] text-center text-[13px] opacity-60">
-        Press{" "}
-        <kbd className="ag-glass-subtle rounded px-1.5 py-0.5 font-mono text-[11px]">
-          ⌘K
-        </kbd>{" "}
-        to start a session. Lenses light up as you and your agents work.
-      </p>
-    </div>
-  );
+export default function WorkspaceLandingPage(): never {
+  const sid = crypto.randomUUID();
+  redirect(`/workspace/${sid}`);
 }

--- a/apps/broomva/app/workspace/page.tsx
+++ b/apps/broomva/app/workspace/page.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 /**
@@ -7,12 +8,19 @@ import { redirect } from "next/navigation";
  * (prose intro → fs.write welcome.md → prose follow-up), and the user
  * lands on the Session lens with content already flowing.
  *
+ * Next 16 + cacheComponents treats `crypto.randomUUID()` as cacheable by
+ * default in Server Components and would prerender a static UUID — which
+ * defeats the bootstrap (every visitor would land on the same sid).
+ * Touching `headers()` first opts the route out of prerendering, marking
+ * it as dynamic so each request gets a fresh UUID.
+ *
  * Session continuity (re-attaching to a most-recent session per the parent
  * spec's `Identity.ListSessions` step) is deferred until the lifegw
  * Identity RPC ships. v1 always opens a new session, which is the honest
  * stub — `/workspace` is a "begin" gate, not a directory.
  */
-export default function WorkspaceLandingPage(): never {
+export default async function WorkspaceLandingPage(): Promise<never> {
+  await headers();
   const sid = crypto.randomUUID();
   redirect(`/workspace/${sid}`);
 }

--- a/apps/broomva/components/lenses/agents/__tests__/AgentCard.test.tsx
+++ b/apps/broomva/components/lenses/agents/__tests__/AgentCard.test.tsx
@@ -7,9 +7,9 @@ import type { AgentSpec } from "../useAgents";
 afterEach(() => cleanup());
 
 const spec: AgentSpec = {
-  id: "atlas",
-  path: "agents/atlas/spec.md",
-  name: "Atlas",
+  id: "broomva",
+  path: "agents/broomva/spec.md",
+  name: "Broomva",
   archetype: "resident",
   description: "Resident agent of this workspace.",
   model: "claude-sonnet-4.5",
@@ -21,7 +21,7 @@ const spec: AgentSpec = {
 describe("AgentCard", () => {
   it("renders name, archetype, description, model, and one chip per grant", () => {
     render(<AgentCard spec={spec} />);
-    expect(screen.getByText("Atlas")).toBeTruthy();
+    expect(screen.getByText("Broomva")).toBeTruthy();
     expect(screen.getByText("resident")).toBeTruthy();
     expect(screen.getByText("Resident agent of this workspace.")).toBeTruthy();
     expect(screen.getByText("claude-sonnet-4.5")).toBeTruthy();
@@ -39,7 +39,7 @@ describe("AgentCard", () => {
     const link = container.querySelector("a");
     expect(link).toBeTruthy();
     expect(link?.getAttribute("href")).toBe(
-      `?file=${encodeURIComponent("agents/atlas/spec.md")}`,
+      `?file=${encodeURIComponent("agents/broomva/spec.md")}`,
     );
   });
 });

--- a/apps/broomva/components/lenses/agents/__tests__/AgentsLens.test.tsx
+++ b/apps/broomva/components/lenses/agents/__tests__/AgentsLens.test.tsx
@@ -39,15 +39,15 @@ describe("AgentsLens", () => {
               type: "tool_call",
               name: "fs.write",
               args: {
-                path: "agents/atlas/spec.md",
-                frontmatter: { name: "Atlas", archetype: "resident" },
+                path: "agents/broomva/spec.md",
+                frontmatter: { name: "Broomva", archetype: "resident" },
               },
             },
           },
         ],
       },
     });
-    expect(screen.getByText("Atlas")).toBeTruthy();
+    expect(screen.getByText("Broomva")).toBeTruthy();
     expect(screen.getByText("1 installed")).toBeTruthy();
   });
 });

--- a/apps/broomva/components/lenses/agents/__tests__/useAgents.test.tsx
+++ b/apps/broomva/components/lenses/agents/__tests__/useAgents.test.tsx
@@ -47,9 +47,9 @@ describe("useAgents", () => {
                 type: "tool_call",
                 name: "fs.write",
                 args: {
-                  path: "agents/atlas/spec.md",
+                  path: "agents/broomva/spec.md",
                   frontmatter: {
-                    name: "Atlas",
+                    name: "Broomva",
                     archetype: "resident",
                     description: "Resident agent",
                     model: "claude-sonnet-4.5",
@@ -80,11 +80,11 @@ describe("useAgents", () => {
       }),
     });
     expect(result.current).toHaveLength(2);
-    expect(result.current.map((a) => a.name)).toEqual(["Atlas", "Builder"]);
-    const atlas = result.current[0];
-    expect(atlas.archetype).toBe("resident");
-    expect(atlas.grants).toEqual(["fs.read", "fs.write"]);
-    expect(atlas.approvalMode).toBe("silent");
+    expect(result.current.map((a) => a.name)).toEqual(["Broomva", "Builder"]);
+    const broomva = result.current[0];
+    expect(broomva.archetype).toBe("resident");
+    expect(broomva.grants).toEqual(["fs.read", "fs.write"]);
+    expect(broomva.approvalMode).toBe("silent");
   });
 
   it("ignores fs.write events outside the agents/*/spec.md pattern", () => {
@@ -108,7 +108,7 @@ describe("useAgents", () => {
               intent: {
                 type: "tool_call",
                 name: "fs.write",
-                args: { path: "agents/atlas/notes.md" },
+                args: { path: "agents/broomva/notes.md" },
               },
             },
           ],

--- a/apps/broomva/components/lenses/agents/useAgents.ts
+++ b/apps/broomva/components/lenses/agents/useAgents.ts
@@ -10,7 +10,7 @@ export interface AgentSpec {
   id: string;
   /** Full spec.md path. */
   path: string;
-  /** Human display name, e.g. "Atlas". */
+  /** Human display name, e.g. "Broomva". */
   name: string;
   /** Archetype label, e.g. "resident", "engineer", "researcher". */
   archetype: string;

--- a/apps/broomva/lib/life-runtime/__tests__/session-runtime.welcome.test.ts
+++ b/apps/broomva/lib/life-runtime/__tests__/session-runtime.welcome.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+// `session-runtime.ts` begins with `import "server-only"` which blocks it
+// from loading in node-side test environments. Stub it out.
+vi.mock("server-only", () => ({}));
+
+// The `@broomva/prosopon` package ships an ESM `dist/` whose re-exports
+// don't resolve cleanly under Vitest's raw Node loader (Next.js handles it
+// at runtime). Passthrough `makeEnvelope` is sufficient — the test reads
+// `event.node.intent` off the yielded envelope, which is exactly what we
+// pass through.
+vi.mock("@broomva/prosopon", () => ({
+  makeEnvelope: (args: unknown) => args,
+}));
+
+// `./canonical` transitively imports the DB client + env validators which
+// fail under raw Node without a populated env. We only exercise the seed
+// path which never touches the canonical runtime, so we stub it out.
+vi.mock("../canonical", () => ({
+  createLifeRuntime: () => ({
+    run: async () => ({ kind: "envelopes", stream: (async function* () {})() }),
+  }),
+}));
+
+import { streamSession } from "../session-runtime";
+
+/**
+ * The session-runtime's seedFreshSession helper is private, but its
+ * side-effects are observable through the public `streamSession` API:
+ * a fresh session's buffered envelopes are exactly the seed sequence.
+ *
+ * We drain the buffered envelopes by iterating streamSession with an
+ * already-aborted-after-N-envelopes signal — but since seedFreshSession
+ * buffers eagerly into state.buffer before any streamer is parked, the
+ * first stream call replays them synchronously up front and only THEN
+ * parks for new ones. We use a short setTimeout abort so the test exits
+ * cleanly after consuming the seed.
+ */
+
+async function collectSeed(sid: string): Promise<unknown[]> {
+  const controller = new AbortController();
+  const out: unknown[] = [];
+  // Abort the stream after 50ms so it stops parking for new envelopes.
+  const timer = setTimeout(() => controller.abort(), 50);
+  try {
+    for await (const env of streamSession({
+      sid,
+      fromSeq: 0n,
+      signal: controller.signal,
+    })) {
+      out.push(env);
+    }
+  } catch {
+    // AbortError or "stream aborted" — expected after the timer fires.
+  } finally {
+    clearTimeout(timer);
+  }
+  return out;
+}
+
+describe("seedFreshSession", () => {
+  it("emits exactly 5 envelopes for a fresh session", async () => {
+    const sid = `test-fresh-${crypto.randomUUID()}`;
+    const envelopes = await collectSeed(sid);
+    expect(envelopes).toHaveLength(5);
+  });
+
+  it("emits envelopes in the expected order: spec, quickstart, intro prose, welcome.md, follow-up prose", async () => {
+    const sid = `test-order-${crypto.randomUUID()}`;
+    const envelopes = (await collectSeed(sid)) as Array<{
+      event: {
+        type: string;
+        node: {
+          id: string;
+          intent: {
+            type?: string;
+            name?: string;
+            args?: { path?: string };
+            text?: string;
+          };
+        };
+      };
+    }>;
+    expect(envelopes.map((e) => e.event.node.intent.type)).toEqual([
+      "tool_call",
+      "tool_call",
+      "prose",
+      "tool_call",
+      "prose",
+    ]);
+    expect(envelopes[0].event.node.intent.args?.path).toBe(
+      "agents/broomva/spec.md",
+    );
+    expect(envelopes[1].event.node.intent.args?.path).toBe(
+      "notes/quickstart.md",
+    );
+    expect(envelopes[2].event.node.intent.text).toMatch(/I'm Broomva/);
+    expect(envelopes[3].event.node.intent.args?.path).toBe("welcome.md");
+    expect(envelopes[4].event.node.intent.text).toMatch(
+      /Where would you like to start/,
+    );
+  });
+
+  it("is idempotent — re-streaming the same sid does not re-emit the seed", async () => {
+    const sid = `test-idempotent-${crypto.randomUUID()}`;
+    const first = await collectSeed(sid);
+    const second = await collectSeed(sid);
+    expect(first).toHaveLength(5);
+    expect(second).toHaveLength(0);
+  });
+});

--- a/apps/broomva/lib/life-runtime/session-runtime.ts
+++ b/apps/broomva/lib/life-runtime/session-runtime.ts
@@ -75,7 +75,7 @@ function getOrCreateSession(sid: string): SessionState {
       nextSeq: 1,
     };
     SESSIONS.set(sid, state);
-    seedWelcomeFiles(state);
+    seedFreshSession(state);
   }
   return state;
 }
@@ -103,139 +103,218 @@ function emit(state: SessionState, inner: Envelope): void {
 }
 
 // ---------------------------------------------------------------------------
-// Welcome-files seed (v1 stub-mode shortcut)
+// Fresh-session seed (v1 stub-mode shortcut)
 // ---------------------------------------------------------------------------
 
 /**
- * Emit a pair of synthetic `fs.write` tool_call intents the first time a
- * session is materialized. Gives the Files lens content to render on first
- * connect; without the seed, the tree would always be empty in v1 because
- * no real agent currently writes to the Soma FS.
+ * Emit the v1 fresh-session payload the first time a session is materialized.
+ * Three independent emitters fire in order:
  *
- * In production these would be SHA blob refs resolved via `Events.GetBlob`;
- * for the v1 in-process stub we embed `content` + `frontmatter` directly in
- * `intent.args`. The viewer reads them inline. The seed is idempotent per
- * session (only fires when `state.nextSeq === 1`).
+ *   1. emitAgentSpec    — agents/broomva/spec.md (the resident agent's spec
+ *                          frontmatter; visible in the Agents lens)
+ *   2. emitQuickstart   — notes/quickstart.md (anonymous reference page;
+ *                          visible in the Files lens)
+ *   3. emitWelcomeArc   — Broomva's 3-beat introduction emitted as
+ *                          (prose intro → fs.write welcome.md → prose
+ *                          follow-up). Plays on the Session lens canvas
+ *                          on first paint.
+ *
+ * Idempotent per session: only fires on `state.nextSeq === 1`. Production
+ * (Plan C v1.1+) will replace this stub with a real arcan-provider-local
+ * agent that emits the same envelopes through the canonical runtime.
  */
-function seedWelcomeFiles(state: SessionState): void {
+function seedFreshSession(state: SessionState): void {
   if (state.nextSeq !== 1) return;
-  const welcome = makeEnvelope({
-    session_id: state.sid,
-    seq: state.nextSeq,
-    event: {
-      type: "node_added",
-      parent: SCENE_ROOT_ID,
-      node: {
-        id: `seed-welcome-${state.sid}`,
-        intent: {
-          type: "tool_call",
-          name: "fs.write",
-          args: {
-            path: "welcome.md",
-            content: [
-              "# Welcome",
-              "",
-              "This is your workspace. It persists across sessions.",
-              "",
-              "## What you can do here",
-              "",
-              "- Open `notes/quickstart.md` for a one-minute tour.",
-              "- Open the Session lens (dock or ⌘K) to converse with an agent.",
-              "- Anything an agent writes appears here as a real file.",
-              "",
-              "Nothing here is hidden. Every file write was an Operation, and every",
-              "Operation is reversible.",
-            ].join("\n"),
-            frontmatter: {
-              kind: "doc",
-              tags: ["welcome"],
-              created: new Date().toISOString(),
+  emitAgentSpec(state);
+  emitQuickstart(state);
+  emitWelcomeArc(state);
+}
+
+function emitAgentSpec(state: SessionState): void {
+  emit(
+    state,
+    makeEnvelope({
+      session_id: state.sid,
+      seq: state.nextSeq,
+      event: {
+        type: "node_added",
+        parent: SCENE_ROOT_ID,
+        node: {
+          id: `seed-broomva-spec-${state.sid}`,
+          intent: {
+            type: "tool_call",
+            name: "fs.write",
+            args: {
+              path: "agents/broomva/spec.md",
+              content: [
+                "# Broomva — Resident agent",
+                "",
+                "You are Broomva, the resident voice of this workspace.",
+                "You introduce the workspace and stay available for direct",
+                "questions. Your tone is calm, deliberate, useful.",
+                "",
+                "## Boundaries",
+                "",
+                "- Read and write within this workspace only.",
+                "- Auto-snapshot every fs.write; nothing is destructive.",
+                "- Defer policy-sensitive operations with an approval card.",
+              ].join("\n"),
+              frontmatter: {
+                kind: "agent_spec",
+                name: "Broomva",
+                archetype: "resident",
+                description:
+                  "Resident voice of this workspace. Introduces the OS and stays available for direct questions.",
+                model: "claude-sonnet-4.5",
+                grants: ["fs.read", "fs.write", "memory.read", "memory.write"],
+                approval_mode: "silent",
+                tags: ["welcome", "resident"],
+                created: new Date().toISOString(),
+              },
             },
           },
         },
       },
-    },
-  });
-  emit(state, welcome);
-  const quickstart = makeEnvelope({
-    session_id: state.sid,
-    seq: state.nextSeq,
-    event: {
-      type: "node_added",
-      parent: SCENE_ROOT_ID,
-      node: {
-        id: `seed-quickstart-${state.sid}`,
-        intent: {
-          type: "tool_call",
-          name: "fs.write",
-          args: {
-            path: "notes/quickstart.md",
-            content: [
-              "# Quickstart",
-              "",
-              "Three things to try:",
-              "",
-              "1. Click any file in the left rail to open it.",
-              "2. Press ⌘K and start typing to open the command palette.",
-              "3. Switch to the Session lens to talk to an agent.",
-              "",
-              "The right rail shows the outline of the current file and any",
-              "backlinks pointing at it.",
-            ].join("\n"),
-            frontmatter: {
-              kind: "doc",
-              tags: ["welcome", "quickstart"],
-              created: new Date().toISOString(),
+    }),
+  );
+}
+
+function emitQuickstart(state: SessionState): void {
+  emit(
+    state,
+    makeEnvelope({
+      session_id: state.sid,
+      seq: state.nextSeq,
+      event: {
+        type: "node_added",
+        parent: SCENE_ROOT_ID,
+        node: {
+          id: `seed-quickstart-${state.sid}`,
+          intent: {
+            type: "tool_call",
+            name: "fs.write",
+            args: {
+              path: "notes/quickstart.md",
+              content: [
+                "# Quickstart",
+                "",
+                "Three things to try:",
+                "",
+                "1. Click any file in the left rail to open it.",
+                "2. Press ⌘K and start typing to open the command palette.",
+                "3. Switch lenses via the dock or URL parameters.",
+                "",
+                "The right rail shows the outline of the current file and",
+                "any backlinks pointing at it.",
+              ].join("\n"),
+              frontmatter: {
+                kind: "doc",
+                tags: ["welcome", "quickstart"],
+                created: new Date().toISOString(),
+              },
             },
           },
         },
       },
-    },
-  });
-  emit(state, quickstart);
-  const atlas = makeEnvelope({
-    session_id: state.sid,
-    seq: state.nextSeq,
-    event: {
-      type: "node_added",
-      parent: SCENE_ROOT_ID,
-      node: {
-        id: `seed-atlas-${state.sid}`,
-        intent: {
-          type: "tool_call",
-          name: "fs.write",
-          args: {
-            path: "agents/atlas/spec.md",
-            content: [
-              "# Atlas — Resident agent",
+    }),
+  );
+}
+
+function emitWelcomeArc(state: SessionState): void {
+  // Beat 1: Broomva introduces herself.
+  emit(
+    state,
+    makeEnvelope({
+      session_id: state.sid,
+      seq: state.nextSeq,
+      event: {
+        type: "node_added",
+        parent: SCENE_ROOT_ID,
+        node: {
+          id: `seed-welcome-intro-${state.sid}`,
+          // `author` is a plan-level extension on prose; ProseIntent reads it
+          // via a local type widening. The canonical Intent::Prose only has
+          // `{ type, text }`, so cast through `never` to carry the field.
+          intent: {
+            type: "prose",
+            text: [
+              "Welcome. I'm Broomva — the resident voice of this workspace.",
               "",
-              "You are Atlas, the resident agent of this workspace. You introduce",
-              "the workspace to its user and respond to direct questions.",
-              "",
-              "## Boundaries",
-              "",
-              "- Read and write within this workspace only.",
-              "- Auto-snapshot every fs.write; nothing is destructive.",
-              "- Defer policy-sensitive operations to the user with an approval card.",
+              "A workspace is persistent. This file, your conversations with me, the agents you spawn, the memory we build — all of it survives between visits.",
             ].join("\n"),
-            frontmatter: {
-              kind: "agent_spec",
-              name: "Atlas",
-              archetype: "resident",
-              description:
-                "Resident agent of this workspace; introduces the OS and stays available for direct questions.",
-              model: "claude-sonnet-4.5",
-              grants: ["fs.read", "fs.write", "memory.read", "memory.write"],
-              approval_mode: "silent",
-              tags: ["welcome", "resident"],
-              created: new Date().toISOString(),
+            author: "agent",
+          } as never,
+        },
+      },
+    }),
+  );
+  // Beat 2: Broomva writes welcome.md (first-person authored).
+  emit(
+    state,
+    makeEnvelope({
+      session_id: state.sid,
+      seq: state.nextSeq,
+      event: {
+        type: "node_added",
+        parent: SCENE_ROOT_ID,
+        node: {
+          id: `seed-welcome-md-${state.sid}`,
+          intent: {
+            type: "tool_call",
+            name: "fs.write",
+            args: {
+              path: "welcome.md",
+              content: [
+                "# Welcome",
+                "",
+                "I'm Broomva — the resident voice of this workspace.",
+                "",
+                "A workspace is persistent. This file, your conversations with me, the agents you spawn, the memory we build — all of it survives between visits.",
+                "",
+                "## Three things to try",
+                "",
+                "- Read `notes/quickstart.md` for the one-minute tour.",
+                "- Open the Agents lens (`?lens=agents`) to see who's installed.",
+                "- Ask me anything in the Session lens.",
+                "",
+                "Nothing here is hidden. Every write I make is an Operation, and every Operation is reversible.",
+              ].join("\n"),
+              frontmatter: {
+                kind: "doc",
+                tags: ["welcome"],
+                author: "broomva",
+                created: new Date().toISOString(),
+              },
             },
           },
         },
       },
-    },
-  });
-  emit(state, atlas);
+    }),
+  );
+  // Beat 3: Broomva closes with a question.
+  emit(
+    state,
+    makeEnvelope({
+      session_id: state.sid,
+      seq: state.nextSeq,
+      event: {
+        type: "node_added",
+        parent: SCENE_ROOT_ID,
+        node: {
+          id: `seed-welcome-question-${state.sid}`,
+          intent: {
+            type: "prose",
+            text: [
+              "I wrote `welcome.md` for you while we get acquainted — you can open it from the left rail.",
+              "",
+              "Where would you like to start: a tour of the workspace, or your first question?",
+            ].join("\n"),
+            author: "agent",
+          } as never,
+        },
+      },
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements Plan C from `docs/superpowers/plans/2026-05-14-broomva-welcome-agent.md`. The resident agent is now **Broomva** — the workspace introduces itself in its own voice.

Descends from `docs/superpowers/specs/2026-05-11-broomva-ai-os-first-slice-design.md` §3 PR 7 (Welcome agent + session bootstrap) and §2 "Agents" workspace primitive.

## What lands

### Rebrand: Atlas → Broomva
The placeholder Atlas seed shipped in B-6 is replaced with Broomva. The OS speaks in its own voice. Frontmatter, agent spec, voice, and fixture data are all rebranded for consistency.

### Welcome arc on first connect
`seedFreshSession` (renamed from `seedWelcomeFiles`) now emits **5 envelopes** in this order on every fresh session:

1. `fs.write agents/broomva/spec.md` — Broomva's spec (visible in Agents lens)
2. `fs.write notes/quickstart.md` — anonymous reference page (Files lens)
3. `prose` from Broomva: *"Welcome. I'm Broomva — the resident voice of this workspace…"*
4. `fs.write welcome.md` — first-person Broomva-authored welcome (Files lens)
5. `prose` from Broomva: closing question — *"Where would you like to start: a tour of the workspace, or your first question?"*

The arc plays on the Session lens canvas the moment the user lands.

### Landing-page bootstrap
`/workspace` is no longer a static welcome screen. It's a Server-Component redirect: mint a fresh UUID via `crypto.randomUUID()` and `redirect(/workspace/<uuid>)`. The new sid triggers `seedFreshSession` → Broomva's 5-envelope arc → user sees their workspace populated immediately across all three lenses.

Session continuity (re-attaching to the most-recent session per the parent spec's `Identity.ListSessions` step) is deferred until the lifegw Identity RPC ships — v1 always opens a new session.

## Validation

- `bun run turbo lint --filter=@broomva/web`: ✓ 2/2 successful
- `bun run turbo test:types --filter=@broomva/web`: ✓ 2/2 successful
- `bun run test:unit components/lenses/ lib/life-runtime/__tests__/`: ✓ **51/51** tests passing (48 lens + 3 new welcome)

## What does NOT land (deferred)

- **Real arcan-provider-local Broomva runtime.** v1 ships the welcome arc as an in-process stub seed. v1.1 wires a real agent runtime that emits the same envelopes through the canonical `createLifeRuntime` pipeline.
- **Identity.ListSessions continuity.** `/workspace` always opens a fresh session in v1. Continuity ships when the lifegw Identity RPC lands.
- **Richer 7-beat Origami arc.** Parent spec defines 3 beats; calmer onboarding with anchors, transitions, and snapshot moments lives in v1.1.
- **Per-user soul-derived greeting.** The intro prose is a static string; personalization keyed on Anima identity ships when the Anima JWT carries display-name claims.

## Closes the first-slice AI-OS surface

With Plan C merged, the v1 surface is complete:
- Three lenses (Session, Files, Agents) all populated on first connect
- A resident agent (Broomva) in their own voice
- Real first-session bootstrap from the `/workspace` landing
- Pure-derivation architecture: every visible piece is a projection of the same Prosopon scene over the in-process stub upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fresh sessions now initialize with a welcome sequence including agent specification, quickstart, introduction, and welcome documentation.

* **Tests**
  * Added comprehensive test suite validating session initialization behavior.
  * Updated existing tests to reflect agent reference changes.

* **Chores**
  * Updated agent references throughout the workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/161)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->