### PR TITLE
feat(agent-session): multi-turn streaming contract (Plan E-2)

### DIFF
--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/contract.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/contract.ts
@@ -3,32 +3,38 @@
  * tests against every backend so per-backend test files only have
  * to wire the client factory.
  *
- * Plan E-2 (Task 4). The harness defines 7 tests:
+ * Plan E-2 (Task 4) + P20 round-1 parity fixes. The harness defines
+ * 6 cross-backend tests + 1 InProcess-only test (history accumulation,
+ * gated by `options.observesHistory`):
  *
- *   1. per-turn baseline — yields tokens + a single finish then closes.
- *   2. multi-turn: first user message runs a turn.
- *   3. multi-turn: sendMessage triggers a second turn.
- *   4. multi-turn: history accumulates across turns.
- *   5. multi-turn: abort signal terminates the loop with a single
- *      terminal finish.
+ *   1. per-turn baseline — yields tokens + a single terminal finish
+ *      then closes.
+ *   2. multi-turn: first user message runs a turn AND emits `turn_end`
+ *      (NOT `finish`) at the turn boundary — both backends.
+ *   3. multi-turn: after the first `turn_end`, a second `sendMessage`
+ *      produces a second token batch + another `turn_end` — both
+ *      backends.
+ *   4. multi-turn (InProcess-only): history accumulates across turns.
+ *   5. multi-turn: abort signal yields tokens → `warning` (code endsWith
+ *      `.aborted`) → terminal `finish` (reason `"aborted"`) — both
+ *      backends.
  *   6. multi-turn: sendMessage on unknown sid throws
  *      AgentSessionUnknownSidError.
  *   7. multi-turn: sendMessage on closed (post-abort) sid throws
  *      AgentSessionUnknownSidError.
  *
- * Backends call `runAgentSessionClientContract(suiteName, makeClient)`;
- * the harness owns describe/it blocks.
+ * Test #4 is backend-specific because lifed accumulates history
+ * server-side and the WS protocol doesn't echo it back; only the
+ * InProcess factory can observe per-turn history.
+ *
+ * Backends call `runAgentSessionClientContract(suiteName, makeClient,
+ * options?)`; the harness owns describe/it blocks.
  *
  * `makeClient` returns a freshly-constructed client AND a `script`
  * — the script encodes the deterministic events the backend's
  * underlying substrate should yield per turn. For InProcess, the
  * script is fed through a fake `RealAgentRunner`; for LifedWs, the
  * script is fed through a fake `WebSocketFactory`.
- *
- * History accumulation is verified by the script — when the harness
- * runs turn 2, the script can return a different token stream
- * based on the history it observed for that turn. The backend's
- * factory is responsible for hooking up that introspection.
  *
  * @see ../in-process-client.ts
  * @see ../lifed-ws-client.ts
@@ -111,6 +117,19 @@ export type MakeClient = (script: AgentSessionScript) => {
   observations: SubstrateObservations;
 };
 
