### PR TITLE
Broomva AI-OS — Plan D: Workspace identity + replay-on-read session buffer

### DIFF
--- a/apps/broomva/app/api/me/sessions/route.ts
+++ b/apps/broomva/app/api/me/sessions/route.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { getSafeSession } from "@/lib/auth";
+import { listSessions } from "@/lib/workspace/session-registry";
+
+/**
+ * GET /api/me/sessions
+ *
+ * Returns the logged-in user's session id list (most-recent first),
+ * sourced from the in-memory registry. v1.1 (Plan E) replaces the
+ * registry with lifegw's Identity.ListSessions RPC backed by Lago
+ * persistence; the wire shape stays the same.
+ *
+ * Returns 401 when no session.
+ */
+export async function GET(): Promise<NextResponse> {
+  const h = await headers();
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: h },
+  });
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+  return NextResponse.json({ sessions: listSessions(userId) });
+}

--- a/apps/broomva/app/workspace/[sessionId]/page.tsx
+++ b/apps/broomva/app/workspace/[sessionId]/page.tsx
@@ -1,7 +1,10 @@
+import { headers } from "next/headers";
 import { AgentsLens } from "@/components/lenses/agents/AgentsLens";
 import { FilesLens } from "@/components/lenses/files/FilesLens";
 import { SessionLensClient } from "@/components/lenses/session/SessionLensClient";
 import { WorkspaceSession } from "@/components/lenses/session/WorkspaceSession";
