### PR TITLE
fix(release): drop linux-arm64 from CLI build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,10 +128,12 @@ jobs:
             target: x86_64-unknown-linux-gnu
             target_label: linux-x64
             use_cross: false
-          - runner: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            target_label: linux-arm64
-            use_cross: true
+          # linux-arm64 deferred — `cross v0.2.5` aarch64 container is
+          # missing libssl-dev, so `openssl-sys` fails to build. Re-add
+          # this matrix entry once a Cross.toml ships with a pre-build
+          # step that apt-installs the cross deps, or once broomva-cli
+          # switches its TLS backend to rustls. Until then, linux-arm64
+          # users hit install.sh's `cargo install` fallback path.
     env:
       VERSION: ${{ needs.tag.outputs.version }}
       TAG: ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
## Summary

The v0.4.1 auto-release succeeded for 3 of 4 targets but `linux-arm64` failed at the `openssl-sys` build step:

```
error: failed to run custom build command for `openssl-sys v0.9.112`
warning: build failed, waiting for other jobs to finish...
##[error]Process completed with exit code 101.
```

Root cause: the `cross v0.2.5` `aarch64-unknown-linux-gnu` container is missing `libssl-dev`, so `openssl-sys` has no headers to link against.

This PR defers `linux-arm64` from the matrix. Re-add when either:
- A `Cross.toml` ships with a pre-build step `apt-get install -y libssl-dev:arm64`, OR
- `broomva-cli` switches its TLS backend from `openssl-sys` to `rustls`

linux-arm64 users keep the existing `install.sh` `cargo install` fallback path — same shape as before v0.4.1.

## v0.4.1 release stays as-is

The published v0.4.1 release has 3 valid binaries (darwin-arm64/x64 + linux-x64) with sha256 verification files. Users on those platforms get the fast prebuilt path; everyone else falls through to cargo-install.

## No VERSION bump

`release.yml` triggers on `paths: [VERSION]` only — this patch doesn't fire the workflow. The next VERSION bump produces a 3-target release that completes successfully (no failed jobs in the run).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` validates
- [ ] CI green (no VERSION change, so release.yml shouldn't fire)
- [ ] After merge: next VERSION bump produces a green release.yml run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Linux ARM64 binary builds from the automated release pipeline. This build target will no longer be included in release distributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->