+/**
+ * Per-backend opt-ins for tests that genuinely cannot be cross-backend.
+ *
+ * `observesHistory`: when true, the harness runs the history-accumulation
+ * test (Test #4). Only the InProcess backend can see history client-side;
+ * lifed accumulates server-side and the WS protocol doesn't echo it back.
+ * Setting this on a non-observable backend would deadlock on a false
+ * assertion, so the test is explicitly gated.
+ */
+export interface ContractOptions {
+  observesHistory?: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
@@ -184,15 +203,19 @@ function tokenDeltas(events: CanonicalAgentEvent[]): string[] {
 /**
  * Single entry point. Backends call:
  *
- *   runAgentSessionClientContract("InProcessAgentSessionClient", makeInProcessClient);
+ *   runAgentSessionClientContract("InProcessAgentSessionClient", makeInProcessClient, { observesHistory: true });
+ *   runAgentSessionClientContract("LifedWsAgentSessionClient", makeLifedWsClient);
  *
  * The harness owns describe/it. Tests are self-contained — each
- * constructs a fresh client + script.
+ * constructs a fresh client + script. `options.observesHistory`
+ * gates the InProcess-only history-accumulation test.
  */
 export function runAgentSessionClientContract(
   suiteName: string,
   makeClient: MakeClient,
+  options: ContractOptions = {},
 ): void {
+  const { observesHistory = false } = options;
   describe(`${suiteName} — AgentSessionClient contract`, () => {
     // ---------------------------------------------------------------------
     // Test 1: per-turn baseline regression guard
@@ -225,10 +248,10 @@ export function runAgentSessionClientContract(
     });
 
     // ---------------------------------------------------------------------
-    // Test 2: multi-turn first turn
+    // Test 2: multi-turn first turn emits turn_end (not finish)
     // ---------------------------------------------------------------------
 
-    it("multi-turn: first user message runs a turn", async () => {
+    it("multi-turn: first user message runs a turn and emits turn_end at the boundary", async () => {
       const sid = `contract-mt-1-${Date.now()}`;
       const script: AgentSessionScript = {
         turns: [{ tokens: ["First", " turn"] }, { tokens: ["never"] }],
@@ -243,35 +266,37 @@ export function runAgentSessionClientContract(
         signal: controller.signal,
       });
 
-      // Pull events until we've seen BOTH expected tokens. The exact
-      // sequence + event count varies per backend (InProcess emits
-      // open + text_start + tokens + text_end; LifedWs emits tokens +
-      // per-turn FINISH). The contract assertion is just "the tokens
-      // arrive in order and no TERMINAL finish has fired yet".
+      // Pull events until we observe a turn_end. The substrate emits:
+      //   [open] tokens (text_start/end inserted by InProcess) … turn_end
+      // We assert the cross-backend contract: tokens land in order,
+      // followed by exactly one `turn_end`, and NO `finish` event has
+      // landed yet (the iterator stays parked for turn 2).
       const reader = iter[Symbol.asyncIterator]();
       const seen: CanonicalAgentEvent[] = [];
-      const tokens: string[] = [];
-      for (let i = 0; i < 30 && tokens.length < 2; i++) {
+      let turnEndSeen = false;
+      for (let i = 0; i < 30 && !turnEndSeen; i++) {
         const { value, done } = await reader.next();
         if (done) break;
         seen.push(value);
-        if (value.event.kind === "token") {
-          tokens.push((value.event as { delta: string }).delta);
+        if (value.event.kind === "turn_end") {
+          turnEndSeen = true;
         }
       }
-      expect(tokens).toEqual(["First", " turn"]);
+      expect(turnEndSeen).toBe(true);
+      // Tokens arrived in order — the substrate yielded both deltas
+      // before the turn boundary.
+      expect(tokenDeltas(seen)).toEqual(["First", " turn"]);
+      // Critical contract assertion: NO `finish` event fired before
+      // `turn_end`. `finish` is the terminal-and-last event; between
+      // turns the canonical marker is `turn_end`.
+      const finishesBeforeBoundary = seen.filter(
+        (e) => e.event.kind === "finish",
+      );
+      expect(finishesBeforeBoundary).toHaveLength(0);
 
-      // No TERMINAL finish has been yielded yet — multi-turn mode keeps
-      // the iterator alive. (A per-turn FINISH from the substrate IS
-      // a "finish"-kind event but is just a turn boundary; the test's
-      // strict assertion of "0 finish events seen" would only hold for
-      // backends that swallow per-turn finishes. We instead assert the
-      // weaker invariant: the iterator is STILL PARKED, i.e., the next
-      // pull does not immediately yield {done: true}.)
-      // Note: we can't synchronously prove "iterator is parked" without
-      // racing. We rely on the iterator-still-alive shape: abort + drain
-      // succeeds in a finite number of iterations. If a terminal finish
-      // had fired earlier, the iterator would have closed already.
+      // Iterator is still alive — abort + drain succeeds in finite
+      // iterations. If a terminal finish had fired earlier, the
+      // iterator would have closed already.
       controller.abort();
       let drainCount = 0;
       while (drainCount < 50) {
@@ -286,7 +311,7 @@ export function runAgentSessionClientContract(
     // Test 3: multi-turn sendMessage triggers a second turn
     // ---------------------------------------------------------------------
 
-    it("multi-turn: sendMessage triggers a second turn", async () => {
+    it("multi-turn: sendMessage after turn_end triggers a second turn that emits its own turn_end", async () => {
       const sid = `contract-mt-2-${Date.now()}`;
       const script: AgentSessionScript = {
         turns: [{ tokens: ["A"] }, { tokens: ["B"] }],
@@ -301,33 +326,45 @@ export function runAgentSessionClientContract(
         signal: controller.signal,
       });
 
-      // Pull turn 1 events first.
+      // Pull events until turn 1's `turn_end` arrives — the explicit
+      // turn-boundary marker. Both backends emit this; cross-backend
+      // contract.
       const turn1Events: CanonicalAgentEvent[] = [];
       const reader = iter[Symbol.asyncIterator]();
-      for (let i = 0; i < 6; i++) {
+      for (let i = 0; i < 30; i++) {
         const { value, done } = await reader.next();
         if (done) break;
         turn1Events.push(value);
-        if (value.event.kind === "token" && value.event.delta === "A") {
-          // got the turn-1 token; park is about to happen.
-          break;
-        }
+        if (value.event.kind === "turn_end") break;
       }
       expect(tokenDeltas(turn1Events)).toContain("A");
+      // Exactly one turn_end and zero finishes in turn 1.
+      expect(
+        turn1Events.filter((e) => e.event.kind === "turn_end"),
+      ).toHaveLength(1);
+      expect(turn1Events.filter((e) => e.event.kind === "finish")).toHaveLength(
+        0,
+      );
 
       // Fire the second turn.
       await client.sendMessage(sid, "second");
 
-      // Pull turn 2 events.
+      // Pull events until turn 2's `turn_end` arrives.
       const turn2Events: CanonicalAgentEvent[] = [];
-      // Wait up to 10 reads for the "B" token.
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < 30; i++) {
         const { value, done } = await reader.next();
         if (done) break;
         turn2Events.push(value);
-        if (value.event.kind === "token" && value.event.delta === "B") break;
+        if (value.event.kind === "turn_end") break;
       }
       expect(tokenDeltas(turn2Events)).toContain("B");
+      // Turn 2 also yields exactly one turn_end + zero finishes.
+      expect(
+        turn2Events.filter((e) => e.event.kind === "turn_end"),
+      ).toHaveLength(1);
+      expect(turn2Events.filter((e) => e.event.kind === "finish")).toHaveLength(
+        0,
+      );
 
       // Cleanup — abort and drain.
       controller.abort();
@@ -339,83 +376,87 @@ export function runAgentSessionClientContract(
     });
 
     // ---------------------------------------------------------------------
-    // Test 4: history accumulates across turns
+    // Test 4: history accumulates across turns — InProcess-only.
+    //
+    // This is a backend-specific extension, NOT a cross-backend contract.
+    // LifedWs accumulates history server-side and the WS protocol doesn't
+    // echo it back, so the WS factory has no way to observe per-turn
+    // history client-side. Gated by `options.observesHistory`.
     // ---------------------------------------------------------------------
 
-    it("multi-turn: history accumulates across turns", async () => {
-      const sid = `contract-mt-3-${Date.now()}`;
-      const script: AgentSessionScript = {
-        turns: [
-          { tokens: ["alpha"], userMessageEcho: "first" },
-          { tokens: ["beta"], userMessageEcho: "second" },
-        ],
-      };
-      const { client, observations } = makeClient(script);
-      const controller = new AbortController();
+    (observesHistory ? it : it.skip)(
+      "multi-turn: history accumulates across turns (InProcess-observable backends only)",
+      async () => {
+        const sid = `contract-mt-3-${Date.now()}`;
+        const script: AgentSessionScript = {
+          turns: [
+            { tokens: ["alpha"], userMessageEcho: "first" },
+            { tokens: ["beta"], userMessageEcho: "second" },
+          ],
+        };
+        const { client, observations } = makeClient(script);
+        const controller = new AbortController();
 
-      const iter = client.stream({
-        ...baseInput(sid),
-        userMessage: "first",
-        multiTurn: true,
-        signal: controller.signal,
-      });
-      const reader = iter[Symbol.asyncIterator]();
+        const iter = client.stream({
+          ...baseInput(sid),
+          userMessage: "first",
+          multiTurn: true,
+          signal: controller.signal,
+        });
+        const reader = iter[Symbol.asyncIterator]();
 
-      // Pull turn 1 until "alpha".
-      for (let i = 0; i < 10; i++) {
-        const { value, done } = await reader.next();
-        if (done) break;
-        if (value.event.kind === "token" && value.event.delta === "alpha") {
-          break;
+        // Pull turn 1 until "alpha".
+        for (let i = 0; i < 10; i++) {
+          const { value, done } = await reader.next();
+          if (done) break;
+          if (value.event.kind === "token" && value.event.delta === "alpha") {
+            break;
+          }
         }
-      }
 
-      // Turn 1 observed: userMessage="first", history (if observable) is empty.
-      expect(observations.observedTurns.length).toBeGreaterThanOrEqual(1);
-      expect(observations.observedTurns[0].userMessage).toBe("first");
-      // History assertions are conditional — see SubstrateObservations
-      // docstring for why the LifedWs backend leaves history undefined.
-      if (observations.observedTurns[0].history !== undefined) {
+        // Turn 1 observed: userMessage="first", history empty.
+        expect(observations.observedTurns.length).toBeGreaterThanOrEqual(1);
+        expect(observations.observedTurns[0].userMessage).toBe("first");
+        // observesHistory === true ⇒ factory must populate history.
         expect(observations.observedTurns[0].history).toEqual([]);
-      }
 
-      // Trigger turn 2.
-      await client.sendMessage(sid, "second");
+        // Trigger turn 2.
+        await client.sendMessage(sid, "second");
 
-      // Pull turn 2 until "beta".
-      for (let i = 0; i < 10; i++) {
-        const { value, done } = await reader.next();
-        if (done) break;
-        if (value.event.kind === "token" && value.event.delta === "beta") {
-          break;
+        // Pull turn 2 until "beta".
+        for (let i = 0; i < 10; i++) {
+          const { value, done } = await reader.next();
+          if (done) break;
+          if (value.event.kind === "token" && value.event.delta === "beta") {
+            break;
+          }
         }
-      }
 
-      // Turn 2 observed: userMessage="second"; history (if observable)
-      // includes turn-1's {user, assistant} pair.
-      expect(observations.observedTurns.length).toBeGreaterThanOrEqual(2);
-      expect(observations.observedTurns[1].userMessage).toBe("second");
-      if (observations.observedTurns[1].history !== undefined) {
+        // Turn 2 observed: userMessage="second"; history includes
+        // turn-1's {user, assistant} pair.
+        expect(observations.observedTurns.length).toBeGreaterThanOrEqual(2);
+        expect(observations.observedTurns[1].userMessage).toBe("second");
         expect(observations.observedTurns[1].history).toEqual([
           { role: "user", content: "first" },
           { role: "assistant", content: "alpha" },
         ]);
-      }
 
-      // Cleanup.
-      controller.abort();
-      while (true) {
-        const { done } = await reader.next();
-        if (done) break;
-      }
-    });
+        // Cleanup.
+        controller.abort();
+        while (true) {
+          const { done } = await reader.next();
+          if (done) break;
+        }
+      },
+    );
 
     // ---------------------------------------------------------------------
-    // Test 5: abort signal terminates the multi-turn loop with one
-    // terminal finish
+    // Test 5: abort signal yields tokens → warning → terminal finish.
+    // Strict cross-backend parity — same event sequence for both
+    // InProcess and LifedWs.
     // ---------------------------------------------------------------------
 
-    it("multi-turn: abort signal terminates the loop with a single terminal finish", async () => {
+    it("multi-turn: abort signal yields tokens → warning(*.aborted) → terminal finish(reason='aborted')", async () => {
       const sid = `contract-mt-4-${Date.now()}`;
       const script: AgentSessionScript = {
         turns: [{ tokens: ["x"] }, { tokens: ["y"] }],
@@ -431,27 +472,21 @@ export function runAgentSessionClientContract(
       });
 
       const reader = iter[Symbol.asyncIterator]();
-      // Pull turn 1 to completion (token + per-turn finish boundary
-      // signal) so the iterator is parked waiting for the next
-      // sendMessage. The InProcess backend doesn't surface a per-turn
-      // finish event (swallowed in the multi-turn body); the LifedWs
-      // backend DOES (the consumer needs it to persist the turn). The
-      // test accepts both: pull until we see the "x" token AND drain
-      // any subsequent non-token frames up to the next park.
+      // Pull until the "x" token lands; subsequent reads may park
+      // (InProcess) or pick up a turn_end (WS), so we don't drain past
+      // the token here.
       const turn1Events: CanonicalAgentEvent[] = [];
       for (let i = 0; i < 10; i++) {
         const { value, done } = await reader.next();
         if (done) break;
         turn1Events.push(value);
         if (value.event.kind === "token" && value.event.delta === "x") {
-          // Subsequent reads might pull a per-turn finish (WS backend)
-          // or park immediately (InProcess backend). We can't safely
-          // pull more here — the parked InProcess reader would hang.
           break;
         }
       }
+      expect(tokenDeltas(turn1Events)).toContain("x");
 
-      // Abort and drain — collect events until iterator done.
+      // Abort and drain — collect every event until iterator done.
       controller.abort();
       const remaining: CanonicalAgentEvent[] = [];
       while (true) {
@@ -460,21 +495,32 @@ export function runAgentSessionClientContract(
         remaining.push(value);
       }
 
-      // The drain may include:
-      //   - A per-turn finish event from the WS backend (reason "stop")
-      //     — this is the turn boundary the consumer would normally use
-      //     to persist the turn. Multi-turn semantics: turn-finishes ≠
-      //     stream-terminal-finishes.
-      //   - An abort warning (kind "warning", code "lifed-ws.aborted"
-      //     or "in-process.aborted").
-      //   - Exactly one TERMINAL finish (reason "aborted").
-      //
-      // We assert: at least one finish; the LAST finish is reason
-      // "aborted" (the terminal one).
+      // Exactly one TERMINAL `finish` with reason "aborted" — the
+      // contract reserves `finish` for the one-and-only terminal event.
+      // No `turn_end` event after abort (the abort path skips boundary
+      // emission and goes straight to warning + terminal finish).
       const finishes = remaining.filter((e) => e.event.kind === "finish");
-      expect(finishes.length).toBeGreaterThanOrEqual(1);
-      const terminal = finishes[finishes.length - 1];
+      expect(finishes).toHaveLength(1);
+      const terminal = finishes[0];
       expect((terminal.event as { reason: string }).reason).toBe("aborted");
+      // `finish` IS the last event (terminal-and-last invariant).
+      expect(remaining[remaining.length - 1]).toBe(terminal);
+
+      // Exactly one abort warning with a backend-suffixed code ending
+      // in `.aborted` (e.g. `in-process.aborted` or `lifed-ws.aborted`).
+      // Cross-backend parity: both surfaces emit this so consumers
+      // distinguish "abort from client" from "transport collapsed".
+      const warnings = remaining.filter(
+        (e) =>
+          e.event.kind === "warning" &&
+          (e.event as { code: string }).code.endsWith(".aborted"),
+      );
+      expect(warnings).toHaveLength(1);
+
+      // Sequence: warning lands BEFORE the terminal finish.
+      const warningIdx = remaining.indexOf(warnings[0]);
+      const finishIdx = remaining.indexOf(terminal);
+      expect(warningIdx).toBeLessThan(finishIdx);
     });
 
     // ---------------------------------------------------------------------

--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/contract.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/contract.ts
@@ -1,0 +1,536 @@
+/**
+ * Contract test harness for `AgentSessionClient` — runs the SAME
+ * tests against every backend so per-backend test files only have
+ * to wire the client factory.
+ *
+ * Plan E-2 (Task 4). The harness defines 7 tests:
+ *
+ *   1. per-turn baseline — yields tokens + a single finish then closes.
+ *   2. multi-turn: first user message runs a turn.
+ *   3. multi-turn: sendMessage triggers a second turn.
+ *   4. multi-turn: history accumulates across turns.
+ *   5. multi-turn: abort signal terminates the loop with a single
+ *      terminal finish.
+ *   6. multi-turn: sendMessage on unknown sid throws
+ *      AgentSessionUnknownSidError.
+ *   7. multi-turn: sendMessage on closed (post-abort) sid throws
+ *      AgentSessionUnknownSidError.
+ *
+ * Backends call `runAgentSessionClientContract(suiteName, makeClient)`;
+ * the harness owns describe/it blocks.
+ *
+ * `makeClient` returns a freshly-constructed client AND a `script`
+ * — the script encodes the deterministic events the backend's
+ * underlying substrate should yield per turn. For InProcess, the
+ * script is fed through a fake `RealAgentRunner`; for LifedWs, the
+ * script is fed through a fake `WebSocketFactory`.
+ *
+ * History accumulation is verified by the script — when the harness
+ * runs turn 2, the script can return a different token stream
+ * based on the history it observed for that turn. The backend's
+ * factory is responsible for hooking up that introspection.
+ *
+ * @see ../in-process-client.ts
+ * @see ../lifed-ws-client.ts
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  AgentSessionClient,
+  AgentStreamInput,
+  CanonicalAgentEvent,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// Script shape — the per-backend factory wires this through its fake
+// substrate. The contract harness only knows about the canonical events
+// the backend should yield; the backend factories translate the events
+// into whatever shape their fake substrate emits.
+// ---------------------------------------------------------------------------
+
+/**
+ * One scripted turn — the substrate yields these canonical events in
+ * order, then signals "turn end" (FINISH for WS / done for InProcess).
+ *
+ * `userMessageEcho`: when set, the harness uses this string to assert
+ * the substrate observed the right user message for the turn. Each
+ * backend's factory passes it through when wiring the fake.
+ */
+export interface ScriptedTurn {
+  /** Token deltas the substrate emits this turn. */
+  tokens: string[];
+  /** Optional per-turn introspection — last user message the substrate saw. */
+  userMessageEcho?: string;
+  /**
+   * Optional history snapshot the substrate observed at the start of
+   * this turn. Set when a test wants to verify history accumulation
+   * across turns (Test #4). Indexed against
+   * `scriptedSubstrate.observedHistory[turnIndex]`.
+   */
+  historyEcho?: Array<{ role: "user" | "assistant"; content: string }>;
+}
+
+/**
+ * The full script the test wires into the substrate. `turns[i]` defines
+ * what the substrate emits on turn `i`. Multi-turn tests typically
+ * have 2+ entries; per-turn tests have exactly one.
+ */
+export interface AgentSessionScript {
+  turns: ScriptedTurn[];
+}
+
+/**
+ * Per-turn observations the substrate records. Tests inspect this to
+ * verify history accumulation, user-message routing, abort propagation.
+ *
+ * `history` is OPTIONAL — the LifedWs backend can't observe history
+ * client-side (lifed accumulates it server-side and the WS protocol
+ * doesn't echo it back), so the WS factory leaves it undefined and
+ * the harness skips the history assertions for that backend.
+ */
+export interface SubstrateObservations {
+  /**
+   * Each entry is `{ userMessage, history? }` at the start of the turn.
+   * `history` is populated only when the substrate is observable from
+   * the client side (InProcess: yes; LifedWs: no).
+   */
+  observedTurns: Array<{
+    userMessage: string;
+    history?: Array<{ role: "user" | "assistant"; content: string }>;
+  }>;
+}
+
+/**
+ * The factory contract: a per-backend factory produces a fresh client
+ * + the observations object the harness asserts against. The factory
+ * controls how the script is fed into the underlying substrate.
+ */
+export type MakeClient = (script: AgentSessionScript) => {
+  client: AgentSessionClient;
+  observations: SubstrateObservations;
+};
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a baseline `AgentStreamInput` for the contract suite. Tests
+ * spread additional fields on top.
+ */
+function baseInput(sid: string): Omit<AgentStreamInput, "userMessage"> {
+  return {
+    sessionId: sid,
+    agentId: "user:contract-test",
+    projectSlug: "sentinel-property-ops",
+    history: [],
+    kernelCtx: {
+      sessionId: sid,
+      agentId: "user:contract-test",
+    },
+    // Provide a fake capability so the lifed-ws factory doesn't reject
+    // on the no-capability path. InProcess ignores this field.
+    capability: { token: "contract-test-cap", expiresAt: 9_999_999_999 },
+  };
+}
+
+/**
+ * Collect events from an async iterable until either the iterator
+ * closes or we observe `count` events (whichever comes first).
+ */
+async function collectN(
+  iter: AsyncIterable<CanonicalAgentEvent>,
+  count: number,
+): Promise<CanonicalAgentEvent[]> {
+  const out: CanonicalAgentEvent[] = [];
+  for await (const ev of iter) {
+    out.push(ev);
+    if (out.length >= count) break;
+  }
+  return out;
+}
+
+/**
+ * Collect ALL events the iterator yields. Used after abort or when the
+ * test expects the iterator to close on its own.
+ */
+async function collectAll(
+  iter: AsyncIterable<CanonicalAgentEvent>,
+): Promise<CanonicalAgentEvent[]> {
+  const out: CanonicalAgentEvent[] = [];
+  for await (const ev of iter) {
+    out.push(ev);
+  }
+  return out;
+}
+
+/**
+ * Yield the macrotask queue once so any pending `addEventListener` /
+ * promise microtask resolutions land before the next assertion. Both
+ * backends rely on event-loop scheduling for `open` / queue drain.
+ */
+const tick = (ms = 0) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Filter events to just the token deltas for assertion brevity.
+ */
+function tokenDeltas(events: CanonicalAgentEvent[]): string[] {
+  return events
+    .filter((e) => e.event.kind === "token")
+    .map((e) => (e.event as { delta: string }).delta);
+}
+
+/**
+ * Single entry point. Backends call:
+ *
+ *   runAgentSessionClientContract("InProcessAgentSessionClient", makeInProcessClient);
+ *
+ * The harness owns describe/it. Tests are self-contained — each
+ * constructs a fresh client + script.
+ */
+export function runAgentSessionClientContract(
+  suiteName: string,
+  makeClient: MakeClient,
+): void {
+  describe(`${suiteName} — AgentSessionClient contract`, () => {
+    // ---------------------------------------------------------------------
+    // Test 1: per-turn baseline regression guard
+    // ---------------------------------------------------------------------
+
+    it("per-turn (multiTurn=false): yields tokens and a single finish then closes the iterator", async () => {
+      const sid = `contract-pt-1-${Date.now()}`;
+      const script: AgentSessionScript = {
+        turns: [{ tokens: ["Hello", " world"] }],
+      };
+      const { client } = makeClient(script);
+
+      const events = await collectAll(
+        client.stream({
+          ...baseInput(sid),
+          userMessage: "say hi",
+          // multiTurn omitted → per-turn path
+        }),
+      );
+
+      const tokens = tokenDeltas(events);
+      expect(tokens).toEqual(["Hello", " world"]);
+
+      // Exactly one terminal finish — the per-turn iterator MUST close.
+      const finishes = events.filter((e) => e.event.kind === "finish");
+      expect(finishes).toHaveLength(1);
+
+      // Iterator must be fully drained — collectAll() returned.
+      expect(events[events.length - 1].event.kind).toBe("finish");
+    });
+
+    // ---------------------------------------------------------------------
+    // Test 2: multi-turn first turn
+    // ---------------------------------------------------------------------
+
+    it("multi-turn: first user message runs a turn", async () => {
+      const sid = `contract-mt-1-${Date.now()}`;
+      const script: AgentSessionScript = {
+        turns: [{ tokens: ["First", " turn"] }, { tokens: ["never"] }],
+      };
+      const { client } = makeClient(script);
+      const controller = new AbortController();
+
+      const iter = client.stream({
+        ...baseInput(sid),
+        userMessage: "turn 1 prompt",
+        multiTurn: true,
+        signal: controller.signal,
+      });
+
+      // Pull events until we've seen BOTH expected tokens. The exact
+      // sequence + event count varies per backend (InProcess emits
+      // open + text_start + tokens + text_end; LifedWs emits tokens +
+      // per-turn FINISH). The contract assertion is just "the tokens
+      // arrive in order and no TERMINAL finish has fired yet".
+      const reader = iter[Symbol.asyncIterator]();
+      const seen: CanonicalAgentEvent[] = [];
+      const tokens: string[] = [];
+      for (let i = 0; i < 30 && tokens.length < 2; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        seen.push(value);
+        if (value.event.kind === "token") {
+          tokens.push((value.event as { delta: string }).delta);
+        }
+      }
+      expect(tokens).toEqual(["First", " turn"]);
+
+      // No TERMINAL finish has been yielded yet — multi-turn mode keeps
+      // the iterator alive. (A per-turn FINISH from the substrate IS
+      // a "finish"-kind event but is just a turn boundary; the test's
+      // strict assertion of "0 finish events seen" would only hold for
+      // backends that swallow per-turn finishes. We instead assert the
+      // weaker invariant: the iterator is STILL PARKED, i.e., the next
+      // pull does not immediately yield {done: true}.)
+      // Note: we can't synchronously prove "iterator is parked" without
+      // racing. We rely on the iterator-still-alive shape: abort + drain
+      // succeeds in a finite number of iterations. If a terminal finish
+      // had fired earlier, the iterator would have closed already.
+      controller.abort();
+      let drainCount = 0;
+      while (drainCount < 50) {
+        const { done } = await reader.next();
+        drainCount += 1;
+        if (done) break;
+      }
+      expect(drainCount).toBeLessThan(50);
+    });
+
+    // ---------------------------------------------------------------------
+    // Test 3: multi-turn sendMessage triggers a second turn
+    // ---------------------------------------------------------------------
+
+    it("multi-turn: sendMessage triggers a second turn", async () => {
+      const sid = `contract-mt-2-${Date.now()}`;
+      const script: AgentSessionScript = {
+        turns: [{ tokens: ["A"] }, { tokens: ["B"] }],
+      };
+      const { client } = makeClient(script);
+      const controller = new AbortController();
+
+      const iter = client.stream({
+        ...baseInput(sid),
+        userMessage: "first",
+        multiTurn: true,
+        signal: controller.signal,
+      });
+
+      // Pull turn 1 events first.
+      const turn1Events: CanonicalAgentEvent[] = [];
+      const reader = iter[Symbol.asyncIterator]();
+      for (let i = 0; i < 6; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        turn1Events.push(value);
+        if (value.event.kind === "token" && value.event.delta === "A") {
+          // got the turn-1 token; park is about to happen.
+          break;
+        }
+      }
+      expect(tokenDeltas(turn1Events)).toContain("A");
+
+      // Fire the second turn.
+      await client.sendMessage(sid, "second");
+
+      // Pull turn 2 events.
+      const turn2Events: CanonicalAgentEvent[] = [];
+      // Wait up to 10 reads for the "B" token.
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        turn2Events.push(value);
+        if (value.event.kind === "token" && value.event.delta === "B") break;
+      }
+      expect(tokenDeltas(turn2Events)).toContain("B");
+
+      // Cleanup — abort and drain.
+      controller.abort();
+      // Drain remaining events from the iterator until done.
+      while (true) {
+        const { done } = await reader.next();
+        if (done) break;
+      }
+    });
+
+    // ---------------------------------------------------------------------
+    // Test 4: history accumulates across turns
+    // ---------------------------------------------------------------------
+
+    it("multi-turn: history accumulates across turns", async () => {
+      const sid = `contract-mt-3-${Date.now()}`;
+      const script: AgentSessionScript = {
+        turns: [
+          { tokens: ["alpha"], userMessageEcho: "first" },
+          { tokens: ["beta"], userMessageEcho: "second" },
+        ],
+      };
+      const { client, observations } = makeClient(script);
+      const controller = new AbortController();
+
+      const iter = client.stream({
+        ...baseInput(sid),
+        userMessage: "first",
+        multiTurn: true,
+        signal: controller.signal,
+      });
+      const reader = iter[Symbol.asyncIterator]();
+
+      // Pull turn 1 until "alpha".
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        if (value.event.kind === "token" && value.event.delta === "alpha") {
+          break;
+        }
+      }
+
+      // Turn 1 observed: userMessage="first", history (if observable) is empty.
+      expect(observations.observedTurns.length).toBeGreaterThanOrEqual(1);
+      expect(observations.observedTurns[0].userMessage).toBe("first");
+      // History assertions are conditional — see SubstrateObservations
+      // docstring for why the LifedWs backend leaves history undefined.
+      if (observations.observedTurns[0].history !== undefined) {
+        expect(observations.observedTurns[0].history).toEqual([]);
+      }
+
+      // Trigger turn 2.
+      await client.sendMessage(sid, "second");
+
+      // Pull turn 2 until "beta".
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        if (value.event.kind === "token" && value.event.delta === "beta") {
+          break;
+        }
+      }
+
+      // Turn 2 observed: userMessage="second"; history (if observable)
+      // includes turn-1's {user, assistant} pair.
+      expect(observations.observedTurns.length).toBeGreaterThanOrEqual(2);
+      expect(observations.observedTurns[1].userMessage).toBe("second");
+      if (observations.observedTurns[1].history !== undefined) {
+        expect(observations.observedTurns[1].history).toEqual([
+          { role: "user", content: "first" },
+          { role: "assistant", content: "alpha" },
+        ]);
+      }
+
+      // Cleanup.
+      controller.abort();
+      while (true) {
+        const { done } = await reader.next();
+        if (done) break;
+      }
+    });
+
+    // ---------------------------------------------------------------------
+    // Test 5: abort signal terminates the multi-turn loop with one
+    // terminal finish
+    // ---------------------------------------------------------------------
+
+    it("multi-turn: abort signal terminates the loop with a single terminal finish", async () => {
+      const sid = `contract-mt-4-${Date.now()}`;
+      const script: AgentSessionScript = {
+        turns: [{ tokens: ["x"] }, { tokens: ["y"] }],
+      };
+      const { client } = makeClient(script);
+      const controller = new AbortController();
+
+      const iter = client.stream({
+        ...baseInput(sid),
+        userMessage: "first",
+        multiTurn: true,
+        signal: controller.signal,
+      });
+
+      const reader = iter[Symbol.asyncIterator]();
+      // Pull turn 1 to completion (token + per-turn finish boundary
+      // signal) so the iterator is parked waiting for the next
+      // sendMessage. The InProcess backend doesn't surface a per-turn
+      // finish event (swallowed in the multi-turn body); the LifedWs
+      // backend DOES (the consumer needs it to persist the turn). The
+      // test accepts both: pull until we see the "x" token AND drain
+      // any subsequent non-token frames up to the next park.
+      const turn1Events: CanonicalAgentEvent[] = [];
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        turn1Events.push(value);
+        if (value.event.kind === "token" && value.event.delta === "x") {
+          // Subsequent reads might pull a per-turn finish (WS backend)
+          // or park immediately (InProcess backend). We can't safely
+          // pull more here — the parked InProcess reader would hang.
+          break;
+        }
+      }
+
+      // Abort and drain — collect events until iterator done.
+      controller.abort();
+      const remaining: CanonicalAgentEvent[] = [];
+      while (true) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        remaining.push(value);
+      }
+
+      // The drain may include:
+      //   - A per-turn finish event from the WS backend (reason "stop")
+      //     — this is the turn boundary the consumer would normally use
+      //     to persist the turn. Multi-turn semantics: turn-finishes ≠
+      //     stream-terminal-finishes.
+      //   - An abort warning (kind "warning", code "lifed-ws.aborted"
+      //     or "in-process.aborted").
+      //   - Exactly one TERMINAL finish (reason "aborted").
+      //
+      // We assert: at least one finish; the LAST finish is reason
+      // "aborted" (the terminal one).
+      const finishes = remaining.filter((e) => e.event.kind === "finish");
+      expect(finishes.length).toBeGreaterThanOrEqual(1);
+      const terminal = finishes[finishes.length - 1];
+      expect((terminal.event as { reason: string }).reason).toBe("aborted");
+    });
+
+    // ---------------------------------------------------------------------
+    // Test 6: sendMessage on unknown sid throws
+    // ---------------------------------------------------------------------
+
+    it("multi-turn: sendMessage on unknown sid throws AgentSessionUnknownSidError", async () => {
+      const script: AgentSessionScript = { turns: [{ tokens: ["x"] }] };
+      const { client } = makeClient(script);
+
+      await expect(
+        client.sendMessage("sid-that-never-existed", "hi"),
+      ).rejects.toMatchObject({
+        name: "AgentSessionUnknownSidError",
+        code: "agent-session.unknown_sid",
+      });
+    });
+
+    // ---------------------------------------------------------------------
+    // Test 7: sendMessage on closed (post-abort) sid throws
+    // ---------------------------------------------------------------------
+
+    it("multi-turn: sendMessage on closed (post-abort) sid throws AgentSessionUnknownSidError", async () => {
+      const sid = `contract-mt-5-${Date.now()}`;
+      const script: AgentSessionScript = {
+        turns: [{ tokens: ["x"] }],
+      };
+      const { client } = makeClient(script);
+      const controller = new AbortController();
+
+      const iter = client.stream({
+        ...baseInput(sid),
+        userMessage: "first",
+        multiTurn: true,
+        signal: controller.signal,
+      });
+      const reader = iter[Symbol.asyncIterator]();
+      for (let i = 0; i < 10; i++) {
+        const { value, done } = await reader.next();
+        if (done) break;
+        if (value.event.kind === "token" && value.event.delta === "x") break;
+      }
+      controller.abort();
+      // Drain.
+      while (true) {
+        const { done } = await reader.next();
+        if (done) break;
+      }
+      // Give the finally-block any microtasks it needs to clean up.
+      await tick();
+
+      // After cleanup, the sid is gone.
+      await expect(client.sendMessage(sid, "too late")).rejects.toMatchObject({
+        name: "AgentSessionUnknownSidError",
+        code: "agent-session.unknown_sid",
+      });
+    });
+  });
+}

--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/in-process-contract.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/in-process-contract.test.ts
@@ -239,4 +239,5 @@ const makeInProcessClient: MakeClient = (script: AgentSessionScript) => {
 runAgentSessionClientContract(
   "InProcessAgentSessionClient",
   makeInProcessClient,
+  { observesHistory: true },
 );

--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/in-process-contract.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/in-process-contract.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Contract tests for `InProcessAgentSessionClient`.
+ *
+ * Wires the contract harness (`./contract.ts`) to a deterministic
+ * `RealAgentRunner` stub. The stub reads a script from a globalThis
+ * registry keyed by `lifeSessionId`. Each call to `runner.run()`
+ * consumes the next scripted turn.
+ *
+ * Plan E-2 Task 4.
+ *
+ * The `vi.mock` factory hoists above imports — to share state between
+ * the mock and the test, we route through `globalThis.__inproc_contract`,
+ * a `WeakMap`-style record initialised lazily by the mock factory and
+ * read by both sides.
+ *
+ * @see ./contract.ts
+ * @see ../in-process-client.ts
+ */
+
+// @vitest-environment node
+import { afterEach, beforeEach, vi } from "vitest";
+
+// Shared registry — must live in a stable globalThis slot so the
+// hoisted `vi.mock` factory can find it at module-evaluation time.
+interface ContractGlobal {
+  scripts: Map<string, { turns: Array<{ tokens: string[] }> }>;
+  turnIndexes: Map<string, number>;
+  observations: Map<
+    string,
+    {
+      observedTurns: Array<{
+        userMessage: string;
+        history: Array<{ role: "user" | "assistant"; content: string }>;
+      }>;
+    }
+  >;
+}
+
+const __global = globalThis as unknown as {
+  __inproc_contract?: ContractGlobal;
+};
+if (!__global.__inproc_contract) {
+  __global.__inproc_contract = {
+    scripts: new Map(),
+    turnIndexes: new Map(),
+    observations: new Map(),
+  };
+}
+const G: ContractGlobal = __global.__inproc_contract;
+
+// `in-process-client.ts` begins with `import "server-only"`. Stub it
+// out so it loads under raw Node.
+vi.mock("server-only", () => ({}));
+
+// Mock `real-runner` BEFORE its consumer imports it. The fake runner
+// reads `globalThis.__inproc_contract` lazily — at `run()` call time
+// rather than at factory-evaluation time — so the registry exists
+// even though vi.mock hoists ABOVE the module body that sets it up.
+vi.mock("../../real-runner", () => {
+  const getG = (): ContractGlobal => {
+    const g = (globalThis as unknown as { __inproc_contract?: ContractGlobal })
+      .__inproc_contract;
+    if (!g) {
+      throw new Error(
+        "in-process-contract.test: __inproc_contract registry missing; test setup is broken",
+      );
+    }
+    return g;
+  };
+  return {
+    makeLifeToolHandlers: () => ({}),
+    RealAgentRunner: class FakeRunner {
+      private readonly sid: string;
+      private readonly userMessage: string;
+      private readonly history: Array<{
+        role: "user" | "assistant";
+        content: string;
+      }>;
+      constructor(opts: {
+        lifeSessionId?: string;
+        userMessage: string;
+        history: Array<{ role: "user" | "assistant"; content: string }>;
+      }) {
+        this.sid = opts.lifeSessionId ?? "";
+        this.userMessage = opts.userMessage;
+        this.history = opts.history.map((h) => ({ ...h }));
+      }
+      async *run() {
+        const G2 = getG();
+        const turns = G2.scripts.get(this.sid);
+        const turnIndex = G2.turnIndexes.get(this.sid) ?? 0;
+        const turn = turns?.turns[turnIndex];
+
+        // Observe BEFORE yielding so the test can assert mid-stream.
+        const obs = G2.observations.get(this.sid);
+        if (obs) {
+          obs.observedTurns.push({
+            userMessage: this.userMessage,
+            history: this.history.map((h) => ({ ...h })),
+          });
+        }
+        G2.turnIndexes.set(this.sid, turnIndex + 1);
+
+        if (!turn) {
+          // Out-of-script — yield a finish so the iterator unblocks.
+          yield {
+            kind: "domain",
+            event: {
+              type: "done",
+              payload: { finishReason: "stop" },
+              at: new Date().toISOString(),
+            },
+          };
+          return;
+        }
+
+        // text-start / token deltas / text-end as LLM stream parts.
+        const msgId = `msg-${Date.now()}-${turnIndex}`;
+        yield {
+          kind: "llm",
+          part: { type: "text-start", id: msgId },
+          at: new Date().toISOString(),
+        };
+        for (const delta of turn.tokens) {
+          yield {
+            kind: "llm",
+            part: { type: "text-delta", id: msgId, delta, text: delta },
+            at: new Date().toISOString(),
+          };
+        }
+        yield {
+          kind: "llm",
+          part: { type: "text-end", id: msgId },
+          at: new Date().toISOString(),
+        };
+        // Per-turn done — in-process client swallows in multi-turn,
+        // forwards in per-turn mode.
+        yield {
+          kind: "domain",
+          event: {
+            type: "done",
+            payload: { finishReason: "stop" },
+            at: new Date().toISOString(),
+          },
+        };
+      }
+    },
+  };
+});
+
+// Kernel factory — returns a fake KernelClient with no-op VM.
+vi.mock("../../kernel/factory", () => ({
+  createKernelClient: () => ({
+    backendId: "in-process",
+    createVm: async () => ({
+      handleId: "vm-fake",
+      backendId: "in-process",
+    }),
+    destroy: async () => undefined,
+  }),
+}));
+
+// `kernel/in-process-client` re-exports the ToolHandler type — the
+// import is type-only on the real path, but the cjs interop wants
+// SOMETHING at runtime. Empty module is fine.
+vi.mock("../../kernel/in-process-client", () => ({}));
+
+// Projects — minimal fake.
+vi.mock("../../projects", () => {
+  const slug = "sentinel-property-ops";
+  const cfg = {
+    slug,
+    moduleTypeId: "sentinel-property-ops",
+    toolAllowlist: ["note"],
+    billing: { mode: "free" as const, pricePerRunCents: 0 },
+  };
+  return {
+    isProjectSlug: (s: string) => s === slug,
+    getProjectConfig: () => cfg,
+  };
+});
+
+// Imports happen AFTER vi.mock so the module graph builds with mocks.
+import { InProcessAgentSessionClient } from "../in-process-client";
+import {
+  type AgentSessionScript,
+  type MakeClient,
+  runAgentSessionClientContract,
+  type SubstrateObservations,
+} from "./contract";
+
+beforeEach(() => {
+  G.scripts.clear();
+  G.turnIndexes.clear();
+  G.observations.clear();
+});
+
+afterEach(() => {
+  G.scripts.clear();
+  G.turnIndexes.clear();
+  G.observations.clear();
+});
+
+const makeInProcessClient: MakeClient = (script: AgentSessionScript) => {
+  const observations: SubstrateObservations = { observedTurns: [] };
+  const client = new InProcessAgentSessionClient({
+    resolveProject: async () =>
+      ({
+        id: "fake-project-id",
+        slug: "sentinel-property-ops",
+        moduleTypeId: "sentinel-property-ops",
+        displayName: "Sentinel",
+      }) as never,
+  });
+
+  // Wrap stream() so the first call seeds the script/observations
+  // registry with the sid the client uses. Subsequent calls reuse.
+  const originalStream = client.stream.bind(client);
+  // biome-ignore lint/suspicious/noExplicitAny: test-only patch
+  (client as any).stream = async function* (input: {
+    sessionId: string;
+  }): AsyncIterable<unknown> {
+    if (!G.scripts.has(input.sessionId)) {
+      G.scripts.set(input.sessionId, script);
+      G.turnIndexes.set(input.sessionId, 0);
+      G.observations.set(input.sessionId, observations);
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: test-only forward
+    yield* originalStream(input as any);
+  };
+
+  return { client, observations };
+};
+
+runAgentSessionClientContract(
+  "InProcessAgentSessionClient",
+  makeInProcessClient,
+);

--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/in-process-contract.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/in-process-contract.test.ts
@@ -28,9 +28,13 @@ interface ContractGlobal {
   observations: Map<
     string,
     {
+      // `history` is optional to mirror `SubstrateObservations`'s
+      // contract (WS backend leaves it undefined; see contract.ts).
+      // The InProcess fake DOES populate it, so consumers can assume
+      // a value, but the type must stay assignable.
       observedTurns: Array<{
         userMessage: string;
-        history: Array<{ role: "user" | "assistant"; content: string }>;
+        history?: Array<{ role: "user" | "assistant"; content: string }>;
       }>;
     }
   >;

--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/lifed-ws-contract.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/lifed-ws-contract.test.ts
@@ -24,7 +24,7 @@
  */
 
 // @vitest-environment node
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -33,6 +33,7 @@ vi.mock("server-only", () => ({}));
 
 import type { WebSocketFactory } from "../lifed-ws-client";
 import { LifedWsAgentSessionClient } from "../lifed-ws-client";
+import type { CanonicalAgentEvent } from "../types";
 import {
   type AgentSessionScript,
   type MakeClient,
@@ -190,3 +191,153 @@ const makeLifedWsClient: MakeClient = (script: AgentSessionScript) => {
 };
 
 runAgentSessionClientContract("LifedWsAgentSessionClient", makeLifedWsClient);
+
+// ---------------------------------------------------------------------------
+// Per-turn baseline regression tests for close-after-finish behavior.
+//
+// These verify the strict terminal-finish-once invariant on the
+// per-turn path: when the server already sent FINISH, a subsequent
+// close (normal OR error) MUST NOT double-emit a second `finish`.
+// Pre-fix, the per-turn finally block paired error+finish on any
+// close code even when finishYielded was already true (Codex
+// reviewer's BLOCKER #5 — "transient close after finish").
+// ---------------------------------------------------------------------------
+
+/**
+ * A tight, deterministic WS fake that emits exactly:
+ *   - one TOKEN frame (so the iterator has something to yield)
+ *   - one FINISH frame
+ *   - then a close(code) — caller chooses 1000 (normal) or 1011 (transient)
+ *
+ * Used by the close-after-finish regression tests below. The harness's
+ * `FakeWebSocket` is too message-driven for this — it auto-closes on
+ * script exhaustion, which obscures the close-code timing the test
+ * needs to control directly.
+ */
+class CloseAfterFinishFake {
+  readyState = 0; // CONNECTING
+  private handlers: FakeWsHandlers = {};
+
+  constructor(private readonly closeCode: number) {
+    queueMicrotask(() => {
+      this.readyState = 1; // OPEN
+      this.handlers.open?.();
+    });
+  }
+
+  addEventListener<K extends keyof FakeWsHandlers>(
+    event: K,
+    h: NonNullable<FakeWsHandlers[K]>,
+  ): void {
+    // biome-ignore lint/suspicious/noExplicitAny: handler union
+    (this.handlers as any)[event] = h;
+  }
+
+  send(_data: string): void {
+    queueMicrotask(() => {
+      if (this.readyState !== 1) return;
+      this.handlers.message?.({
+        data: JSON.stringify({
+          kind: "agent_event",
+          seq_no: "1",
+          record: {
+            sequence: 1,
+            at: new Date().toISOString(),
+            kind: "TOKEN",
+            payload: { text: "hi" },
+          },
+          agent_kind: "AGENT_EVENT_KIND_TOKEN",
+        }),
+      });
+      this.handlers.message?.({
+        data: JSON.stringify({
+          kind: "agent_event",
+          seq_no: "2",
+          record: {
+            sequence: 2,
+            at: new Date().toISOString(),
+            kind: "FINISH",
+            payload: { finish_reason: "stop" },
+          },
+          agent_kind: "AGENT_EVENT_KIND_FINISH",
+        }),
+      });
+      // Fire the close on the next microtask so the FINISH frame is
+      // fully processed by the client's pump loop first.
+      queueMicrotask(() => {
+        this.readyState = 3; // CLOSED
+        this.handlers.close?.({ code: this.closeCode, reason: "" });
+      });
+    });
+  }
+
+  close(_code = 1000, _reason = ""): void {
+    this.readyState = 3;
+  }
+}
+
+async function drainStream(
+  client: LifedWsAgentSessionClient,
+  sid: string,
+): Promise<CanonicalAgentEvent[]> {
+  const events: CanonicalAgentEvent[] = [];
+  const iter = client.stream({
+    sessionId: sid,
+    agentId: "user:close-after-finish",
+    projectSlug: "sentinel-property-ops",
+    history: [],
+    kernelCtx: { sessionId: sid, agentId: "user:close-after-finish" },
+    capability: { token: "fake", expiresAt: 9_999_999_999 },
+    userMessage: "hi",
+    // multiTurn omitted → per-turn path under test.
+  });
+  for await (const ev of iter) events.push(ev);
+  return events;
+}
+
+describe("LifedWsAgentSessionClient — per-turn close-after-finish parity", () => {
+  it("per-turn: server FINISH followed by normal close (1000) does NOT double-emit finish", async () => {
+    const wsFactory: WebSocketFactory = () =>
+      new CloseAfterFinishFake(1000) as unknown as ReturnType<WebSocketFactory>;
+    const client = new LifedWsAgentSessionClient({
+      baseUrl: "https://fake.lifegw.test",
+      webSocketFactory: wsFactory,
+      fetchFn: (async () => new Response("OK")) as typeof fetch,
+    });
+
+    const events = await drainStream(client, "close-after-finish-1000");
+    // Exactly one `finish` total — the server FINISH frame produced
+    // it; the normal close handler must NOT synthesize another.
+    const finishes = events.filter((e) => e.event.kind === "finish");
+    expect(finishes).toHaveLength(1);
+    // No paired `error` event either — close 1000 is clean.
+    const errors = events.filter((e) => e.event.kind === "error");
+    expect(errors).toHaveLength(0);
+    // `finish` is terminal-and-last.
+    expect(events[events.length - 1].event.kind).toBe("finish");
+  });
+
+  it("per-turn: server FINISH followed by error close (1011) does NOT double-emit terminal events", async () => {
+    const wsFactory: WebSocketFactory = () =>
+      new CloseAfterFinishFake(1011) as unknown as ReturnType<WebSocketFactory>;
+    const client = new LifedWsAgentSessionClient({
+      baseUrl: "https://fake.lifegw.test",
+      webSocketFactory: wsFactory,
+      fetchFn: (async () => new Response("OK")) as typeof fetch,
+    });
+
+    const events = await drainStream(client, "close-after-finish-1011");
+    // Exactly one `finish` total — the server FINISH frame already
+    // produced the terminal event. A subsequent transient close
+    // (1011) MUST NOT pair-emit error+finish.
+    const finishes = events.filter((e) => e.event.kind === "finish");
+    expect(finishes).toHaveLength(1);
+    // No `error` event either — once FINISH lands, the stream is
+    // contractually closed; transient transport close after that is
+    // a no-op for the consumer.
+    const errors = events.filter((e) => e.event.kind === "error");
+    expect(errors).toHaveLength(0);
+    // `finish` remains terminal-and-last.
+    expect(events[events.length - 1].event.kind).toBe("finish");
+  });
+});

--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/lifed-ws-contract.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/lifed-ws-contract.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Contract tests for `LifedWsAgentSessionClient`.
+ *
+ * Wires the contract harness (`./contract.ts`) to a scripted fake
+ * `WebSocketFactory`. The fake WS:
+ *
+ *   - Fires `open` asynchronously via `queueMicrotask`.
+ *   - Accepts inbound `send_message` frames and emits one scripted
+ *     turn's worth of `agent_event` frames (token deltas + FINISH).
+ *   - Per-turn FINISH does NOT close the WS — matches lifed's actual
+ *     behavior (Open Q 1 verdict).
+ *   - Records observed userMessages per turn so the contract harness
+ *     can assert routing.
+ *
+ * History is NOT observable from the client side — lifed accumulates
+ * it server-side. The fake leaves `observedTurns[i].history`
+ * undefined; the harness skips the history assertion for this backend
+ * (see contract.ts Test #4).
+ *
+ * Plan E-2 Task 4.
+ *
+ * @see ./contract.ts
+ * @see ../lifed-ws-client.ts
+ */
+
+// @vitest-environment node
+import { vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// `kernel/types` is type-only on the import path — no runtime stub
+// needed. The client only carries VmHandle through opaque generics.
+
+import type { WebSocketFactory } from "../lifed-ws-client";
+import { LifedWsAgentSessionClient } from "../lifed-ws-client";
+import {
+  type AgentSessionScript,
+  type MakeClient,
+  runAgentSessionClientContract,
+  type SubstrateObservations,
+} from "./contract";
+
+// ---------------------------------------------------------------------------
+// FakeWebSocket — scripted bidi WS used by the LifedWs contract suite.
+// ---------------------------------------------------------------------------
+
+/** Minimal WsLike shape — must match `lifed-ws-client.ts`'s WsLike. */
+interface FakeWsHandlers {
+  open?: () => void;
+  message?: (e: { data: unknown }) => void;
+  error?: (e: { message?: string }) => void;
+  close?: (e: { code: number; reason: string }) => void;
+}
+
+class FakeWebSocket {
+  readyState = 0; // CONNECTING
+  private handlers: FakeWsHandlers = {};
+  private script: AgentSessionScript;
+  private observations: SubstrateObservations;
+  private turnIndex = 0;
+  private seqNo = 0;
+
+  constructor(script: AgentSessionScript, observations: SubstrateObservations) {
+    this.script = script;
+    this.observations = observations;
+    // Fire `open` on the next microtask so the client's
+    // addEventListener has time to register.
+    queueMicrotask(() => {
+      this.readyState = 1; // OPEN
+      this.handlers.open?.();
+    });
+  }
+
+  addEventListener<K extends keyof FakeWsHandlers>(
+    event: K,
+    h: NonNullable<FakeWsHandlers[K]>,
+  ): void {
+    // biome-ignore lint/suspicious/noExplicitAny: handler union
+    (this.handlers as any)[event] = h;
+  }
+
+  send(data: string): void {
+    // Inbound `send_message` frame — start a new turn.
+    let frame: { kind: string; content?: string };
+    try {
+      frame = JSON.parse(data) as typeof frame;
+    } catch {
+      return;
+    }
+    if (frame.kind !== "send_message") return;
+    const userMessage = frame.content ?? "";
+    this.observations.observedTurns.push({
+      userMessage,
+      // History intentionally omitted — see file docstring.
+    });
+
+    const turn = this.script.turns[this.turnIndex];
+    this.turnIndex += 1;
+
+    if (!turn) {
+      // Out-of-script — emit just a FINISH so the stream advances.
+      this.scheduleFinish();
+      return;
+    }
+
+    // Schedule token frames + FINISH on subsequent microtasks so the
+    // client's iterator parks/wakes naturally.
+    queueMicrotask(() => {
+      for (const delta of turn.tokens) {
+        if (this.readyState !== 1) return;
+        this.seqNo += 1;
+        const eventFrame = {
+          kind: "agent_event",
+          seq_no: String(this.seqNo),
+          record: {
+            sequence: this.seqNo,
+            at: new Date().toISOString(),
+            kind: "TOKEN",
+            payload: { text: delta },
+          },
+          agent_kind: "AGENT_EVENT_KIND_TOKEN",
+        };
+        this.handlers.message?.({ data: JSON.stringify(eventFrame) });
+      }
+      this.scheduleFinish();
+    });
+  }
+
+  private scheduleFinish(): void {
+    queueMicrotask(() => {
+      if (this.readyState !== 1) return;
+      this.seqNo += 1;
+      const finishFrame = {
+        kind: "agent_event",
+        seq_no: String(this.seqNo),
+        record: {
+          sequence: this.seqNo,
+          at: new Date().toISOString(),
+          kind: "FINISH",
+          payload: { finish_reason: "stop" },
+        },
+        agent_kind: "AGENT_EVENT_KIND_FINISH",
+      };
+      this.handlers.message?.({ data: JSON.stringify(finishFrame) });
+
+      // Auto-close ONLY when the script is exhausted. Per-turn tests
+      // ship one-turn scripts; multi-turn tests ship 2+. The Open Q 1
+      // verdict says lifed keeps the WS open across many turns, but
+      // when the conversation truly concludes the WS must close so
+      // the iterator can exit. Exhaustion is our model of that.
+      //
+      // Reads readyState after FINISH propagation — if the per-turn
+      // client called cleanup() in its finally, readyState is 3 by
+      // now and we no-op.
+      if (this.turnIndex >= this.script.turns.length) {
+        queueMicrotask(() => {
+          if (this.readyState === 1) {
+            this.close(1000, "script exhausted");
+          }
+        });
+      }
+    });
+  }
+
+  close(code = 1000, reason = ""): void {
+    this.readyState = 3; // CLOSED
+    queueMicrotask(() => {
+      this.handlers.close?.({ code, reason });
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory wiring for the harness.
+// ---------------------------------------------------------------------------
+
+const makeLifedWsClient: MakeClient = (script: AgentSessionScript) => {
+  const observations: SubstrateObservations = { observedTurns: [] };
+  const webSocketFactory: WebSocketFactory = () =>
+    new FakeWebSocket(
+      script,
+      observations,
+    ) as unknown as ReturnType<WebSocketFactory>;
+  const client = new LifedWsAgentSessionClient({
+    baseUrl: "https://fake.lifegw.test",
+    webSocketFactory,
+    fetchFn: (async () => new Response("OK")) as typeof fetch,
+  });
+  return { client, observations };
+};
+
+runAgentSessionClientContract("LifedWsAgentSessionClient", makeLifedWsClient);

--- a/apps/broomva/lib/life-runtime/agent-session/event-translators.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/event-translators.test.ts
@@ -197,10 +197,15 @@ describe("event-translators — llmPartToCanonical", () => {
     });
     expect(out).toHaveLength(1);
     const ev = out[0]!;
-    if (ev.kind !== "tool_call_pending") throw new Error("expected tool_call_pending");
+    if (ev.kind !== "tool_call_pending")
+      throw new Error("expected tool_call_pending");
     expect(ev.call.callId).toBe("call-1");
     expect(ev.call.toolName).toBe("note");
-    expect(JSON.parse(ev.call.inputJson)).toEqual({ slug: "x", title: "T", body: "B" });
+    expect(JSON.parse(ev.call.inputJson)).toEqual({
+      slug: "x",
+      title: "T",
+      body: "B",
+    });
   });
 
   it("translates tool-result into tool_result", () => {

--- a/apps/broomva/lib/life-runtime/agent-session/factory.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/factory.test.ts
@@ -47,13 +47,16 @@ vi.mock("./in-process-client", () => {
     async *stream() {
       // No-op generator. Tests don't iterate.
     }
+    async sendMessage(_sid: string, _content: string): Promise<void> {
+      // No-op stub — factory tests don't exercise sendMessage.
+    }
   }
   return { InProcessAgentSessionClient };
 });
 
 import {
-  createAgentSessionClient,
   type CreateAgentSessionClientOverrides,
+  createAgentSessionClient,
 } from "./factory";
 
 // Cache the env we may stomp; restore in afterEach.

--- a/apps/broomva/lib/life-runtime/agent-session/factory.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/factory.ts
@@ -17,7 +17,6 @@
 
 import "server-only";
 import { resolveProjectBySlug } from "../db-seed";
-import { type AgentSessionClient } from "./types";
 import {
   InProcessAgentSessionClient,
   type InProcessAgentSessionClientDeps,
@@ -26,6 +25,7 @@ import {
   LifedWsAgentSessionClient,
   type LifedWsAgentSessionClientDeps,
 } from "./lifed-ws-client";
+import { type AgentSessionClient } from "./types";
 
 /**
  * Inputs that override the default factory behavior. Intended only
@@ -78,10 +78,7 @@ export function createAgentSessionClient(
     }
     const deps: LifedWsAgentSessionClientDeps = {
       baseUrl: lifedUrl,
-      healthTimeoutMs: parseTimeout(
-        process.env.LIFED_HEALTH_TIMEOUT_MS,
-        2_000,
-      ),
+      healthTimeoutMs: parseTimeout(process.env.LIFED_HEALTH_TIMEOUT_MS, 2_000),
       ...overrides.lifedWsDeps,
     };
     return new LifedWsAgentSessionClient(deps);

--- a/apps/broomva/lib/life-runtime/agent-session/in-process-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/in-process-client.ts
@@ -24,27 +24,28 @@ import { createKernelClient } from "../kernel/factory";
 import { type ToolHandler } from "../kernel/in-process-client";
 import type { VmHandle } from "../kernel/types";
 import {
-  makeLifeToolHandlers,
-  RealAgentRunner,
-  type RealRunnerOptions,
-} from "../real-runner";
-import {
   getProjectConfig,
   isProjectSlug,
   type ProjectConfig,
   type ProjectSlug,
 } from "../projects";
+import {
+  makeLifeToolHandlers,
+  RealAgentRunner,
+  type RealRunnerOptions,
+} from "../real-runner";
 import type { ModuleTypeId } from "../types";
 import {
   domainEventToCanonical,
   llmPartToCanonical,
 } from "./event-translators";
-import type {
-  AgentEvent,
-  AgentSessionClient,
-  AgentSessionHealth,
-  AgentStreamInput,
-  CanonicalAgentEvent,
+import {
+  type AgentEvent,
+  type AgentSessionClient,
+  type AgentSessionHealth,
+  AgentSessionUnknownSidError,
+  type AgentStreamInput,
+  type CanonicalAgentEvent,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -78,8 +79,7 @@ export interface InProcessAgentSessionClientDeps {
 
 const DEFAULT_KERNEL_FACTORY = (deps: {
   tools: Record<string, ToolHandler>;
-}): KernelClient =>
-  createKernelClient({ tools: deps.tools });
+}): KernelClient => createKernelClient({ tools: deps.tools });
 
 /**
  * In-process `AgentSessionClient` — runs `RealAgentRunner` and emits
@@ -106,9 +106,17 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
     };
   }
 
-  async *stream(
-    input: AgentStreamInput,
-  ): AsyncIterable<CanonicalAgentEvent> {
+  /**
+   * Multi-turn message ingestion. Implementation lands in Task 2 of
+   * Plan E-2. Until then, calling this on an active session throws —
+   * the per-turn path doesn't register a queue and there's no
+   * multi-turn state to push into.
+   */
+  async sendMessage(sessionId: string, _content: string): Promise<void> {
+    throw new AgentSessionUnknownSidError(sessionId);
+  }
+
+  async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
     if (!isProjectSlug(input.projectSlug)) {
       yield this.canonical(0n, {
         kind: "error",
@@ -142,7 +150,8 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
       ));
 
     let seq = 0n;
-    const emit = (e: AgentEvent): CanonicalAgentEvent => this.canonical(seq++, e);
+    const emit = (e: AgentEvent): CanonicalAgentEvent =>
+      this.canonical(seq++, e);
 
     yield emit({ kind: "open", sessionId: input.sessionId, vmHandle: vm });
 

--- a/apps/broomva/lib/life-runtime/agent-session/in-process-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/in-process-client.ts
@@ -58,6 +58,31 @@ import {
 // vitest without dragging the AI SDK + DB env validation chain.)
 
 // ---------------------------------------------------------------------------
+// Multi-turn queue plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * Sentinel resolved into the queue when the multi-turn loop must exit
+ * (abort signal fires, fatal error, generator dropped). The queue
+ * resolver receives either a string (the next user message) or this
+ * symbol.
+ */
+const QUEUE_CLOSED = Symbol("QUEUE_CLOSED");
+
+/**
+ * One parked waiter awaiting the next user message. Mirrors the
+ * `session-runtime.ts` waiter pattern — see Plan D's replay buffer.
+ *
+ * The `resolve` function fires exactly once. When the producer
+ * (`sendMessage`) lands a message before any consumer parks, the
+ * message is appended as a `pending` entry instead; the next
+ * `nextFromQueue` call drains it immediately.
+ */
+type TurnQueueEntry =
+  | { kind: "waiter"; resolve: (v: string | typeof QUEUE_CLOSED) => void }
+  | { kind: "pending"; content: string };
+
+// ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
 
@@ -91,6 +116,23 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
   private readonly kernelClientFactory: NonNullable<
     InProcessAgentSessionClientDeps["kernelClientFactory"]
   >;
+  /**
+   * Per-sid multi-turn queue. Populated when `stream(input)` is called
+   * with `input.multiTurn === true`; removed when that stream exits.
+   *
+   * Entry semantics:
+   *   - On `sendMessage(sid, content)`: if the head entry is a `waiter`,
+   *     shift + resolve it. Otherwise push a `pending` entry.
+   *   - On `nextFromQueue(sid)`: if the head entry is `pending`, shift +
+   *     return its content. Otherwise push a `waiter` and await.
+   *
+   * This single-array design avoids two separate "waiters" + "pending"
+   * arrays staying in lockstep. Only one shape is ever in the array at
+   * a time — `waiter` while no producer has landed; `pending` while no
+   * consumer is parked. The contract guarantees a producer-or-consumer
+   * race resolves correctly without dropping messages.
+   */
+  private readonly turnQueues = new Map<string, TurnQueueEntry[]>();
 
   constructor(deps: InProcessAgentSessionClientDeps) {
     this.resolveProject = deps.resolveProject;
@@ -107,13 +149,25 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
   }
 
   /**
-   * Multi-turn message ingestion. Implementation lands in Task 2 of
-   * Plan E-2. Until then, calling this on an active session throws —
-   * the per-turn path doesn't register a queue and there's no
-   * multi-turn state to push into.
+   * Push a new user message into an active multi-turn stream. Resolves
+   * once the message is queued (not once the turn completes).
+   *
+   * Throws `AgentSessionUnknownSidError` when no multi-turn stream is
+   * registered for the given `sessionId` — either the stream never
+   * opened in multi-turn mode (per-turn streams don't register a
+   * queue), or it already terminated and cleaned up.
    */
-  async sendMessage(sessionId: string, _content: string): Promise<void> {
-    throw new AgentSessionUnknownSidError(sessionId);
+  async sendMessage(sessionId: string, content: string): Promise<void> {
+    const entries = this.turnQueues.get(sessionId);
+    if (!entries) throw new AgentSessionUnknownSidError(sessionId);
+    const head = entries[0];
+    if (head && head.kind === "waiter") {
+      entries.shift();
+      head.resolve(content);
+      return;
+    }
+    // No consumer parked — buffer for the next `nextFromQueue` call.
+    entries.push({ kind: "pending", content });
   }
 
   async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
@@ -154,6 +208,17 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
       this.canonical(seq++, e);
 
     yield emit({ kind: "open", sessionId: input.sessionId, vmHandle: vm });
+
+    // Branch on multi-turn opt-in. The per-turn path stays bit-for-bit
+    // identical to today (E-2 invariant: zero behavior change for
+    // canonical.ts:254). The multi-turn path replaces the single
+    // runner.run() with an outer queue-pumping loop.
+    if (input.multiTurn === true) {
+      yield* this.streamMultiTurn(input, project, cfg, kernelClient, vm, {
+        emitNext: emit,
+      });
+      return;
+    }
 
     const runnerOpts: RealRunnerOptions = {
       project,
@@ -245,6 +310,279 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
         // swallow — destroy must not break the stream
       }
     }
+  }
+
+  /**
+   * Multi-turn body. Splits out from `stream()` so the per-turn path
+   * stays a flat read-from-top branch.
+   *
+   * Loop shape:
+   *   1. Register a queue for this sid so `sendMessage` can land
+   *      messages.
+   *   2. Outer loop:
+   *      - First iteration: use `input.userMessage` directly.
+   *      - Subsequent: park on the queue until the next message arrives
+   *        (or the signal aborts).
+   *      - Run one `RealAgentRunner` per turn against the accumulated
+   *        history; yield events through the existing translation.
+   *      - Append `{ role: "user", content: userMessage }` and the
+   *        assistant text (gathered from token events) to history.
+   *      - DO NOT emit `finish` between turns — only emit one terminal
+   *        `finish` when the loop exits.
+   *   3. Finally: emit exactly one terminal `finish`, drain any parked
+   *      waiters, destroy VM.
+   */
+  private async *streamMultiTurn(
+    input: AgentStreamInput,
+    project: LifeProject,
+    cfg: ProjectConfig,
+    kernelClient: KernelClient,
+    vm: VmHandle,
+    plumb: { emitNext: (e: AgentEvent) => CanonicalAgentEvent },
+  ): AsyncIterable<CanonicalAgentEvent> {
+    const { emitNext } = plumb;
+    const sid = input.sessionId;
+    this.turnQueues.set(sid, []);
+
+    // Per-iteration accumulated history. Starts as a copy of the
+    // caller-provided rehydrated history; each turn appends one
+    // {user, assistant} pair.
+    const history: Array<{ role: "user" | "assistant"; content: string }> =
+      input.history.map((h) => ({ role: h.role, content: h.content }));
+
+    let userMessage = input.userMessage;
+    let firstTurn = true;
+    let exitReason: "stop" | "aborted" | "error" = "stop";
+    let exitError: { code: string; message: string } | null = null;
+
+    try {
+      // Outer loop — one iteration per user turn.
+      while (true) {
+        if (input.signal?.aborted) {
+          exitReason = "aborted";
+          break;
+        }
+
+        if (!firstTurn) {
+          // Park until the next user message lands, or the signal
+          // aborts. Returns QUEUE_CLOSED if the abort/finalisation
+          // fired first.
+          const next = await this.nextFromQueue(sid, input.signal);
+          if (next === QUEUE_CLOSED) {
+            // Either the signal aborted or the iterator was dropped;
+            // either way, exit cleanly.
+            exitReason = input.signal?.aborted ? "aborted" : "stop";
+            break;
+          }
+          userMessage = next;
+        }
+        firstTurn = false;
+
+        const runnerOpts: RealRunnerOptions = {
+          project,
+          moduleTypeId: cfg.moduleTypeId as ModuleTypeId,
+          projectSlug: cfg.slug,
+          input: userMessage,
+          maxCostCents: maxCostCentsFor(cfg),
+          onFinish: undefined,
+          // Pass the accumulated history; each turn sees prior turns'
+          // assistant outputs as context.
+          history,
+          userMessage,
+          paymentMode: paymentModeFor(cfg),
+          kernelClient,
+          vm,
+          kernelCtx: input.kernelCtx,
+          turnId: `inproc-mt-${sid}-${Date.now().toString(36)}`,
+          lifeSessionId: sid,
+        };
+
+        const runner = new RealAgentRunner(runnerOpts);
+
+        // Per-turn thinking pair state — resets each turn so a stale
+        // reasoning streak from turn N doesn't bleed into turn N+1.
+        let inReasoning = false;
+        const reasoningStartedAt = { ms: 0 };
+
+        // Capture assistant text from token events so we can append it
+        // to `history` for the next turn's runner.
+        let assistantText = "";
+
+        // The runner emits exactly one `finish` event per call (via
+        // its `done` DomainEvent). In multi-turn mode we swallow that
+        // per-turn finish so the iterable stays alive — the consumer
+        // only sees a terminal `finish` when the OUTER loop exits.
+        let perTurnFinishSeen = false;
+
+        try {
+          for await (const y of runner.run()) {
+            if (input.signal?.aborted) {
+              exitReason = "aborted";
+              break;
+            }
+
+            if (y.kind === "llm") {
+              const events = llmPartToCanonical(y.part);
+              for (const ev of events) {
+                if (ev.kind === "thinking_start") {
+                  if (!inReasoning) {
+                    inReasoning = true;
+                    reasoningStartedAt.ms = Date.now();
+                    yield emitNext(ev);
+                  }
+                  continue;
+                }
+                if (inReasoning) {
+                  inReasoning = false;
+                  yield emitNext({
+                    kind: "thinking_end",
+                    ms: Date.now() - reasoningStartedAt.ms,
+                  });
+                }
+                if (ev.kind === "token") {
+                  assistantText += ev.delta;
+                }
+                yield emitNext(ev);
+              }
+            } else if (y.kind === "domain") {
+              if (inReasoning) {
+                inReasoning = false;
+                yield emitNext({
+                  kind: "thinking_end",
+                  ms: Date.now() - reasoningStartedAt.ms,
+                });
+              }
+              for (const ev of domainEventToCanonical(y.event)) {
+                if (ev.kind === "finish") {
+                  perTurnFinishSeen = true;
+                  // Swallow — terminal finish lives in the outer
+                  // `finally`. The per-turn finish from the runner
+                  // marks a turn boundary; we don't surface it to
+                  // the consumer in multi-turn mode (the contract is
+                  // "exactly one terminal finish per stream()").
+                  continue;
+                }
+                if (ev.kind === "error") {
+                  // A turn-level error promotes to a stream-level
+                  // error. Capture it for the terminal finish.
+                  exitReason = "error";
+                  exitError = { code: ev.code, message: ev.message };
+                  yield emitNext(ev);
+                  continue;
+                }
+                yield emitNext(ev);
+              }
+            }
+          }
+        } catch (err) {
+          // Runner threw — surface as a stream-level error and exit
+          // the outer loop.
+          const e = err as Error;
+          exitReason = "error";
+          exitError = {
+            code: "in-process.runner_failed",
+            message: e.message ?? "runner threw",
+          };
+          yield emitNext({
+            kind: "error",
+            code: exitError.code,
+            message: exitError.message,
+          });
+        }
+
+        // Append this turn to history for the next iteration's runner.
+        history.push({ role: "user", content: userMessage });
+        if (assistantText.length > 0) {
+          history.push({ role: "assistant", content: assistantText });
+        }
+
+        // Belt-and-suspenders: if the runner didn't emit a per-turn
+        // finish, log a warning so operators see the anomaly. Doesn't
+        // affect correctness.
+        if (!perTurnFinishSeen && exitReason === "stop") {
+          // No-op for now — the multi-turn contract doesn't require
+          // a per-turn finish; we just expect one for parity with the
+          // single-turn path. Future telemetry could surface this.
+        }
+
+        if (exitReason === "error" || exitReason === "aborted") {
+          break;
+        }
+        // Loop and wait for the next message.
+      }
+    } finally {
+      // Drain any parked waiters so they don't hang forever.
+      const parked = this.turnQueues.get(sid);
+      this.turnQueues.delete(sid);
+      if (parked) {
+        for (const entry of parked) {
+          if (entry.kind === "waiter") {
+            entry.resolve(QUEUE_CLOSED);
+          }
+        }
+      }
+      // Emit exactly one terminal finish.
+      yield emitNext({
+        kind: "finish",
+        reason:
+          exitReason === "error"
+            ? (exitError?.code ?? "error")
+            : exitReason === "aborted"
+              ? "aborted"
+              : "stop",
+      });
+      try {
+        await kernelClient.destroy(vm);
+      } catch {
+        // swallow — destroy must not break the stream
+      }
+    }
+  }
+
+  /**
+   * Park until the next user message arrives, or the abort signal
+   * fires (whichever comes first). Returns the message content on
+   * success, or `QUEUE_CLOSED` on abort / iterator-dropped.
+   *
+   * Drains any pre-queued `pending` entry immediately — `sendMessage`
+   * appends `pending` when no consumer is parked.
+   */
+  private nextFromQueue(
+    sid: string,
+    signal?: AbortSignal,
+  ): Promise<string | typeof QUEUE_CLOSED> {
+    const entries = this.turnQueues.get(sid);
+    if (!entries) return Promise.resolve(QUEUE_CLOSED);
+    const head = entries[0];
+    if (head && head.kind === "pending") {
+      entries.shift();
+      return Promise.resolve(head.content);
+    }
+    return new Promise<string | typeof QUEUE_CLOSED>((resolve) => {
+      if (signal?.aborted) {
+        resolve(QUEUE_CLOSED);
+        return;
+      }
+      const onAbort = () => {
+        // Remove the waiter from the queue (if still queued) and
+        // resolve as closed.
+        const list = this.turnQueues.get(sid);
+        if (list) {
+          const idx = list.indexOf(waiter);
+          if (idx >= 0) list.splice(idx, 1);
+        }
+        resolve(QUEUE_CLOSED);
+      };
+      const waiter: TurnQueueEntry = {
+        kind: "waiter",
+        resolve: (v) => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve(v);
+        },
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      entries.push(waiter);
+    });
   }
 
   private canonical(seq: bigint, event: AgentEvent): CanonicalAgentEvent {

--- a/apps/broomva/lib/life-runtime/agent-session/in-process-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/in-process-client.ts
@@ -496,18 +496,24 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
           history.push({ role: "assistant", content: assistantText });
         }
 
-        // Belt-and-suspenders: if the runner didn't emit a per-turn
-        // finish, log a warning so operators see the anomaly. Doesn't
-        // affect correctness.
-        if (!perTurnFinishSeen && exitReason === "stop") {
-          // No-op for now — the multi-turn contract doesn't require
-          // a per-turn finish; we just expect one for parity with the
-          // single-turn path. Future telemetry could surface this.
-        }
-
         if (exitReason === "error" || exitReason === "aborted") {
           break;
         }
+
+        // The turn completed cleanly — emit a `turn_end` event so the
+        // consumer (typically the SSE handler) sees an explicit turn
+        // boundary. The iterator stays alive; the next iteration parks
+        // on `nextFromQueue` waiting for the next user message.
+        //
+        // Reference: contract `stream()` docstring — "may yield
+        // `turn_end` events between turns; `finish` remains
+        // terminal-and-last." Matches the lifed-ws backend, which
+        // translates per-turn AGENT_EVENT_KIND_FINISH into `turn_end`.
+        yield emitNext({ kind: "turn_end" });
+        // (perTurnFinishSeen retained as a debug signal — under normal
+        // operation it should always be true here.)
+        void perTurnFinishSeen;
+
         // Loop and wait for the next message.
       }
     } finally {
@@ -520,6 +526,18 @@ export class InProcessAgentSessionClient implements AgentSessionClient {
             entry.resolve(QUEUE_CLOSED);
           }
         }
+      }
+      // Abort-warning parity with the per-turn path AND the lifed-ws
+      // multi-turn path — both emit a `warning` with code `<backend>
+      // .aborted` so consumers can distinguish "abort came from the
+      // client" from "transport closed unexpectedly". Without this,
+      // multi-turn InProcess silently dropped the abort signal.
+      if (exitReason === "aborted") {
+        yield emitNext({
+          kind: "warning",
+          code: "in-process.aborted",
+          message: "stream aborted by client",
+        });
       }
       // Emit exactly one terminal finish.
       yield emitNext({

--- a/apps/broomva/lib/life-runtime/agent-session/index.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/index.ts
@@ -13,8 +13,8 @@
  */
 
 export {
-  createAgentSessionClient,
   type CreateAgentSessionClientOverrides,
+  createAgentSessionClient,
 } from "./factory";
 export {
   InProcessAgentSessionClient,
@@ -25,12 +25,13 @@ export {
   type LifedWsAgentSessionClientDeps,
   type WebSocketFactory,
 } from "./lifed-ws-client";
-export type {
-  AgentEvent,
-  AgentSessionBackendId,
-  AgentSessionClient,
-  AgentSessionHealth,
-  AgentStreamInput,
-  CanonicalAgentEvent,
-  TierUserCap,
+export {
+  type AgentEvent,
+  type AgentSessionBackendId,
+  type AgentSessionClient,
+  type AgentSessionHealth,
+  AgentSessionUnknownSidError,
+  type AgentStreamInput,
+  type CanonicalAgentEvent,
+  type TierUserCap,
 } from "./types";

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.test.ts
@@ -8,11 +8,10 @@
 //
 // File under test: ./lifed-ws-client.ts
 
-import { describe, expect, it } from "vitest";
-
 // `lifed-ws-client.ts` begins with `import "server-only"`; stub the
 // module so it loads in node-side test environments.
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
 vi.mock("server-only", () => ({}));
 
 import { _internals } from "./lifed-ws-client";
@@ -268,9 +267,7 @@ describe("decodeAgentEvent — UNKNOWN", () => {
     });
     // The session id should be threaded into the warning message so
     // operators can correlate.
-    expect((decoded as { message: string }).message).toContain(
-      "sess-test",
-    );
+    expect((decoded as { message: string }).message).toContain("sess-test");
   });
 });
 
@@ -330,9 +327,7 @@ describe("createSession (Stage 3a)", () => {
     expect(out.createdAtUnix).toBe(1_777_900_000);
 
     // Wire-shape assertions.
-    expect(captured.url).toBe(
-      "https://lifegw.test/v1/agent/create_session",
-    );
+    expect(captured.url).toBe("https://lifegw.test/v1/agent/create_session");
     expect(captured.init?.method).toBe("POST");
     const headers = captured.init?.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer tok_xyz");
@@ -350,10 +345,9 @@ describe("createSession (Stage 3a)", () => {
     const captured: { body?: string } = {};
     const stubFetch: typeof fetch = async (_url, init) => {
       captured.body = init?.body as string;
-      return new Response(
-        JSON.stringify({ sid: "x", agent_id: "y" }),
-        { status: 200 },
-      );
+      return new Response(JSON.stringify({ sid: "x", agent_id: "y" }), {
+        status: 200,
+      });
     };
     const client = new Cls({
       baseUrl: "https://lifegw.test",

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -467,6 +467,7 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
     let lastSeq = 0n;
     let openErrCode: string | null = null;
     let openErrMsg: string | null = null;
+    let finishYielded = false;
 
     const cleanup = () => {
       try {
@@ -562,12 +563,14 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
             // defensive
           }
           const decoded = decodeAgentEvent(frame, input);
-          if (decoded)
+          if (decoded) {
+            if (decoded.kind === "finish") finishYielded = true;
             yield {
               seq,
               at: frame.record.at ?? new Date().toISOString(),
               event: decoded,
             };
+          }
         } else if (frame.kind === "closing") {
           // server is about to close the stream (Spec C₃ §6.5). Don't
           // yield this — the close event will produce the finish.
@@ -587,7 +590,7 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
           kind: "finish",
           reason: "error",
         });
-      } else {
+      } else if (!finishYielded) {
         // Normal close — if the server didn't send a FINISH event,
         // synthesize one so consumers don't hang.
         // (Idiomatic lifed always sends FINISH; this is belt-and-suspenders.)

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -197,14 +197,21 @@ export interface LifedWsAgentSessionClientDeps {
  * `multiTurn === true` path; never used by the per-turn path.
  *
  * `pending` carries messages that arrive via `sendMessage` before
- * the WS reaches OPEN state — they're drained when `open` fires.
- * The initial `input.userMessage` lives in `pending` for the same
- * reason: at construction time the WS isn't open yet.
+ * the WS reaches OPEN state OR while a turn is already in flight —
+ * they're drained one-at-a-time at turn boundaries. The initial
+ * `input.userMessage` lives in `pending` until `open` fires.
+ *
+ * `currentTurnInFlight` is the turn-boundary gate: once
+ * `sendMessage` writes a frame onto an open socket, this flips to
+ * `true` and stays `true` until the next `turn_end` event lands. The
+ * gate ensures strict FIFO turn ordering — no pipelining, no two
+ * `send_message` frames written before the first one's FINISH lands.
  */
 interface LiveWsEntry {
   ws: WsLike;
   pending: string[];
   isOpen: boolean;
+  currentTurnInFlight: boolean;
 }
 
 export class LifedWsAgentSessionClient implements AgentSessionClient {
@@ -355,19 +362,46 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
    * Throws `AgentSessionUnknownSidError` when no multi-turn WS is
    * registered for the given `sessionId` — either the session never
    * opened in multi-turn mode (per-turn streams don't register an
-   * entry), or it already terminated and cleaned up.
+   * entry), or it already terminated and cleaned up. Also throws if
+   * the socket has already advanced to CLOSING/CLOSED but cleanup
+   * hasn't deleted the entry yet (race window between server-side
+   * close and the close handler firing) — without this, the bare
+   * `ws.send` below would raise a raw transport error and the SSE
+   * handler would surface a 500 instead of a typed envelope.
    *
-   * Buffers messages that arrive before the WS reaches OPEN state;
-   * the `open` event handler drains the buffer in arrival order.
+   * Buffers messages that arrive before the WS reaches OPEN state
+   * AND messages that arrive while a turn is already in flight; the
+   * `open` event handler and the `turn_end` translation site drain
+   * the buffer one-at-a-time so turns serialize strictly FIFO.
    */
   async sendMessage(sessionId: string, content: string): Promise<void> {
     const entry = this.liveStreams.get(sessionId);
     if (!entry) throw new AgentSessionUnknownSidError(sessionId);
-    if (entry.isOpen) {
-      const frame: InboundFrame = { kind: "send_message", content };
-      entry.ws.send(JSON.stringify(frame));
+    // Catch the "WS closed but cleanup hasn't deleted the entry yet"
+    // race. WebSocket.readyState 1 === OPEN per the WHATWG spec; 0
+    // is CONNECTING, 2 is CLOSING, 3 is CLOSED. We only write when
+    // OPEN; CONNECTING falls through to the buffered-pending path.
+    if (
+      entry.ws.readyState !== /* OPEN */ 1 &&
+      entry.ws.readyState !== /* CONNECTING */ 0
+    ) {
+      throw new AgentSessionUnknownSidError(sessionId);
+    }
+    if (!entry.isOpen) {
+      // Not yet opened — buffer until the `open` handler drains.
+      entry.pending.push(content);
       return;
     }
+    if (!entry.currentTurnInFlight) {
+      // Free to send immediately. Take the turn-in-flight gate so
+      // subsequent calls are forced through the pending buffer.
+      const frame: InboundFrame = { kind: "send_message", content };
+      entry.ws.send(JSON.stringify(frame));
+      entry.currentTurnInFlight = true;
+      return;
+    }
+    // A turn is already running — buffer; the turn_end translation
+    // site drains one entry on each turn boundary.
     entry.pending.push(content);
   }
 
@@ -580,43 +614,60 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
       }
     } finally {
       cleanup();
-      if (openErrCode || openErrMsg) {
-        yield this.canonical(++lastSeq, {
-          kind: "error",
-          code: openErrCode ?? "lifed-ws.error",
-          message: openErrMsg ?? "lifed-ws stream errored",
-        });
-        yield this.canonical(++lastSeq, {
-          kind: "finish",
-          reason: "error",
-        });
-      } else if (!finishYielded) {
-        // Normal close — if the server didn't send a FINISH event,
-        // synthesize one so consumers don't hang.
-        // (Idiomatic lifed always sends FINISH; this is belt-and-suspenders.)
-        yield this.canonical(++lastSeq, {
-          kind: "finish",
-          reason: "stop",
-        });
+      // Strict terminal-finish-once invariant: if the server already
+      // sent a FINISH frame (`finishYielded === true`) the iterator
+      // already yielded its one terminal `finish`. Subsequent close
+      // events — whether normal (1000), transient (1011/1001/4002/
+      // 4004), or terminal (1008/4003/4005) — MUST NOT double-emit
+      // a second `finish` or a paired `error` + `finish`. The contract
+      // `stream()` docstring is unambiguous: "exactly one `finish` as
+      // the terminal-and-last event."
+      if (!finishYielded) {
+        if (openErrCode || openErrMsg) {
+          yield this.canonical(++lastSeq, {
+            kind: "error",
+            code: openErrCode ?? "lifed-ws.error",
+            message: openErrMsg ?? "lifed-ws stream errored",
+          });
+          yield this.canonical(++lastSeq, {
+            kind: "finish",
+            reason: "error",
+          });
+        } else {
+          // Normal close — server didn't send FINISH; synthesize one
+          // so consumers don't hang. (Idiomatic lifed always sends
+          // FINISH; this is belt-and-suspenders.)
+          yield this.canonical(++lastSeq, {
+            kind: "finish",
+            reason: "stop",
+          });
+        }
       }
     }
   }
 
   /**
    * Multi-turn WS body. Opens a single WS that stays alive across many
-   * `send_message` frames; per-turn FINISH events are forwarded to the
-   * consumer as turn boundaries (so the SSE handler can persist the
-   * turn and reset its per-turn state) but the iterator stays alive.
+   * `send_message` frames; per-turn FINISH events are translated into
+   * `turn_end` events (the canonical turn-boundary marker — see
+   * `decodeAgentEvent`) so the iterator can keep yielding without ever
+   * emitting `finish` between turns. The terminal `finish` lands once,
+   * in the outer `finally`, when the WS truly closes.
    *
    * Differences from the per-turn path:
    *   1. The initial `input.userMessage` is registered in
    *      `liveStreams.pending` *before* the WS opens, not sent inline
    *      in the `open` handler. This unifies the inbound write path
-   *      with `sendMessage()`.
+   *      with `sendMessage()` and lets the turn-in-flight gate cover
+   *      the first send.
    *   2. The frame-pump loop forwards `AGENT_EVENT_KIND_FINISH` events
-   *      to the consumer (turn boundary) but does NOT break the loop;
-   *      it only breaks on close / unrecoverable error / abort.
-   *   3. The terminal `finish` is emitted once at iterator end (clean
+   *      to the consumer as `turn_end` (turn boundary) and does NOT
+   *      break the loop; it only breaks on close / unrecoverable
+   *      error / abort.
+   *   3. After each `turn_end` lands, the `currentTurnInFlight` gate
+   *      releases and one pending message (if any) is sent — strict
+   *      FIFO turn ordering, no pipelining.
+   *   4. The terminal `finish` is emitted once at iterator end (clean
    *      close → "stop", abort → "aborted", error → error code).
    *
    * Per Open Q 1 verdict (2026-05-15, confirmed via Rust source
@@ -655,10 +706,14 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
 
     // Register live-streams entry before any await so `sendMessage`
     // can target this sid immediately if the SSE handler races ahead.
+    // The initial user message lives in `pending` until the WS reaches
+    // OPEN — the `open` handler drains exactly one entry and flips
+    // the turn-in-flight gate, mirroring the `sendMessage` write path.
     const entry: LiveWsEntry = {
       ws,
       pending: [input.userMessage],
       isOpen: false,
+      currentTurnInFlight: false,
     };
     this.liveStreams.set(sid, entry);
 
@@ -695,20 +750,21 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
 
     ws.addEventListener("open", () => {
       entry.isOpen = true;
-      // Drain pending in arrival order. Any messages that landed via
-      // `sendMessage` before the WS opened are sent now.
-      const pending = entry.pending;
-      entry.pending = [];
-      for (const content of pending) {
-        const frame: InboundFrame = { kind: "send_message", content };
-        try {
-          ws.send(JSON.stringify(frame));
-        } catch (err) {
-          openErrCode ??= "lifed-ws.send_failed";
-          openErrMsg ??= `failed to send open frame: ${(err as Error).message}`;
-          cleanup();
-          return;
-        }
+      // Drain EXACTLY ONE pending entry — the first user message of the
+      // conversation. The turn-boundary gate (`currentTurnInFlight`)
+      // ensures we don't pipeline subsequent messages into lifed before
+      // the first turn's FINISH lands; any messages buffered while
+      // CONNECTING stay queued until the next `turn_end` drains them.
+      if (entry.pending.length === 0) return;
+      const content = entry.pending.shift()!;
+      const frame: InboundFrame = { kind: "send_message", content };
+      try {
+        ws.send(JSON.stringify(frame));
+        entry.currentTurnInFlight = true;
+      } catch (err) {
+        openErrCode ??= "lifed-ws.send_failed";
+        openErrMsg ??= `failed to send open frame: ${(err as Error).message}`;
+        cleanup();
       }
     });
 
@@ -798,10 +854,35 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
               at: frame.record.at ?? new Date().toISOString(),
               event: decoded,
             };
-            // Per-turn FINISH is a turn boundary in multi-turn mode —
-            // we yield it (so the consumer can persist the turn) but
-            // keep the iterator alive. The terminal finish lives in
-            // the outer `finally`.
+            // Turn-boundary handling: when the decoder translated a
+            // per-turn FINISH into `turn_end` (multi-turn mode only),
+            // release the turn-in-flight gate and drain ONE more
+            // pending message so turns serialize strictly FIFO. Doing
+            // this AFTER the yield guarantees the consumer observes
+            // `turn_end` before the next turn's tokens land.
+            if (decoded.kind === "turn_end") {
+              entry.currentTurnInFlight = false;
+              if (
+                entry.pending.length > 0 &&
+                entry.ws.readyState === /* OPEN */ 1
+              ) {
+                const next = entry.pending.shift()!;
+                const sendFrame: InboundFrame = {
+                  kind: "send_message",
+                  content: next,
+                };
+                try {
+                  entry.ws.send(JSON.stringify(sendFrame));
+                  entry.currentTurnInFlight = true;
+                } catch (err) {
+                  openErrCode ??= "lifed-ws.send_failed";
+                  openErrMsg ??= `failed to send next turn frame: ${
+                    (err as Error).message
+                  }`;
+                  cleanup();
+                }
+              }
+            }
           }
         } else if (frame.kind === "closing") {
           // server is about to close the stream (Spec C₃ §6.5).
@@ -883,6 +964,13 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
  * JSON per Spec C₃ §6.2 sub-phase A); we extract the typed fields we
  * care about and fall through to `warning` on unknown kinds so the UI
  * keeps streaming.
+ *
+ * In multi-turn mode (`ctx.multiTurn === true`), per-turn
+ * `AGENT_EVENT_KIND_FINISH` frames translate into `turn_end` events
+ * — the contract reserves `finish` for the terminal-and-last event,
+ * which the multi-turn stream emits exactly once at iterator exit.
+ * The per-turn path keeps the historical mapping (FINISH → `finish`)
+ * so callers see a single terminal event.
  */
 function decodeAgentEvent(
   frame: Extract<OutboundFrame, { kind: "agent_event" }>,
@@ -933,6 +1021,13 @@ function decodeAgentEvent(
       };
     }
     case "AGENT_EVENT_KIND_FINISH": {
+      // Multi-turn mode: per-turn FINISH is a TURN BOUNDARY, not the
+      // terminal event. Translate to `turn_end` so the stream-loop
+      // can keep the iterator alive and surface the terminal `finish`
+      // exactly once in its `finally` block.
+      if (ctx.multiTurn === true) {
+        return { kind: "turn_end" };
+      }
       const usage = payload.usage as
         | {
             input_tokens?: number;

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -192,6 +192,21 @@ export interface LifedWsAgentSessionClientDeps {
  * Lifed WebSocket-streaming agent session client. Active when
  * `LIFED_GATEWAY_URL` is set in the environment.
  */
+/**
+ * One live multi-turn WS, tracked per sid. Populated on the
+ * `multiTurn === true` path; never used by the per-turn path.
+ *
+ * `pending` carries messages that arrive via `sendMessage` before
+ * the WS reaches OPEN state — they're drained when `open` fires.
+ * The initial `input.userMessage` lives in `pending` for the same
+ * reason: at construction time the WS isn't open yet.
+ */
+interface LiveWsEntry {
+  ws: WsLike;
+  pending: string[];
+  isOpen: boolean;
+}
+
 export class LifedWsAgentSessionClient implements AgentSessionClient {
   readonly backendId = "lifed-ws" as const;
   private readonly baseUrl: string;
@@ -199,6 +214,22 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
   private readonly healthTimeoutMs: number;
   private readonly healthTokenProducer?: () => Promise<string | undefined>;
   private readonly fetchFn: typeof fetch;
+  /**
+   * Per-sid live WS state. Only populated for the multi-turn path
+   * (per-turn streams use a single locally-scoped WS that's
+   * constructed-then-discarded inside `stream()`).
+   *
+   * Cross-turn lifecycle: lifegw + lifed keep the WS open across many
+   * `send_message` frames (Open Q 1 verdict, confirmed via Rust source
+   * inspection 2026-05-15: `lifed::services::agent::stream_session`
+   * attaches a passive fanout subscriber; `lifegw::services::ws`
+   * drives `drive_upstream_tail` which only exits on Err(status)). A
+   * per-turn FINISH event is yielded to the consumer as a turn boundary
+   * but does NOT close the WS — the iterator stays alive until the WS
+   * itself closes (abort, transport error, server-initiated 1008/4003
+   * etc.).
+   */
+  private readonly liveStreams = new Map<string, LiveWsEntry>();
 
   constructor(deps: LifedWsAgentSessionClientDeps) {
     if (!deps.baseUrl) {
@@ -317,12 +348,27 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
   }
 
   /**
-   * Multi-turn message ingestion. Implementation lands in Task 3 of
-   * Plan E-2. Until then, calling this on an active session throws —
-   * the per-turn path doesn't register a per-sid WS map entry.
+   * Push a new user message into an active multi-turn WS stream.
+   * Resolves once the frame is queued or written to the socket (not
+   * once the turn completes).
+   *
+   * Throws `AgentSessionUnknownSidError` when no multi-turn WS is
+   * registered for the given `sessionId` — either the session never
+   * opened in multi-turn mode (per-turn streams don't register an
+   * entry), or it already terminated and cleaned up.
+   *
+   * Buffers messages that arrive before the WS reaches OPEN state;
+   * the `open` event handler drains the buffer in arrival order.
    */
-  async sendMessage(sessionId: string, _content: string): Promise<void> {
-    throw new AgentSessionUnknownSidError(sessionId);
+  async sendMessage(sessionId: string, content: string): Promise<void> {
+    const entry = this.liveStreams.get(sessionId);
+    if (!entry) throw new AgentSessionUnknownSidError(sessionId);
+    if (entry.isOpen) {
+      const frame: InboundFrame = { kind: "send_message", content };
+      entry.ws.send(JSON.stringify(frame));
+      return;
+    }
+    entry.pending.push(content);
   }
 
   async health(): Promise<AgentSessionHealth> {
@@ -373,6 +419,16 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
         "lifed-ws.no_capability",
         "LifedWsAgentSessionClient requires a Tier-User capability (input.capability)",
       );
+      return;
+    }
+
+    // Branch on multi-turn opt-in. The per-turn path stays bit-for-bit
+    // identical to today (E-2 invariant: zero behavior change for
+    // canonical.ts:254). The multi-turn path keeps the WS open across
+    // many `send_message` frames and treats per-turn FINISH as a turn
+    // boundary instead of a terminal close.
+    if (input.multiTurn === true) {
+      yield* this.streamMultiTurn(input);
       return;
     }
 
@@ -535,6 +591,243 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
         // Normal close — if the server didn't send a FINISH event,
         // synthesize one so consumers don't hang.
         // (Idiomatic lifed always sends FINISH; this is belt-and-suspenders.)
+        yield this.canonical(++lastSeq, {
+          kind: "finish",
+          reason: "stop",
+        });
+      }
+    }
+  }
+
+  /**
+   * Multi-turn WS body. Opens a single WS that stays alive across many
+   * `send_message` frames; per-turn FINISH events are forwarded to the
+   * consumer as turn boundaries (so the SSE handler can persist the
+   * turn and reset its per-turn state) but the iterator stays alive.
+   *
+   * Differences from the per-turn path:
+   *   1. The initial `input.userMessage` is registered in
+   *      `liveStreams.pending` *before* the WS opens, not sent inline
+   *      in the `open` handler. This unifies the inbound write path
+   *      with `sendMessage()`.
+   *   2. The frame-pump loop forwards `AGENT_EVENT_KIND_FINISH` events
+   *      to the consumer (turn boundary) but does NOT break the loop;
+   *      it only breaks on close / unrecoverable error / abort.
+   *   3. The terminal `finish` is emitted once at iterator end (clean
+   *      close → "stop", abort → "aborted", error → error code).
+   *
+   * Per Open Q 1 verdict (2026-05-15, confirmed via Rust source
+   * inspection — see liveStreams docstring), lifegw + lifed keep the
+   * WS open across many `send_message` frames, so this branch is the
+   * happy path. If lifed *did* close after each FINISH, this code
+   * would observe the close and exit on the next iteration — the
+   * fallback shape is the same, just with a single-turn lifetime.
+   */
+  private async *streamMultiTurn(
+    input: AgentStreamInput,
+  ): AsyncIterable<CanonicalAgentEvent> {
+    const sid = input.sessionId;
+    if (!input.capability) {
+      // Unreachable — checked by caller — but typecheck needs it.
+      yield* this.errorThenFinish(
+        0n,
+        "lifed-ws.no_capability",
+        "LifedWsAgentSessionClient requires a Tier-User capability (input.capability)",
+      );
+      return;
+    }
+    const wsUrl = this.buildWsUrl(input);
+    const protocols = [`bearer.${input.capability.token}`];
+    let ws: WsLike;
+    try {
+      ws = this.webSocketFactory(wsUrl, protocols);
+    } catch (err) {
+      yield* this.errorThenFinish(
+        0n,
+        "lifed-ws.factory_failed",
+        `failed to construct WebSocket: ${(err as Error).message}`,
+      );
+      return;
+    }
+
+    // Register live-streams entry before any await so `sendMessage`
+    // can target this sid immediately if the SSE handler races ahead.
+    const entry: LiveWsEntry = {
+      ws,
+      pending: [input.userMessage],
+      isOpen: false,
+    };
+    this.liveStreams.set(sid, entry);
+
+    const queue: OutboundFrame[] = [];
+    let closed = false;
+    let resolveNext: ((v: void) => void) | null = null;
+    const wake = () => {
+      const r = resolveNext;
+      resolveNext = null;
+      r?.();
+    };
+    const waitForFrame = () =>
+      new Promise<void>((resolve) => {
+        if (queue.length > 0 || closed) return resolve();
+        resolveNext = resolve;
+      });
+
+    let lastSeq = 0n;
+    let openErrCode: string | null = null;
+    let openErrMsg: string | null = null;
+
+    const cleanup = () => {
+      try {
+        if (
+          ws.readyState !== /* CLOSED */ 3 &&
+          ws.readyState !== /* CLOSING */ 2
+        ) {
+          ws.close(CLOSE_NORMAL, "client done");
+        }
+      } catch {
+        // swallow
+      }
+    };
+
+    ws.addEventListener("open", () => {
+      entry.isOpen = true;
+      // Drain pending in arrival order. Any messages that landed via
+      // `sendMessage` before the WS opened are sent now.
+      const pending = entry.pending;
+      entry.pending = [];
+      for (const content of pending) {
+        const frame: InboundFrame = { kind: "send_message", content };
+        try {
+          ws.send(JSON.stringify(frame));
+        } catch (err) {
+          openErrCode ??= "lifed-ws.send_failed";
+          openErrMsg ??= `failed to send open frame: ${(err as Error).message}`;
+          cleanup();
+          return;
+        }
+      }
+    });
+
+    ws.addEventListener("message", (e) => {
+      const text = typeof e.data === "string" ? e.data : null;
+      if (!text) return;
+      try {
+        const f = JSON.parse(text) as OutboundFrame;
+        queue.push(f);
+        wake();
+      } catch {
+        // malformed frame — drop. lifed should not produce these.
+      }
+    });
+
+    ws.addEventListener("error", (e) => {
+      openErrCode ??= "lifed-ws.transport_error";
+      openErrMsg ??= e.message ?? "websocket error";
+    });
+
+    ws.addEventListener("close", (e) => {
+      closed = true;
+      if (e.code === CLOSE_AUTH) {
+        openErrCode = "lifed-ws.auth";
+        openErrMsg = `auth failed: ${e.reason || "1008"}`;
+      } else if (e.code === CLOSE_IP_BLOCKED) {
+        openErrCode = "lifed-ws.ip_blocked";
+        openErrMsg = `ip blocked: ${e.reason || "4003"}`;
+      } else if (e.code === CLOSE_SEQUENCE_RETIRED) {
+        openErrCode = "lifed-ws.sequence_retired";
+        openErrMsg = `from_sequence retired: ${e.reason || "4005"}`;
+      } else if (TRANSIENT_CLOSE_CODES.has(e.code)) {
+        openErrCode ??= `lifed-ws.transient_${e.code}`;
+        openErrMsg ??= `transient close: ${e.reason || e.code}`;
+      } else if (e.code !== CLOSE_NORMAL) {
+        openErrCode ??= `lifed-ws.unexpected_${e.code}`;
+        openErrMsg ??= `unexpected close: ${e.reason || e.code}`;
+      }
+      wake();
+    });
+
+    // Abort wake-up — if the caller's signal fires, the wait-loop
+    // observes it on the next iteration. Without this listener, the
+    // generator would hang in waitForFrame() with no incoming frame.
+    const onAbort = () => {
+      // We don't set `closed = true` here because we want the close
+      // handler (which fires after cleanup()) to drive the canonical
+      // close-code mapping. We just wake the pump.
+      wake();
+    };
+    if (input.signal) {
+      if (input.signal.aborted) {
+        // Already aborted — fast path.
+        cleanup();
+      } else {
+        input.signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+
+    let abortedYielded = false;
+
+    try {
+      while (!closed || queue.length > 0) {
+        if (input.signal?.aborted && !abortedYielded) {
+          yield this.canonical(lastSeq++, {
+            kind: "warning",
+            code: "lifed-ws.aborted",
+            message: "stream aborted by client",
+          });
+          abortedYielded = true;
+          // Drive a clean close — server-side will see 1000 Normal.
+          cleanup();
+        }
+        if (queue.length === 0) {
+          await waitForFrame();
+          continue;
+        }
+        const frame = queue.shift()!;
+        if (frame.kind === "agent_event") {
+          const seqStr = String(frame.seq_no);
+          const seq = parseSeqStrict(seqStr) ?? lastSeq + 1n;
+          lastSeq = seq;
+          const decoded = decodeAgentEvent(frame, input);
+          if (decoded) {
+            yield {
+              seq,
+              at: frame.record.at ?? new Date().toISOString(),
+              event: decoded,
+            };
+            // Per-turn FINISH is a turn boundary in multi-turn mode —
+            // we yield it (so the consumer can persist the turn) but
+            // keep the iterator alive. The terminal finish lives in
+            // the outer `finally`.
+          }
+        } else if (frame.kind === "closing") {
+          // server is about to close the stream (Spec C₃ §6.5).
+          // Don't yield — the close event will produce the terminal
+          // finish.
+        } else if (frame.kind === "pong") {
+          // unsolicited; ignore
+        }
+      }
+    } finally {
+      input.signal?.removeEventListener("abort", onAbort);
+      this.liveStreams.delete(sid);
+      cleanup();
+      if (input.signal?.aborted) {
+        yield this.canonical(++lastSeq, {
+          kind: "finish",
+          reason: "aborted",
+        });
+      } else if (openErrCode || openErrMsg) {
+        yield this.canonical(++lastSeq, {
+          kind: "error",
+          code: openErrCode ?? "lifed-ws.error",
+          message: openErrMsg ?? "lifed-ws stream errored",
+        });
+        yield this.canonical(++lastSeq, {
+          kind: "finish",
+          reason: "error",
+        });
+      } else {
         yield this.canonical(++lastSeq, {
           kind: "finish",
           reason: "stop",

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -33,18 +33,15 @@
  */
 
 import "server-only";
-import type {
-  ToolCall,
-  ToolResult,
-  VmHandle,
-} from "../kernel/types";
-import type {
-  AgentEvent,
-  AgentSessionClient,
-  AgentSessionHealth,
-  AgentStreamInput,
-  CanonicalAgentEvent,
-  TierUserCap,
+import type { ToolCall, ToolResult, VmHandle } from "../kernel/types";
+import {
+  type AgentEvent,
+  type AgentSessionClient,
+  type AgentSessionHealth,
+  AgentSessionUnknownSidError,
+  type AgentStreamInput,
+  type CanonicalAgentEvent,
+  type TierUserCap,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -102,20 +99,14 @@ interface WsLike {
   close(code?: number, reason?: string): void;
   addEventListener(event: "open", h: () => void): void;
   addEventListener(event: "message", h: (e: { data: unknown }) => void): void;
-  addEventListener(
-    event: "error",
-    h: (e: { message?: string }) => void,
-  ): void;
+  addEventListener(event: "error", h: (e: { message?: string }) => void): void;
   addEventListener(
     event: "close",
     h: (e: { code: number; reason: string }) => void,
   ): void;
 }
 
-export type WebSocketFactory = (
-  url: string,
-  protocols: string[],
-) => WsLike;
+export type WebSocketFactory = (url: string, protocols: string[]) => WsLike;
 
 function defaultWebSocketFactory(): WebSocketFactory {
   const g = globalThis as unknown as {
@@ -325,6 +316,15 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
     };
   }
 
+  /**
+   * Multi-turn message ingestion. Implementation lands in Task 3 of
+   * Plan E-2. Until then, calling this on an active session throws —
+   * the per-turn path doesn't register a per-sid WS map entry.
+   */
+  async sendMessage(sessionId: string, _content: string): Promise<void> {
+    throw new AgentSessionUnknownSidError(sessionId);
+  }
+
   async health(): Promise<AgentSessionHealth> {
     const url = `${this.baseUrl}/healthz`;
     const headers: Record<string, string> = {};
@@ -364,9 +364,7 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
     }
   }
 
-  async *stream(
-    input: AgentStreamInput,
-  ): AsyncIterable<CanonicalAgentEvent> {
+  async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
     if (!input.capability) {
       // Spec D L4-D5 mandates a Tier-User cap on the WS upgrade.
       // Without one the gateway rejects the upgrade with 1008.
@@ -508,7 +506,12 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
             // defensive
           }
           const decoded = decodeAgentEvent(frame, input);
-          if (decoded) yield { seq, at: frame.record.at ?? new Date().toISOString(), event: decoded };
+          if (decoded)
+            yield {
+              seq,
+              at: frame.record.at ?? new Date().toISOString(),
+              event: decoded,
+            };
         } else if (frame.kind === "closing") {
           // server is about to close the stream (Spec C₃ §6.5). Don't
           // yield this — the close event will produce the finish.

--- a/apps/broomva/lib/life-runtime/agent-session/types.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/types.ts
@@ -105,6 +105,18 @@ export type AgentEvent =
   | { kind: "warning"; code: string; message: string }
   /** Fatal error — the stream is about to close abnormally. */
   | { kind: "error"; code: string; message: string }
+  /**
+   * Fires between turns in a multi-turn session. The current turn's
+   * last events have been emitted; the iterator is parked waiting for
+   * the next `sendMessage()`. Per-turn callers (`multiTurn !== true`)
+   * never see this event — the iterator closes after `finish` instead.
+   *
+   * `turn_end` is NEVER terminal — consumers MUST keep pulling from
+   * the iterator after observing it. Both backends (`in-process`,
+   * `lifed-ws`) emit `turn_end` at turn boundaries in multi-turn mode
+   * and reserve `finish` for the one-and-only terminal event.
+   */
+  | { kind: "turn_end" }
   /** Stream finished cleanly. Always the last event. */
   | {
       kind: "finish";
@@ -222,8 +234,15 @@ export interface AgentSessionClient {
    * - The caller's `signal` aborts.
    *
    * Implementations MUST emit events in monotonic `seq` order and
-   * MUST emit exactly one `finish` or `error` as the last event
-   * before the iterator ends.
+   * MUST emit exactly one `finish` as the terminal-and-last event
+   * before the iterator ends. (`error` may precede `finish` to carry
+   * a fatal-error code; the iterator still closes with a `finish`
+   * after the `error`.)
+   *
+   * In multi-turn mode (`input.multiTurn === true`), the stream may
+   * yield `turn_end` events between turns to mark turn boundaries.
+   * `turn_end` is NEVER terminal — `finish` remains terminal-and-last
+   * exactly as in per-turn mode. Per-turn callers never see `turn_end`.
    */
   stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent>;
 

--- a/apps/broomva/lib/life-runtime/agent-session/types.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/types.ts
@@ -169,6 +169,19 @@ export interface AgentStreamInput {
   capability?: TierUserCap;
   /** Aborts the stream. */
   signal?: AbortSignal;
+  /**
+   * When `true`, the returned `AsyncIterable` does NOT finish after the
+   * first turn. Instead, it parks waiting for additional user messages
+   * delivered via `client.sendMessage(sessionId, content)`. Each new
+   * message triggers another turn, with conversation history accumulated
+   * automatically. The iterable only finishes when `signal` aborts or
+   * an unrecoverable error event fires.
+   *
+   * When `false` or omitted, behavior matches the historical per-turn
+   * contract — `input.userMessage` runs to a `finish` event and the
+   * iterable closes. This is the path `canonical.ts` uses today.
+   */
+  multiTurn?: boolean;
 }
 
 /**
@@ -215,9 +228,43 @@ export interface AgentSessionClient {
   stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent>;
 
   /**
+   * Push a new user message into an active multi-turn session. The
+   * corresponding `stream()` iterable picks it up, runs another turn,
+   * and resumes yielding events.
+   *
+   * Throws if `sessionId` has no active multi-turn stream
+   * (`code: "agent-session.unknown_sid"`). Calling on a per-turn (non-
+   * `multiTurn`) session is also an unknown-sid error — per-turn streams
+   * do not register a queue.
+   *
+   * Resolves once the message is queued (not once the turn finishes).
+   */
+  sendMessage(sessionId: string, content: string): Promise<void>;
+
+  /**
    * Cheap reachability probe — used by the `/api/life/health` endpoint
    * to drive the Dock SIM/LIVE/COMING badges. Implementations should
    * NOT open a full agent stream; cap at 2s.
    */
   health(): Promise<AgentSessionHealth>;
+}
+
+/**
+ * Thrown by `AgentSessionClient.sendMessage` when no active multi-turn
+ * stream is registered for the given `sessionId`. Either the session
+ * never opened (race condition — caller invoked `sendMessage` before
+ * `stream()` parked), the stream already terminated (abort, error,
+ * fatal close), or the session opened in per-turn mode (no queue
+ * registered).
+ *
+ * Callers (notably the SSE handler that fans turns from the browser
+ * into the runtime) translate this into a typed envelope so the user
+ * sees a coherent "session expired" surface rather than a 500.
+ */
+export class AgentSessionUnknownSidError extends Error {
+  readonly code = "agent-session.unknown_sid";
+  constructor(sessionId: string) {
+    super(`agent-session: no active multi-turn stream for sid="${sessionId}"`);
+    this.name = "AgentSessionUnknownSidError";
+  }
 }

--- a/apps/broomva/lib/life-runtime/canonical.ts
+++ b/apps/broomva/lib/life-runtime/canonical.ts
@@ -609,7 +609,11 @@ function canonicalToRunnerYield(ev: CanonicalAgentEvent): RunnerYield[] {
     case "vigil_span":
     case "warning":
     case "approval_required":
+    case "turn_end":
       // Not currently surfaced by the legacy emitter; intentional drop.
+      // `turn_end` is the multi-turn boundary marker (Plan E-2 / PR
+      // #164); the legacy ProsoponEmitter is the per-turn path and
+      // ignores it.
       return [];
     case "open":
     case "finish":


### PR DESCRIPTION
## Summary

- Extends `AgentSessionClient` with opt-in multi-turn streaming.
- Both backends (InProcess + LifedWs) support `sendMessage(sid, content)` + `multiTurn?: boolean` on `AgentStreamInput`.
- Welcome-arc seed left in `session-runtime.ts` (E-3 territory); `canonical.ts:254` per-turn path is bit-for-bit unchanged.

## Linear

BRO-1324 (Broomva workspace — supersedes the original BRO-43 which was filed in the wrong Stimulus workspace and deleted)

## Open Q 1 verdict

**lifed keeps the WS open after a per-turn FINISH** — multi-turn WS path implemented (not stubbed).

Confirmed by Rust source inspection of the deployed substrate (a live smoke test against `wss://lifegw-production.up.railway.app/v1/agent/stream` requires a valid Tier-1 cap; the dev token gets rejected at HTTP/2 upgrade with `grpc-status: 16, grpc-message: missing Tier-1 bearer token`, so the question is answered from source instead):

- `core/life/crates/life-runtime/lifed/src/services/agent.rs:399-457` — `stream_session` is a passive fanout subscriber; never terminates after any `AgentEvent` kind (including `Finish`).
- `core/life/crates/life-runtime/lifed/src/routing/fanout.rs:103-139` — `broadcast` doesn't close streams after any event kind; only slow-consumer GC or receiver-dropped close fires.
- `core/life/crates/life-runtime/lifegw/src/services/ws.rs:842-899` — `drive_upstream_tail` loops `while let Some(item) = stream.next().await`; only exits on `Err(status)` or stream end.
- `core/life/crates/life-runtime/lifed/tests/integration_send_message.rs:106-164` — `multi_tab_fanout_emits_to_all_attached_streams` asserts streams stay attached across multiple `send_message` calls.

Captured server-response snippet:

```
HTTP/2 200 
content-type: application/grpc
grpc-message: missing Tier-1 bearer token
grpc-status: 16
```

## Tests

- 350 pre-existing + 14 new = **364 unit tests pass** (52 files via `bun run test:unit`).
- `agent-session/` subtree: 60 → 74 (+14, exactly 7 contract tests per backend).
- Biome clean (`bunx biome check lib/life-runtime/agent-session/` exits 0; 13 cosmetic warnings only).
- Typecheck clean (`bunx tsc --noEmit | grep -v 'skills/refresh'`): zero new errors. 3 pre-existing errors on `main` unrelated to Plan E-2 (`@/.next/types/routes` for project pages, unused `@ts-expect-error` in `source-badge.tsx`).

## Test plan

- [x] Per-turn baseline (`canonical.ts` behavior) unchanged — `tokens + one finish + iterator closes`.
- [x] Multi-turn opt-in: `open → tokens → sendMessage → tokens → ...`.
- [x] History accumulates across turns (InProcess; WS skips — server-side state).
- [x] Abort signal cleanly terminates with terminal `finish` reason `"aborted"`.
- [x] Unknown-sid `sendMessage` throws `AgentSessionUnknownSidError` (`code: "agent-session.unknown_sid"`).
- [x] Post-abort `sendMessage` on the same sid throws (cleanup verified).

## Incidental fix

The LifedWs per-turn path was double-emitting `finish` events when the server sent both a `FINISH` `agent_event` frame AND a clean close — the old code yielded the decoded FINISH plus a belt-and-suspenders synthesized one in `finally`. This PR tracks `finishYielded` and skips the synthesis when the server already sent one. Contract test #1 caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-turn conversation support allowing sessions to remain active for multiple user messages.
  * New `sendMessage()` API enables sending additional messages during active multi-turn sessions.
  * Introduced `turn_end` event marking boundaries between turns in multi-turn mode.

* **Tests**
  * Established comprehensive contract test harness validating consistent behavior across all backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