+import { getSafeSession } from "@/lib/auth";
+import { registerSession } from "@/lib/workspace/session-registry";
 
 interface SessionPageProps {
   params: Promise<{ sessionId: string }>;
@@ -25,6 +28,24 @@ export default async function SessionPage({
 }: SessionPageProps) {
   const { sessionId } = await params;
   const { seq, file, lens } = await searchParams;
+
+  // Register this sid with the logged-in user's session list so it
+  // surfaces in the LeftRail sidebar. Best-effort — the page itself is
+  // not gated on auth (auth happens at the SSE/REST routes), so we
+  // swallow failures silently.
+  try {
+    const h = await headers();
+    const { data: session } = await getSafeSession({
+      fetchOptions: { headers: h },
+    });
+    const userId = session?.user?.id;
+    if (userId) {
+      registerSession(userId, sessionId);
+    }
+  } catch {
+    // Best-effort; don't block the page on registry hiccups.
+  }
+
   const initialSeq = ((): bigint => {
     if (!seq) return 0n;
     try {

--- a/apps/broomva/app/workspace/page.tsx
+++ b/apps/broomva/app/workspace/page.tsx
@@ -1,26 +1,34 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { getSafeSession } from "@/lib/auth";
+import { getWorkspaceId } from "@/lib/workspace/identity";
 
 /**
- * /workspace landing. Bootstraps a fresh session by minting a new UUID
- * and redirecting to `/workspace/<sid>`. The session-runtime materializes
- * that sid the first time it's streamed, emits Broomva's welcome arc
- * (prose intro → fs.write welcome.md → prose follow-up), and the user
- * lands on the Session lens with content already flowing.
+ * /workspace landing. Resolves the logged-in user's stable workspace_id
+ * (deterministic hash of Better Auth userId) and redirects to
+ * `/workspace/<workspace_id>`. Same user always lands on the same URL —
+ * refresh stays on the same workspace, the welcome arc plays once per
+ * process lifetime (idempotent seed guard), subsequent connects replay
+ * the in-process buffer.
  *
- * Next 16 + cacheComponents treats `crypto.randomUUID()` as cacheable by
- * default in Server Components and would prerender a static UUID — which
- * defeats the bootstrap (every visitor would land on the same sid).
- * Touching `headers()` first opts the route out of prerendering, marking
- * it as dynamic so each request gets a fresh UUID.
+ * If the user isn't logged in, redirect to the marketing home with a
+ * `?next=/workspace` continuation. (There is no `/login` route in this
+ * app yet — Better Auth flows go through `/` and modal-driven sign-in.
+ * Plan E formalizes the gated entry point.)
  *
- * Session continuity (re-attaching to a most-recent session per the parent
- * spec's `Identity.ListSessions` step) is deferred until the lifegw
- * Identity RPC ships. v1 always opens a new session, which is the honest
- * stub — `/workspace` is a "begin" gate, not a directory.
+ * Touching `headers()` first opts the route out of prerendering — same
+ * pattern as Plan C, required by Next 16 + cacheComponents for any
+ * Server Component that derives state from the request.
  */
 export default async function WorkspaceLandingPage(): Promise<never> {
-  await headers();
-  const sid = crypto.randomUUID();
-  redirect(`/workspace/${sid}`);
+  const h = await headers();
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: h },
+  });
+  const userId = session?.user?.id;
+  if (!userId) {
+    redirect("/?next=/workspace");
+  }
+  const workspaceId = getWorkspaceId(userId);
+  redirect(`/workspace/${workspaceId}`);
 }

--- a/apps/broomva/components/workspace-shell/LeftRail.tsx
+++ b/apps/broomva/components/workspace-shell/LeftRail.tsx
@@ -1,4 +1,6 @@
+import Link from "next/link";
 import { FilesTree } from "@/components/lenses/files/FilesTree";
+import { SessionsList } from "@/components/workspace-shell/SessionsList";
 
 function RailHeading({
   children,
@@ -23,9 +25,10 @@ function RailHeading({
 /**
  * Left rail — three sections: Sessions, Filesystem, Pinned.
  *
- * All sections are placeholders in v1. Real content lands in PR 4 (Session
- * lens populates Sessions), PR 5 (Files lens populates Filesystem), and a
- * later UX pass for Pinned (currently localStorage-only).
+ * Sessions (Plan D) pulls from /api/me/sessions via SessionsList — the
+ * logged-in user's recently-touched session ids, most recent first.
+ * Filesystem (Plan B-5) renders a tree of fs.write events from the
+ * scene. Pinned remains a placeholder for v1.1.
  */
 export function LeftRail() {
   return (
@@ -33,18 +36,14 @@ export function LeftRail() {
       aria-label="Left rail"
       className="overflow-y-auto border-r border-[color:var(--ag-border-subtle)] px-3 pb-3"
     >
-      <RailHeading count={0} action="+ new">
-        Sessions
-      </RailHeading>
-      <div className="px-1 py-2 font-mono text-[11px] opacity-60">
-        No sessions yet. Open one from the dock or press <kbd>⌘K</kbd>.
-      </div>
-      <button
-        type="button"
-        className="ag-glass-subtle mt-1 w-full rounded px-1 py-1.5 text-left font-mono text-[11px] opacity-70 hover:opacity-100"
+      <RailHeading action="+ new">Sessions</RailHeading>
+      <SessionsList />
+      <Link
+        href="/workspace"
+        className="ag-glass-subtle mt-1 block w-full rounded px-1 py-1.5 text-left font-mono text-[11px] opacity-70 hover:opacity-100"
       >
-        + new session
-      </button>
+        ← my workspace
+      </Link>
 
       <RailHeading action="⌘O">Filesystem</RailHeading>
       <FilesTree />

--- a/apps/broomva/components/workspace-shell/SessionsList.tsx
+++ b/apps/broomva/components/workspace-shell/SessionsList.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { Route } from "next";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface ApiResponse {
+  sessions: string[];
+}
+
+type FetchState =
+  | { kind: "loading" }
+  | { kind: "ready"; sessions: string[] }
+  | { kind: "error" };
+
+const POLL_INTERVAL_MS = 10_000;
+
+/**
+ * SessionsList — renders the logged-in user's session ids as rows in
+ * the LeftRail. Polls `GET /api/me/sessions` every 10s. Each row links
+ * to `/workspace/<sid>`; the currently-active sid (matched by pathname)
+ * is highlighted.
+ *
+ * Polling rather than SSE/WS because the registry mutation cadence is
+ * low (humans clicking) and a 10s pull is cheaper than maintaining an
+ * extra long-lived connection in v1.
+ */
+export function SessionsList() {
+  const pathname = usePathname();
+  const [state, setState] = useState<FetchState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch("/api/me/sessions", { cache: "no-store" });
+        if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+        const data = (await res.json()) as ApiResponse;
+        if (!cancelled) setState({ kind: "ready", sessions: data.sessions });
+      } catch {
+        if (!cancelled) setState({ kind: "error" });
+      }
+    };
+    load();
+    const timer = setInterval(load, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, []);
+
+  if (state.kind === "loading") {
+    return <div className="px-1 py-2 font-mono text-[11px] opacity-50">…</div>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="px-1 py-2 font-mono text-[11px] opacity-60">
+        Sign in to see your sessions.
+      </div>
+    );
+  }
+  if (state.sessions.length === 0) {
+    return (
+      <div className="px-1 py-2 font-mono text-[11px] opacity-60">
+        No sessions yet.
+      </div>
+    );
+  }
+  return (
+    <ul className="flex flex-col gap-0.5">
+      {state.sessions.map((sid) => {
+        const href = `/workspace/${sid}` as Route;
+        const isActive = pathname === href;
+        return (
+          <li key={sid}>
+            <Link
+              href={href}
+              className={`block w-full truncate rounded px-1.5 py-1 text-left font-mono text-[10.5px] transition-colors hover:bg-[color:var(--ag-bg-hover)] ${
+                isActive
+                  ? "bg-[color:var(--ag-bg-hover)] opacity-100"
+                  : "opacity-75"
+              }`}
+            >
+              <span className="opacity-60">▸ </span>
+              <span>{sid.slice(0, 24)}</span>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/broomva/lib/life-runtime/__tests__/session-runtime.replay.test.ts
+++ b/apps/broomva/lib/life-runtime/__tests__/session-runtime.replay.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+// Same mock setup as session-runtime.welcome.test.ts — server-only,
+// @broomva/prosopon, and ./canonical all need stubs under raw Node
+// because session-runtime.ts begins with "server-only" and pulls in
+// the DB-validator chain through canonical.ts. See the welcome test
+// for the full rationale.
+vi.mock("server-only", () => ({}));
+vi.mock("@broomva/prosopon", () => ({
+  makeEnvelope: (args: unknown) => args,
+}));
+vi.mock("../canonical", () => ({
+  createLifeRuntime: () => ({
+    run: async () => ({ kind: "envelopes", stream: (async function* () {})() }),
+  }),
+}));
+
+import { streamSession } from "../session-runtime";
+
+async function collect(
+  sid: string,
+  fromSeq: bigint,
+  timeoutMs: number,
+): Promise<Array<{ seq: string | number | bigint }>> {
+  const controller = new AbortController();
+  const out: Array<{ seq: string | number | bigint }> = [];
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    for await (const env of streamSession({
+      sid,
+      fromSeq,
+      signal: controller.signal,
+    })) {
+      out.push(env as unknown as { seq: string | number | bigint });
+    }
+  } catch {
+    // AbortError expected after timer fires.
+  } finally {
+    clearTimeout(timer);
+  }
+  return out;
+}
+
+describe("streamSession replay-on-read", () => {
+  it("replays the welcome arc on multiple subscriptions to the same sid", async () => {
+    const sid = `test-replay-${crypto.randomUUID()}`;
+    // First subscription fires the seed (5 envelopes from seedFreshSession).
+    const first = await collect(sid, 0n, 80);
+    expect(first).toHaveLength(5);
+    // Second subscription replays the same 5 envelopes — buffer was NOT drained.
+    // This is the bug Plan D fixed.
+    const second = await collect(sid, 0n, 80);
+    expect(second).toHaveLength(5);
+    // And a third confirms the replay is stable, not consumed.
+    const third = await collect(sid, 0n, 80);
+    expect(third).toHaveLength(5);
+  });
+
+  it("honors fromSeq — replay skips envelopes at or before the cursor", async () => {
+    const sid = `test-fromseq-${crypto.randomUUID()}`;
+    const all = await collect(sid, 0n, 80);
+    expect(all).toHaveLength(5);
+    // Subscribe again starting after seq 2 — should get envelopes 3, 4, 5.
+    // seedFreshSession emits 5 envelopes with seq 1..5 (emit increments
+    // nextSeq before each, starting at 1).
+    const tail = await collect(sid, 2n, 80);
+    expect(tail).toHaveLength(3);
+    // fromSeq = 5 ⇒ no envelopes (all ≤ cursor).
+    const empty = await collect(sid, 5n, 80);
+    expect(empty).toHaveLength(0);
+  });
+});

--- a/apps/broomva/lib/life-runtime/__tests__/session-runtime.welcome.test.ts
+++ b/apps/broomva/lib/life-runtime/__tests__/session-runtime.welcome.test.ts
@@ -102,11 +102,21 @@ describe("seedFreshSession", () => {
     );
   });
 
-  it("is idempotent — re-streaming the same sid does not re-emit the seed", async () => {
+  it("is idempotent — seed fires once but the buffer replays on every subscription (Plan D replay-on-read)", async () => {
     const sid = `test-idempotent-${crypto.randomUUID()}`;
     const first = await collectSeed(sid);
     const second = await collectSeed(sid);
+    // Both subscriptions see the same 5 envelopes. Plan D made the buffer
+    // append-only with replay-on-read; the seed runs once (state.nextSeq
+    // guard) but the envelopes it emitted stay buffered for refresh and
+    // multi-tab. Prior to Plan D this test asserted second.length === 0
+    // because the buffer was drained on the first read — that was the
+    // bug Plan D fixed.
     expect(first).toHaveLength(5);
-    expect(second).toHaveLength(0);
+    expect(second).toHaveLength(5);
+    // Same envelope sequence on both reads (seed didn't re-emit; buffer
+    // just replayed).
+    expect(second[0]).toEqual(first[0]);
+    expect(second[4]).toEqual(first[4]);
   });
 });

--- a/apps/broomva/lib/life-runtime/session-runtime.ts
+++ b/apps/broomva/lib/life-runtime/session-runtime.ts
@@ -80,6 +80,16 @@ function getOrCreateSession(sid: string): SessionState {
   return state;
 }
 
+/**
+ * Bounded retention for the per-session append-only envelope buffer.
+ * The buffer is replay-on-read (`streamSession` iterates by index and
+ * never drains), so without a bound it would grow unbounded over a
+ * long-lived process. 500 envelopes ≈ a typical session's worth of
+ * intent traffic with comfortable headroom; older envelopes are
+ * silently dropped from the head when capacity is exceeded.
+ */
+const MAX_BUFFER = 500;
+
 function emit(state: SessionState, inner: Envelope): void {
   // Rewrite seq + session_id so the session lens sees a clean monotonic
   // stream rooted at this sid. Preserve the original event + ts.
@@ -91,14 +101,20 @@ function emit(state: SessionState, inner: Envelope): void {
   });
   state.nextSeq += 1;
   const pending: PendingEnvelope = { envelope };
+  // Always push into the buffer so future subscribers / refresh can
+  // replay. Bounded retention drops oldest beyond MAX_BUFFER.
+  state.buffer.push(pending);
+  if (state.buffer.length > MAX_BUFFER) {
+    state.buffer.shift();
+  }
+  // Wake any parked waiter with the new envelope. The buffer-push above
+  // means live consumers AND future subscribers see the same envelope.
   const waiter = state.waiters.shift();
   if (waiter) {
     waiter.resolve({
-      value: pending.envelope,
+      value: envelope,
       done: false,
     });
-  } else {
-    state.buffer.push(pending);
   }
 }
 
@@ -355,16 +371,20 @@ export async function* streamSession(
   const { sid, fromSeq, signal } = opts;
   const state = getOrCreateSession(sid);
 
-  // Replay buffered envelopes whose seq is strictly greater than fromSeq.
-  // We do NOT drain the buffer — multiple subscribers per session is
-  // a future concern; for B-4a we assume a single subscriber per sid
-  // and treat the buffer as a fast-forward queue.
-  while (state.buffer.length > 0) {
+  // Replay all buffered envelopes whose seq is strictly greater than
+  // fromSeq. The buffer is append-only (see `emit` + `MAX_BUFFER`); we
+  // iterate by index so multiple subscribers and refreshes each get
+  // their own full replay from their own cursor.
+  //
+  // The previous implementation drained via `state.buffer.shift()` —
+  // the comment claimed "we do NOT drain" but the code did exactly
+  // that. After the first subscriber consumed the welcome arc, the
+  // buffer was empty and refresh showed an empty scene. Plan D fixes
+  // this and unlocks multi-tab as a side effect.
+  for (const pending of state.buffer) {
     if (signal.aborted) return;
-    const head = state.buffer.shift();
-    if (!head) break;
-    if (BigInt(head.envelope.seq) <= fromSeq) continue;
-    yield head.envelope;
+    if (BigInt(pending.envelope.seq) <= fromSeq) continue;
+    yield pending.envelope;
   }
 
   // Park until a new envelope arrives or the caller aborts.

--- a/apps/broomva/lib/workspace/__tests__/identity.test.ts
+++ b/apps/broomva/lib/workspace/__tests__/identity.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { getWorkspaceId } from "../identity";
+
+describe("getWorkspaceId", () => {
+  it("is deterministic — same userId always yields the same workspace_id", () => {
+    const a = getWorkspaceId("user-123");
+    const b = getWorkspaceId("user-123");
+    expect(a).toBe(b);
+    expect(a).toMatch(/^w-[0-9a-f]{16}$/);
+  });
+
+  it("produces different ids for different users", () => {
+    const alice = getWorkspaceId("alice");
+    const bob = getWorkspaceId("bob");
+    expect(alice).not.toBe(bob);
+  });
+});

--- a/apps/broomva/lib/workspace/identity.ts
+++ b/apps/broomva/lib/workspace/identity.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { createHash } from "node:crypto";
+
+/**
+ * Deterministic workspace_id for a given Better Auth userId. Produces a
+ * 16-char lowercase hex string from a SHA-256 hash, prefixed with `w-`
+ * for URL-readability. The mapping is stable across processes and
+ * deploys — a given userId always yields the same workspace_id, no
+ * persistent store required.
+ *
+ * Why a hash and not the userId directly?
+ *   - workspace_id appears in URLs; we don't want to leak Better Auth's
+ *     internal id shape (which today is a stringified bigint).
+ *   - The hash is one-way; URL ≠ user identifier.
+ *   - 16 hex chars = 64 bits; collision-resistant well past any
+ *     realistic Broomva user count.
+ *
+ * Why not a JWT-encoded claim?
+ *   - This plan defers Anima JWT minting to Plan E (substrate
+ *     integration). For workspace_id resolution alone, a stable hash
+ *     is sufficient — the auth check happens at the SSE/REST routes
+ *     via `requireSession`, not via JWT verification of the URL itself.
+ */
+export function getWorkspaceId(userId: string): string {
+  const hash = createHash("sha256").update(userId).digest("hex");
+  return `w-${hash.slice(0, 16)}`;
+}

--- a/apps/broomva/lib/workspace/session-registry.ts
+++ b/apps/broomva/lib/workspace/session-registry.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+/**
+ * Per-user session registry (in-memory). Tracks which session ids a
+ * given user has ever opened, so the LeftRail's Sessions sidebar can
+ * render them. Resets on server restart; bounded to 50 sessions per
+ * user (oldest evicted).
+ *
+ * v1.1 (Plan E): replaces this with lifegw's Identity.ListSessions
+ * RPC backed by Lago persistence. The interface stays the same.
+ */
+
+const MAX_SESSIONS_PER_USER = 50;
+const USER_SESSIONS = new Map<string, string[]>();
+
+/** Register a session as opened by this user. Idempotent + move-to-front. */
+export function registerSession(userId: string, sessionId: string): void {
+  let list = USER_SESSIONS.get(userId);
+  if (!list) {
+    list = [];
+    USER_SESSIONS.set(userId, list);
+  }
+  // Move-to-front if already present; otherwise prepend.
+  const idx = list.indexOf(sessionId);
+  if (idx >= 0) {
+    list.splice(idx, 1);
+  }
+  list.unshift(sessionId);
+  if (list.length > MAX_SESSIONS_PER_USER) {
+    list.length = MAX_SESSIONS_PER_USER;
+  }
+}
+
+/** List a user's session ids, most-recently-touched first. */
+export function listSessions(userId: string): string[] {
+  return USER_SESSIONS.get(userId)?.slice() ?? [];
+}


### PR DESCRIPTION
Implements Plan D from `docs/superpowers/plans/2026-05-14-broomva-substrate-plan-d.md`. Delivers the workspace-per-user invariant promised in the original AI-OS prompt — *"Each user has 1 workspace assigned"* — without taking on the lifegw/Soma integration risk yet.

## What lands

### Workspace identity
- `getWorkspaceId(userId)` — deterministic SHA-256 hash → `w-<16 hex>` prefix
- `/workspace` resolves the logged-in user's stable workspace_id and redirects to `/workspace/<workspace_id>`. Same user always lands on the same URL. Unauthenticated users redirect to `/?next=/workspace` (no `/login` route in this app — Better Auth uses modal-driven sign-in via the marketing home).

### Replay-on-read session buffer (bug fix + capability)
- `session-runtime.streamSession()` previously drained `state.buffer.shift()` on first read. The comment claimed *"we do NOT drain"* but the code did exactly that. After the first subscriber consumed the welcome arc, the buffer was empty; refresh showed an empty scene.
- Now: buffer is append-only with bounded retention (last 500 envelopes per session). `streamSession` iterates by index, replays from `fromSeq`, never modifies the buffer. **Multi-tab works for free** — each tab replays from its own cursor.

### Sessions sidebar
- In-memory `session-registry` tracks `userId → Set<sessionId>` (bounded to 50 sessions per user, move-to-front on register)
- `GET /api/me/sessions` returns the registered ids (401 when unauthenticated)
- `<SessionsList />` client component polls every 10s, renders rows, highlights the active sid via pathname match. No new `swr` dependency — falls back to `useState + useEffect + fetch`.
- LeftRail's "No sessions yet." placeholder body replaced. "+ new session" button becomes "← my workspace" — clicks redirect to the user's stable workspace_id.

## Validation

- `bun run turbo lint --filter=@broomva/web`: ✓ 2/2 successful
- `bun run turbo test:types --filter=@broomva/web`: ✓ 2/2 successful
- `bun run test:unit components/lenses/ lib/life-runtime/__tests__/ lib/workspace/__tests__/`: ✓ **55/55** tests passing (48 lens + 3 welcome + 4 new identity/replay; one Plan C welcome test updated to assert the new replay-on-read behavior)

## What does NOT land (deferred to Plan E)

- **Real lifegw / lifed / Soma integration.** Session-runtime stays in-process. Server restart wipes state. `LIFEGW_URL` / `LIFED_GATEWAY_URL` env vars exist but aren't wired into session-runtime's upstream selection yet — that's the substrate-real cutover.
- **Anima JWT minting.** `workspace_id` is a plain SHA-256 hash, not a JWT-encoded claim. Tier-1 JWT minting lands when we wire `lifed-ws`.
- **Server-restart persistence.** Bounded in-memory buffer; survives refresh within a process lifetime, evaporates on Vercel cold start / deploy.
- **Real Broomva LLM response.** Composer messages still go through the canonical runtime stub. Broomva is silent after the welcome arc.
- **Multi-session per user.** The "← my workspace" link currently navigates to the same stable sid. Real per-user multi-session needs a separate sid allocator + Plan E persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)