### PR TITLE
fix(prompts): surface silent GitHub-mirror failure + backfill missing MDX (BRO-1181)

### DIFF
--- a/apps/broomva/app/api/prompts/[slug]/route.test.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.test.ts
@@ -208,4 +208,18 @@ describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
     expect(body.githubMirror).toBeUndefined();
     expect(mockCommitToGitHub).not.toHaveBeenCalled();
   });
+
+  test("admin + mirror THROWS → caught, 200 + githubMirror.ok=false (DB update preserved)", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockRejectedValue(new Error("ETIMEDOUT"));
+
+    const res = await PUT(putReq(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.githubMirror).toEqual({
+      ok: false,
+      error: "ETIMEDOUT",
+    });
+    expect(res.headers.get("Warning")).toContain("ETIMEDOUT");
+  });
 });

--- a/apps/broomva/app/api/prompts/[slug]/route.test.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.test.ts
@@ -241,4 +241,22 @@ describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
     expect(warning).toBeTruthy();
     expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/);
   });
+
+  test("admin + mirror error with non-ASCII (€/emoji) → header ASCII-safe, no 500", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({
+      success: false,
+      error: "GitHub API: 500 — payment € required 🧪",
+    } as never);
+
+    const res = await PUT(putReq(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.githubMirror.error).toContain("🧪");
+    const warning = res.headers.get("Warning");
+    expect(warning).toBeTruthy();
+    // eslint-disable-next-line no-control-regex
+    expect(warning).toMatch(/^[\x20-\x7e]+$/);
+    expect(warning).not.toContain("🧪");
+  });
 });

--- a/apps/broomva/app/api/prompts/[slug]/route.test.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.test.ts
@@ -21,13 +21,24 @@ vi.mock("@/lib/prompts/github-commit", () => ({
   commitPromptToGitHub: vi.fn(),
 }));
 
-import { GET } from "./route";
-import { getPromptBySlug, getPromptMetrics } from "@/lib/db/queries";
+import { GET, PUT } from "./route";
+import {
+  getPromptBySlug,
+  getPromptMetrics,
+  updateUserPrompt,
+} from "@/lib/db/queries";
 import { getContentBySlug } from "@/lib/content";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+import { isAdmin } from "@/lib/prompts/admin";
+import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
 
 const mockGetPrompt = vi.mocked(getPromptBySlug);
 const mockGetMetrics = vi.mocked(getPromptMetrics);
 const mockGetContent = vi.mocked(getContentBySlug);
+const mockUpdateUserPrompt = vi.mocked(updateUserPrompt);
+const mockResolveAuth = vi.mocked(resolveAuth);
+const mockIsAdmin = vi.mocked(isAdmin);
+const mockCommitToGitHub = vi.mocked(commitPromptToGitHub);
 
 const SLUG = "code-review-agent";
 
@@ -124,5 +135,77 @@ describe("GET /api/prompts/[slug]", () => {
     mockGetContent.mockResolvedValue(null);
     const res = await GET(makeReq(), { params: Promise.resolve({ slug: SLUG }) });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
+  const ADMIN_EMAIL = "admin@example.com";
+  const UPDATED_ROW = {
+    ...dbPromptRow,
+    title: "Updated Title",
+  };
+
+  function putReq(): Request {
+    return new Request(`http://localhost/api/prompts/${SLUG}`, {
+      method: "PUT",
+      body: JSON.stringify({ title: "Updated Title" }),
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  beforeEach(() => {
+    mockGetPrompt.mockReset();
+    mockUpdateUserPrompt.mockReset();
+    mockResolveAuth.mockReset();
+    mockIsAdmin.mockReset();
+    mockCommitToGitHub.mockReset();
+
+    mockResolveAuth.mockResolvedValue({
+      userId: dbPromptRow.userId,
+      email: ADMIN_EMAIL,
+    } as never);
+    mockGetPrompt.mockResolvedValue(dbPromptRow as never);
+    mockUpdateUserPrompt.mockResolvedValue(UPDATED_ROW as never);
+  });
+
+  test("admin + mirror success → body carries githubMirror.ok=true, no Warning header", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({ success: true } as never);
+
+    const res = await PUT(putReq(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.githubMirror).toEqual({ ok: true });
+    expect(res.headers.get("Warning")).toBeNull();
+  });
+
+  test("admin + mirror FAILURE → body carries githubMirror.ok=false + Warning header", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({
+      success: false,
+      error: "GITHUB_TOKEN not set",
+    } as never);
+
+    const res = await PUT(putReq(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.githubMirror).toEqual({
+      ok: false,
+      error: "GITHUB_TOKEN not set",
+    });
+    const warning = res.headers.get("Warning");
+    expect(warning).toBeTruthy();
+    expect(warning).toContain("GitHub mirror failed");
+    expect(warning).toContain("GITHUB_TOKEN not set");
+  });
+
+  test("non-admin owner update → no mirror, no githubMirror field", async () => {
+    mockIsAdmin.mockReturnValue(false);
+
+    const res = await PUT(putReq(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.githubMirror).toBeUndefined();
+    expect(mockCommitToGitHub).not.toHaveBeenCalled();
   });
 });

--- a/apps/broomva/app/api/prompts/[slug]/route.test.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.test.ts
@@ -177,6 +177,8 @@ describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
     const body = await res.json();
     expect(body.githubMirror).toEqual({ ok: true });
     expect(res.headers.get("Warning")).toBeNull();
+    // Mirror receives the updated DB row, not the request body
+    expect(mockCommitToGitHub).toHaveBeenCalledWith(UPDATED_ROW);
   });
 
   test("admin + mirror FAILURE → body carries githubMirror.ok=false + Warning header", async () => {
@@ -221,5 +223,22 @@ describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
       error: "ETIMEDOUT",
     });
     expect(res.headers.get("Warning")).toContain("ETIMEDOUT");
+  });
+
+  test("admin + mirror error with CR/LF/control chars → header sanitized, no 500", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({
+      success: false,
+      error: "GitHub API: 500\n{\"message\":\"oops\"}\r\nx",
+    } as never);
+
+    const res = await PUT(putReq(), { params: Promise.resolve({ slug: SLUG }) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.githubMirror.ok).toBe(false);
+    expect(body.githubMirror.error).toContain("\n"); // body preserves raw
+    const warning = res.headers.get("Warning");
+    expect(warning).toBeTruthy();
+    expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/);
   });
 });

--- a/apps/broomva/app/api/prompts/[slug]/route.test.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.test.ts
@@ -239,6 +239,7 @@ describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
     expect(body.githubMirror.error).toContain("\n"); // body preserves raw
     const warning = res.headers.get("Warning");
     expect(warning).toBeTruthy();
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: header sanitization assertion targets RFC 7230 §3.2.6 forbidden range
     expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/);
   });
 
@@ -255,7 +256,7 @@ describe("PUT /api/prompts/[slug] — admin GitHub mirror behavior", () => {
     expect(body.githubMirror.error).toContain("🧪");
     const warning = res.headers.get("Warning");
     expect(warning).toBeTruthy();
-    // eslint-disable-next-line no-control-regex
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: assertion bounds header to printable ASCII (Headers ByteString contract)
     expect(warning).toMatch(/^[\x20-\x7e]+$/);
     expect(warning).not.toContain("🧪");
   });

--- a/apps/broomva/app/api/prompts/[slug]/route.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.ts
@@ -7,7 +7,7 @@ import {
 } from "@/lib/db/queries";
 import { updatePromptSchema } from "@/lib/prompts/validation";
 import { isAdmin } from "@/lib/prompts/admin";
-import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
+import { mirrorIfAdmin, mirrorWarningHeaders } from "@/lib/prompts/mirror";
 import { resolveAuth } from "@/lib/prompts/resolve-auth";
 
 export async function GET(
@@ -112,27 +112,12 @@ export async function PUT(
   }
 
   // Admin: mirror updated DB row back to MDX in the repo. Surface mirror
-  // failures — see app/api/prompts/route.ts for the rationale.
-  let githubMirror: { ok: true } | { ok: false; error: string } | null = null;
-  if (isAdmin(auth.email)) {
-    const ghResult = await commitPromptToGitHub(updated);
-    if (ghResult.success) {
-      githubMirror = { ok: true };
-    } else {
-      const error = ghResult.error ?? "unknown";
-      console.error("GitHub commit failed:", error);
-      githubMirror = { ok: false, error };
-    }
-  }
-
-  const headers: Record<string, string> = {};
-  if (githubMirror && !githubMirror.ok) {
-    headers.Warning = `199 - "GitHub mirror failed: ${githubMirror.error.replace(/"/g, "'")}"`;
-  }
+  // failures (including throws) — see app/api/prompts/route.ts.
+  const githubMirror = await mirrorIfAdmin(auth.email, updated);
 
   return NextResponse.json(
     { ...updated, ...(githubMirror ? { githubMirror } : {}) },
-    { headers },
+    { headers: mirrorWarningHeaders(githubMirror) },
   );
 }
 

--- a/apps/broomva/app/api/prompts/[slug]/route.ts
+++ b/apps/broomva/app/api/prompts/[slug]/route.ts
@@ -111,11 +111,29 @@ export async function PUT(
     return NextResponse.json({ error: "Update failed" }, { status: 500 });
   }
 
+  // Admin: mirror updated DB row back to MDX in the repo. Surface mirror
+  // failures — see app/api/prompts/route.ts for the rationale.
+  let githubMirror: { ok: true } | { ok: false; error: string } | null = null;
   if (isAdmin(auth.email)) {
-    await commitPromptToGitHub(updated);
+    const ghResult = await commitPromptToGitHub(updated);
+    if (ghResult.success) {
+      githubMirror = { ok: true };
+    } else {
+      const error = ghResult.error ?? "unknown";
+      console.error("GitHub commit failed:", error);
+      githubMirror = { ok: false, error };
+    }
   }
 
-  return NextResponse.json(updated);
+  const headers: Record<string, string> = {};
+  if (githubMirror && !githubMirror.ok) {
+    headers.Warning = `199 - "GitHub mirror failed: ${githubMirror.error.replace(/"/g, "'")}"`;
+  }
+
+  return NextResponse.json(
+    { ...updated, ...(githubMirror ? { githubMirror } : {}) },
+    { headers },
+  );
 }
 
 export async function DELETE(

--- a/apps/broomva/app/api/prompts/route.test.ts
+++ b/apps/broomva/app/api/prompts/route.test.ts
@@ -272,4 +272,24 @@ describe("POST /api/prompts — admin GitHub mirror behavior", () => {
     expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/); // header sanitized
     expect(warning).toContain("GitHub mirror failed");
   });
+
+  test("admin + mirror error contains non-ASCII (emoji/€) → header ASCII-safe, response NOT 500", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({
+      success: false,
+      error: "GitHub API: 500 — payment € required 🧪",
+    } as never);
+
+    // Web `Headers` rejects code points outside 0x20-0x7E with a TypeError.
+    // The header must stay ASCII-printable even when upstream errors are not.
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.githubMirror.error).toContain("🧪"); // body preserves raw
+    const warning = res.headers.get("Warning");
+    expect(warning).toBeTruthy();
+    // eslint-disable-next-line no-control-regex
+    expect(warning).toMatch(/^[\x20-\x7e]+$/); // strictly ASCII-printable
+    expect(warning).not.toContain("🧪");
+  });
 });

--- a/apps/broomva/app/api/prompts/route.test.ts
+++ b/apps/broomva/app/api/prompts/route.test.ts
@@ -236,4 +236,18 @@ describe("POST /api/prompts — admin GitHub mirror behavior", () => {
     expect(mockCommitToGitHub).not.toHaveBeenCalled();
     expect(res.headers.get("Warning")).toBeNull();
   });
+
+  test("admin + mirror THROWS → caught, 201 + githubMirror.ok=false (DB write preserved)", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.githubMirror).toEqual({
+      ok: false,
+      error: "ECONNREFUSED",
+    });
+    expect(res.headers.get("Warning")).toContain("ECONNREFUSED");
+  });
 });

--- a/apps/broomva/app/api/prompts/route.test.ts
+++ b/apps/broomva/app/api/prompts/route.test.ts
@@ -269,7 +269,8 @@ describe("POST /api/prompts — admin GitHub mirror behavior", () => {
     expect(body.githubMirror.error).toContain("\n"); // body preserves raw
     const warning = res.headers.get("Warning");
     expect(warning).toBeTruthy();
-    expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/); // header sanitized
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: header sanitization assertion targets RFC 7230 §3.2.6 forbidden range
+    expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/);
     expect(warning).toContain("GitHub mirror failed");
   });
 
@@ -288,8 +289,8 @@ describe("POST /api/prompts — admin GitHub mirror behavior", () => {
     expect(body.githubMirror.error).toContain("🧪"); // body preserves raw
     const warning = res.headers.get("Warning");
     expect(warning).toBeTruthy();
-    // eslint-disable-next-line no-control-regex
-    expect(warning).toMatch(/^[\x20-\x7e]+$/); // strictly ASCII-printable
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: assertion bounds header to printable ASCII (Headers ByteString contract)
+    expect(warning).toMatch(/^[\x20-\x7e]+$/);
     expect(warning).not.toContain("🧪");
   });
 });

--- a/apps/broomva/app/api/prompts/route.test.ts
+++ b/apps/broomva/app/api/prompts/route.test.ts
@@ -27,13 +27,26 @@ vi.mock("@/lib/prompts/github-commit", () => ({
   commitPromptToGitHub: vi.fn(),
 }));
 
-import { GET } from "./route";
-import { getAllPublicPrompts, getMetricsForSlugs } from "@/lib/db/queries";
+import { GET, POST } from "./route";
+import {
+  getAllPublicPrompts,
+  getMetricsForSlugs,
+  createUserPrompt,
+  getPromptBySlug,
+} from "@/lib/db/queries";
 import { getContentList } from "@/lib/content";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+import { isAdmin } from "@/lib/prompts/admin";
+import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
 
 const mockGetAll = vi.mocked(getAllPublicPrompts);
 const mockGetMetrics = vi.mocked(getMetricsForSlugs);
 const mockGetContentList = vi.mocked(getContentList);
+const mockCreateUserPrompt = vi.mocked(createUserPrompt);
+const mockGetPromptBySlug = vi.mocked(getPromptBySlug);
+const mockResolveAuth = vi.mocked(resolveAuth);
+const mockIsAdmin = vi.mocked(isAdmin);
+const mockCommitToGitHub = vi.mocked(commitPromptToGitHub);
 
 function makeReq(qs: string): NextRequest {
   return new NextRequest(`http://localhost/api/prompts${qs ? `?${qs}` : ""}`);
@@ -135,5 +148,92 @@ describe("GET /api/prompts", () => {
     const body = await res.json();
     expect(body[0].slug).toBe("code-review-agent");
     expect(body[1].slug).toBe("refactor-helper");
+  });
+});
+
+describe("POST /api/prompts — admin GitHub mirror behavior", () => {
+  const ADMIN_EMAIL = "admin@example.com";
+  const USER_ID = "user-1";
+
+  const POST_BODY = {
+    title: "Test Prompt",
+    content: "system: hello",
+    summary: "A test prompt",
+    category: "agent-instructions",
+  };
+
+  const CREATED_ROW = {
+    ...DB_PROMPT,
+    slug: "test-prompt",
+    title: POST_BODY.title,
+    content: POST_BODY.content,
+    summary: POST_BODY.summary,
+    category: POST_BODY.category,
+    userId: USER_ID,
+  };
+
+  function postReq(): NextRequest {
+    return new NextRequest("http://localhost/api/prompts", {
+      method: "POST",
+      body: JSON.stringify(POST_BODY),
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  beforeEach(() => {
+    mockResolveAuth.mockReset();
+    mockIsAdmin.mockReset();
+    mockCommitToGitHub.mockReset();
+    mockCreateUserPrompt.mockReset();
+    mockGetPromptBySlug.mockReset();
+
+    mockResolveAuth.mockResolvedValue({
+      userId: USER_ID,
+      email: ADMIN_EMAIL,
+    } as never);
+    mockGetPromptBySlug.mockResolvedValue(undefined as never);
+    mockCreateUserPrompt.mockResolvedValue(CREATED_ROW as never);
+  });
+
+  test("admin + mirror success → body carries githubMirror.ok=true, no Warning header", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({ success: true } as never);
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.githubMirror).toEqual({ ok: true });
+    expect(res.headers.get("Warning")).toBeNull();
+  });
+
+  test("admin + mirror FAILURE → body carries githubMirror.ok=false + Warning header set", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({
+      success: false,
+      error: "GITHUB_TOKEN not set",
+    } as never);
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.githubMirror).toEqual({
+      ok: false,
+      error: "GITHUB_TOKEN not set",
+    });
+    const warning = res.headers.get("Warning");
+    expect(warning).toBeTruthy();
+    expect(warning).toContain("GitHub mirror failed");
+    expect(warning).toContain("GITHUB_TOKEN not set");
+  });
+
+  test("non-admin path → no mirror attempt, no githubMirror in body", async () => {
+    mockIsAdmin.mockReturnValue(false);
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.githubMirror).toBeUndefined();
+    expect(mockCommitToGitHub).not.toHaveBeenCalled();
+    expect(res.headers.get("Warning")).toBeNull();
   });
 });

--- a/apps/broomva/app/api/prompts/route.test.ts
+++ b/apps/broomva/app/api/prompts/route.test.ts
@@ -204,6 +204,8 @@ describe("POST /api/prompts — admin GitHub mirror behavior", () => {
     const body = await res.json();
     expect(body.githubMirror).toEqual({ ok: true });
     expect(res.headers.get("Warning")).toBeNull();
+    // Mirror is called with the created DB row, not the request body
+    expect(mockCommitToGitHub).toHaveBeenCalledWith(CREATED_ROW);
   });
 
   test("admin + mirror FAILURE → body carries githubMirror.ok=false + Warning header set", async () => {
@@ -249,5 +251,25 @@ describe("POST /api/prompts — admin GitHub mirror behavior", () => {
       error: "ECONNREFUSED",
     });
     expect(res.headers.get("Warning")).toContain("ECONNREFUSED");
+  });
+
+  test("admin + mirror error contains CR/LF/control chars → header sanitized, response NOT 500", async () => {
+    mockIsAdmin.mockReturnValue(true);
+    mockCommitToGitHub.mockResolvedValue({
+      success: false,
+      error: 'GitHub API: 422\n{"message":"Bad","status":"422"}\r\nrate-limit',
+    } as never);
+
+    // The Response construction itself must not throw; the raw error survives
+    // in the body, but the header has CR/LF stripped (RFC 7230 §3.2.6).
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.githubMirror.ok).toBe(false);
+    expect(body.githubMirror.error).toContain("\n"); // body preserves raw
+    const warning = res.headers.get("Warning");
+    expect(warning).toBeTruthy();
+    expect(warning).not.toMatch(/[\r\n\x00-\x1f\x7f]/); // header sanitized
+    expect(warning).toContain("GitHub mirror failed");
   });
 });

--- a/apps/broomva/app/api/prompts/route.ts
+++ b/apps/broomva/app/api/prompts/route.ts
@@ -7,8 +7,8 @@ import {
   getPromptBySlug,
 } from "@/lib/db/queries";
 import { createPromptSchema } from "@/lib/prompts/validation";
-import { isAdmin, generateSlug } from "@/lib/prompts/admin";
-import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
+import { generateSlug } from "@/lib/prompts/admin";
+import { mirrorIfAdmin, mirrorWarningHeaders } from "@/lib/prompts/mirror";
 import { resolveAuth } from "@/lib/prompts/resolve-auth";
 import type { UserPrompt } from "@/lib/db/schema";
 import type { ContentSummary } from "@/lib/content";
@@ -166,40 +166,13 @@ export async function POST(request: NextRequest) {
   });
 
   // Admin: commit to GitHub → triggers Vercel redeploy. Surface mirror
-  // failures to the caller — otherwise the prompt lives in DB only and
-  // never reaches the public /prompts page (MDX-backed via getContentList).
+  // failures (including throws) to the caller — otherwise the prompt lives
+  // in DB only and never reaches the public /prompts page (MDX-backed via
+  // getContentList).
   const githubMirror = await mirrorIfAdmin(userEmail, prompt);
 
   return NextResponse.json(
     { ...prompt, ...(githubMirror ? { githubMirror } : {}) },
-    {
-      status: 201,
-      headers: mirrorWarningHeaders(githubMirror),
-    },
+    { status: 201, headers: mirrorWarningHeaders(githubMirror) },
   );
-}
-
-type GithubMirrorStatus =
-  | { ok: true }
-  | { ok: false; error: string };
-
-async function mirrorIfAdmin(
-  email: string | undefined | null,
-  prompt: Parameters<typeof commitPromptToGitHub>[0],
-): Promise<GithubMirrorStatus | null> {
-  if (!isAdmin(email)) return null;
-  const ghResult = await commitPromptToGitHub(prompt);
-  if (ghResult.success) return { ok: true };
-  const error = ghResult.error ?? "unknown";
-  console.error("GitHub commit failed:", error);
-  return { ok: false, error };
-}
-
-function mirrorWarningHeaders(
-  status: GithubMirrorStatus | null,
-): Record<string, string> {
-  if (!status || status.ok) return {};
-  return {
-    Warning: `199 - "GitHub mirror failed: ${status.error.replace(/"/g, "'")}"`,
-  };
 }

--- a/apps/broomva/app/api/prompts/route.ts
+++ b/apps/broomva/app/api/prompts/route.ts
@@ -165,13 +165,41 @@ export async function POST(request: NextRequest) {
     deletedAt: null,
   });
 
-  // Admin: commit to GitHub → triggers Vercel redeploy
-  if (isAdmin(userEmail)) {
-    const ghResult = await commitPromptToGitHub(prompt);
-    if (!ghResult.success) {
-      console.error("GitHub commit failed:", ghResult.error);
-    }
-  }
+  // Admin: commit to GitHub → triggers Vercel redeploy. Surface mirror
+  // failures to the caller — otherwise the prompt lives in DB only and
+  // never reaches the public /prompts page (MDX-backed via getContentList).
+  const githubMirror = await mirrorIfAdmin(userEmail, prompt);
 
-  return NextResponse.json(prompt, { status: 201 });
+  return NextResponse.json(
+    { ...prompt, ...(githubMirror ? { githubMirror } : {}) },
+    {
+      status: 201,
+      headers: mirrorWarningHeaders(githubMirror),
+    },
+  );
+}
+
+type GithubMirrorStatus =
+  | { ok: true }
+  | { ok: false; error: string };
+
+async function mirrorIfAdmin(
+  email: string | undefined | null,
+  prompt: Parameters<typeof commitPromptToGitHub>[0],
+): Promise<GithubMirrorStatus | null> {
+  if (!isAdmin(email)) return null;
+  const ghResult = await commitPromptToGitHub(prompt);
+  if (ghResult.success) return { ok: true };
+  const error = ghResult.error ?? "unknown";
+  console.error("GitHub commit failed:", error);
+  return { ok: false, error };
+}
+
+function mirrorWarningHeaders(
+  status: GithubMirrorStatus | null,
+): Record<string, string> {
+  if (!status || status.ok) return {};
+  return {
+    Warning: `199 - "GitHub mirror failed: ${status.error.replace(/"/g, "'")}"`,
+  };
 }

--- a/apps/broomva/content/prompts/ai-native-platform-architect.mdx
+++ b/apps/broomva/content/prompts/ai-native-platform-architect.mdx
@@ -1,0 +1,153 @@
+---
+title: "AI-Native Platform Architect"
+summary: "Greenfield AI-native platform design from first principles — primitives (memory, sessions, agents, artifacts, runtime), ontology, runtime architecture, UX, onboarding, and implementation sequence. Refuses to reduce to a SaaS dashboard with AI added on top."
+date: 2026-05-19
+published: true
+category: agent-instructions
+model: claude-opus-4.5
+version: "1.0"
+---
+Help me rethink this product from the ground up as an AI-native platform.
+
+This is a greenfield product, systems, and architecture exercise. I want to define the platform from first principles, not as a conventional software product with AI features layered on top, but as a system whose core primitives are native to intelligence, memory, sessions, tools, artifacts, and persistent work.
+
+## Core framing
+
+This platform should be designed as an AI-native operating environment. The primary unit of interaction is not a static page or CRUD object, but an active session of intelligence operating over a persistent workspace or state substrate. Agents are active actors in the system. Memory, artifacts, events, tools, and the workspace itself are first-class primitives.
+
+## Design goal
+
+Produce a deeply reasoned proposal that defines:
+
+- the product vision
+- the conceptual model
+- the core primitives
+- the data model
+- the runtime architecture
+- the onboarding flow
+- the UX principles
+- the key pages or surfaces
+- the implementation sequence required to build it coherently
+
+Use relevant references for:
+
+- onboarding and narrative simplicity
+- AI-native interaction design
+- progressive disclosure
+- workspace/session interaction
+- agent-centric UX
+
+But do not imitate any one product directly. Reframe the design around this platform's own ontology and purpose.
+
+## Reasoning order — inside out
+
+You must reason from the inside out:
+
+1. define the core primitives
+2. define the system ontology
+3. define the entity model and relationships
+4. define the runtime and persistence model
+5. define the UX and page/surface architecture
+6. define the onboarding and narrative flow
+7. define the implementation order
+
+Do not start with screens alone. Start with primitives and operating model.
+
+## Core primitives — explicit definition required
+
+Please explicitly define the core primitives for the platform. Depending on the domain, analyze candidates such as:
+
+- User
+- Workspace
+- Session
+- Agent
+- Runtime
+- Tool
+- Memory
+- Knowledge graph
+- Artifact
+- Document
+- Operation
+- Run
+- Event
+- State snapshot
+- Policy
+- Identity boundary
+- Tenant / organization
+- Environment
+- Task / objective
+
+For each primitive, define:
+
+- what it is
+- why it exists
+- how it persists
+- what it relates to
+- how it appears in the UX
+- how it participates in runtime behavior
+
+## Required output sections
+
+Then define:
+
+### 1. Product architecture
+- what the platform fundamentally is
+- what makes it AI-native
+- how it differs from conventional software
+
+### 2. Data architecture
+- canonical entities
+- relationships
+- event model
+- state model
+- memory and artifact model
+
+### 3. Runtime architecture
+- how sessions are instantiated
+- how agents operate
+- how tools are invoked
+- how memory is updated
+- how artifacts are created
+- how operations are registered
+
+### 4. UX architecture
+- onboarding flow
+- first-run experience
+- workspace/session interaction model
+- feature discovery
+- progressive disclosure
+- how intelligence is made legible to the user
+
+### 5. Narrative and presentation
+- how to explain the system clearly
+- how to make a complex AI-native architecture feel simple
+- how the product story should unfold from first contact to first successful run
+
+### 6. Implementation implications
+- what must be built first
+- foundational abstractions that cannot be skipped
+- what should be deferred
+- common traps that collapse the platform into a conventional app
+
+## Constraints — what NOT to do
+
+- do not design this as a standard SaaS dashboard with AI added on top
+- do not reduce the product to a chat interface only
+- do not ignore memory, runtime, and state as first-class concerns
+- do not start from UI polish before core ontology is defined
+- do not conflate history, memory, artifacts, and operational state without clear boundaries
+
+## Output format
+
+Provide a structured proposal with:
+
+1. platform definition
+2. core primitives
+3. entity and relationship model
+4. runtime and persistence architecture
+5. onboarding and UX architecture
+6. narrative and design principles
+7. recommended greenfield implementation sequence
+8. key tradeoffs and open questions
+
+Think deeply and step by step across the chain of dependencies. The goal is to define an AI-native platform whose architecture is coherent at the level of ontology, runtime, memory, and user experience.

--- a/apps/broomva/content/prompts/bstack-native-ai-platform-architect.mdx
+++ b/apps/broomva/content/prompts/bstack-native-ai-platform-architect.mdx
@@ -1,0 +1,259 @@
+---
+title: "Bstack-Native AI Platform Architect"
+summary: "AI-native platform architecture from first principles, with bstack P1-P20 as the substrate, filesystem+bash/skills+markdown+hooks+bridge as the product shape, and aiOS as the build engine. Combines deep ontology design with executional rigor (knowledge-graph memory, parallel agents, dep-chain analysis, cross-model review) for greenfield platforms and new ecosystem repos."
+date: 2026-05-19
+published: true
+category: agent-instructions
+model: claude-opus-4.5
+version: "1.0"
+tags:
+  - architecture
+  - ai-native
+  - bstack
+  - aios
+  - repo-creation
+  - knowledge-graph
+  - parallel-agents
+  - dependency-analysis
+  - broomva-ecosystem
+  - control-metalayer
+---
+You are operating inside the Broomva ecosystem to architect and create a new AI-native platform — either as a greenfield product or as a new repository within the ecosystem. This is a deep architectural reasoning exercise, but it is not a blank-slate exercise. The platform you are designing is *built from and runs on the same principles as the broomva workspace itself.*
+
+## The thesis you are building from
+
+A genuinely AI-native platform is not "a SaaS app with AI features bolted on." It is also not "a chat interface over an LLM." It is a system in which **the agent IS the runtime** and **the workspace IS the state substrate.**
+
+The platform's operational shape is **Claude-Code-shaped**:
+
+- **Filesystem** is the primary state substrate. A database is one possible projection of state, not state itself. Markdown files, YAML configs, and typed schemas live on disk and are the canonical truth.
+- **Bash + skills** are the primary action surface. Typed primitives, composable, addressable as `/name`, scoped by policy gates. Tools are how the agent acts on the world.
+- **Markdown + YAML** are the primary memory carrier. Agent-readable by default. Human-readable when audience demands (HTML projection on demand per P18).
+- **Hooks + `.control/policy.yaml`** are the primary control surface. Safety shields fire before destructive operations. PreToolUse is the kernel boundary.
+- **Conversation bridge** is the primary episodic memory. Stop hook → JSONL → markdown → knowledge graph projection. Sessions are never lost.
+
+Users of this platform are **agents and the humans who pair with them**. Its primitives are intelligence-native, not CRUD-native.
+
+## Core architectural primitive: bstack as the substrate
+
+The twenty bstack primitives (P1-P20) are **not** optional best practices that the platform "supports." They are the platform's **core architectural primitives, inherited by default from line zero**:
+
+| # | Name | What it means for this platform |
+|---|------|---------------------------------|
+| P1 | Bridge | Every agent session ends in a queryable conversation log |
+| P2 | Gate | Control-metalayer policy gates govern all destructive operations |
+| P3 | Tickets | Every unit of work is tracked Backlog → Done |
+| P4 | Pipeline | Work flows Branch → PR → CI → merge → deploy |
+| P5 | Fanout | Typed parallel agents on isolated worktrees |
+| P6 | Bookkeeping | Knowledge promotion gate: raw extracts → entity pages → synthesis |
+| P7 | Freshness | Skill freshness reflex on session start |
+| P8 | Janitor | Automatic worktree + branch cleanup post-merge |
+| P9 | Wait | Productive wait on CI — never `sleep` |
+| P10 | Hygiene | Clean tree is the only reliable reset point |
+| P11 | Empirical | Validate by interacting (multi-modal evidence), not by reasoning |
+| P12 | Persist | Long-horizon work survives context resets via filesystem state |
+| P13 | Dream | Multi-tier consolidation with frozen-substrate replay |
+| P14 | Dep-Chain | Concrete upstream/downstream enumeration before every write |
+| P15 | Snapshot | Current-state surfacing before every plan |
+| P16 | Crystallize | Rule-of-three promotion of patterns into primitives |
+| P17 | Lens | Typed request routing via role-x intake (no persona rewrites) |
+| P18 | Audience | Format follows audience (agent → markdown; human → HTML) |
+| P19 | Orchestrate | Explicit mechanism choice per (session-scope × trigger × agent-count) |
+| P20 | Cross-Review | Cross-model adversarial gate before substantive merges |
+
+The platform you produce **must** carry these primitives as substrate. The first commit already wires them in. They are not added later.
+
+## Build engine: aiOS, two modes
+
+The engine that materializes this platform is **aiOS** (Broomva Agent OS — `core/life/`, the substrate that hosts arcan, lago, autonomic, anima, vigil, haima, praxis, chronos).
+
+aiOS operates in one of two modes:
+
+### Mode A — First principles
+
+aiOS reasons the platform from primitives and architectural guidelines alone. No assumed scaffolding. Produces:
+
+- platform ontology and primitive set
+- runtime model (perceive/decide/act/observe loop shape)
+- entity and event schemas
+- UX surfaces and interaction contracts
+- onboarding narrative
+- implementation sequence
+
+**Use Mode A when**: the platform's primitives diverge from the existing stack, the domain requires fresh ontology, or no existing scaffolding fits.
+
+### Mode B — Scaffold from stack (default)
+
+aiOS uses the existing broomva stack to materialize the platform via composable skills:
+
+- `/bstack` — bootstrap workspace governance (CLAUDE.md, AGENTS.md, METALAYER.md, `.control/policy.yaml`, `schemas/`, `.githooks/`, 27-skill stack verification)
+- `/symphony-forge` — project scaffolding with control metalayer pre-wired
+- `/agentic-control-kernel` — typed plant/action/trace schemas, safety shields, multi-rate loop hierarchy
+- `/knowledge-graph-memory` — episodic memory bridge from session logs to Obsidian vault
+- `/skill-creator` — package new platform-specific skills
+- `core/life/` substrates — production-grade runtime layer (arcan agent loop, lago event store, anima identity/custody, vigil OTel observability, haima billing, praxis tool dispatch, chronos temporality)
+- `/cross-review` — cross-model adversarial gate (Strata A Codex / Strata B fresh subagent / Strata C composed adversarial skills)
+- `/persist` — long-horizon iteration substrate (PROMPT.md + git tree + state.jsonl)
+- `/p9` — productive wait + CI watcher
+
+**Use Mode B when**: the platform fits the broomva ontology (agent-native, filesystem-substrate, skill-driven), and the existing stack covers the runtime needs.
+
+**Default to Mode B.** When you choose Mode A, justify it explicitly.
+
+## Required execution workflow
+
+Before any architectural proposal or scaffold, run this sequence:
+
+1. **Snapshot (P15)** — surface current workspace state in your response:
+   - `git status`, current branch, ahead/behind
+   - `gh pr list` for in-flight PRs
+   - Linear ticket state for the platform's scope
+   - Last deploy state
+   - Bookkeeping / bridge freshness
+   - Related projects under `apps/`, `freelance/`, `core/`, `work/`
+
+2. **Mine memory** — use `/knowledge-graph-memory` to pull prior context:
+   - `research/entities/{concept,pattern,tool,person,project}/` — grep by topic before asking the user
+   - `~/.claude/projects/-Users-broomva-broomva/memory/` — persona, corporate, academic, active-project state
+   - `docs/conversations/` — prior session decisions on the current branch
+   - Related project CLAUDE.mds
+   - Identify prior architectural decisions that apply; do not re-solve solved problems.
+
+3. **Dep-Chain (P14)** — enumerate concrete dependencies in the response:
+   - Upstream: files, functions, types, contracts, deployed state this depends on
+   - Downstream: consumers, tests, CI gates, docs, in-flight PRs that depend on this
+   - File paths and function names — not abstract handwaving.
+
+4. **Mode decision (A or B)** — state which mode you chose and why, with citation to the substrates that informed the decision.
+
+5. **Lens (P17)** — score domain lenses against the platform's purpose. Load substantive context (not persona personas — substantive context only — no "act as X" rewrites). State which lens(es) apply.
+
+6. **Fanout (P5) plan** — identify which work parallelizes (research streams, sub-system design, scaffold streams) and which must serialize. Use typed worktree-isolated agents where parallel work genuinely helps. Avoid gratuitous parallelism that fragments architecture.
+
+7. **Inside-out reasoning** — proceed in this dependency order, never bottom-up from screens:
+   1. core primitives
+   2. system ontology
+   3. entity model and relationships
+   4. runtime and persistence model
+   5. UX and surface architecture
+   6. onboarding and narrative flow
+   7. implementation sequence
+
+8. **Cross-Review (P20)** — for substantive design proposals (greenfield platform, public API, governance-class decisions, multi-system architecture), fire a cross-model adversarial review before final sign-off. Score anti-slop ≥7/10. Log verdict in the proposal.
+
+## Required output sections
+
+### 1. Platform definition
+- What this platform fundamentally is — one paragraph, no buzzwords
+- The build mode (A or B) and the justification
+- How it inherits the Claude-Code-shape (filesystem + bash/skills + markdown + hooks + bridge)
+
+### 2. Core primitives (this platform's, not bstack's)
+For each: what it is, why it exists, how it persists, what it relates to, how it appears in the UX, how it participates in runtime. Analyze candidates: User, Workspace, Session, Agent, Runtime, Tool, Skill, Memory, Knowledge Graph, Artifact, Document, Operation, Run, Event, State Snapshot, Policy, Identity Boundary, Tenant/Organization, Environment, Task/Objective.
+
+### 3. Bstack inheritance table
+For each bstack primitive (P1-P20), state how it manifests in this platform. Some inherit directly (P1 Bridge — Stop hook to JSONL; P2 Gate — same `.control/policy.yaml` shape). Some adapt (P5 Fanout might mean tenant-isolated agent runs in a multi-tenant context). Some carry over the discipline without the mechanism. Be explicit. This table is the substrate proof.
+
+### 4. Data architecture
+- Canonical entities and their carriers (filesystem path, schema, lifecycle)
+- Relationships (graph edges, link types)
+- Event model (lago shape: append-only, replayable, multi-tier)
+- State model (filesystem-first; database as projection, not source of truth)
+- Memory and artifact model (raw extracts → entity pages → synthesis — P6 lifecycle)
+
+### 5. Runtime architecture
+- How sessions instantiate (entry contract)
+- How agents operate (perceive/decide/act/observe loop shape; controller from `/agentic-control-kernel`)
+- How tools/skills are invoked (control gate boundary — PreToolUse is the kernel)
+- How memory is updated (bridge + bookkeeping pipeline)
+- How artifacts are created (filesystem substrate — files are the truth)
+- How operations are registered (lago event store + vigil traces with GenAI semconv)
+- Multi-rate loop hierarchy (L0 external plant → L1 agent internal → L2 meta-control → L3 governance)
+
+### 6. UX architecture
+- Onboarding flow (first contact → first successful agent run)
+- First-run experience (the "hello world" of agent-native UX)
+- Workspace/session interaction model (chat is one surface, not the only surface)
+- Feature discovery (progressive disclosure — skills emerge as needed, not upfront)
+- How intelligence is made legible to the user (traces, conversation logs, memory visibility)
+- Persona-prompting forbidden in implementation; load substantive context only
+
+### 7. Narrative and presentation
+- How to explain the system clearly (one paragraph for outsiders)
+- How a complex AI-native architecture feels simple at first contact
+- The story arc from "land on page" to "first successful run"
+
+### 8. Implementation sequence
+- What must be built first (foundations — substrate, governance files, skill stack)
+- What can be parallelized (Fanout P5 candidates — list as typed streams)
+- What should be deferred (rule-of-three before any abstraction)
+- Common traps that collapse the platform into a conventional SaaS app
+
+### 9. Repo creation (when this prompt creates a new repo)
+- Repo vision and ecosystem role
+- Architectural overview
+- Module/folder structure (with bstack governance files: `CLAUDE.md`, `AGENTS.md`, `METALAYER.md`, `.control/policy.yaml`, `schemas/`, `.githooks/`, `.claude/settings.json` with hooks wired)
+- Dependency model (Rust workspace structure if applicable; package boundaries; substrate vs application layers)
+- Skills and hooks wired from day one (Stop hook → bridge; PreToolUse → control gate; SessionStart → freshness)
+- Testing strategy (smoke / unit / integration / regression / E2E per P11 — multi-level test composition)
+- Documentation structure (markdown for agent-loaded surfaces; HTML for substantive human-read specs per P18; `docs/specs/`, `docs/plans/`, `docs/adrs/` as `.html` if human-read)
+- Initial implementation plan with dependency-ordered tasks
+- Linear ticket structure (umbrella + sub-tickets per P3 + P5)
+
+### 10. Open questions and tradeoffs
+- What was decided and why
+- What is deferred and why (rule-of-three not yet met; complexity premium not yet earned)
+- What constraints surfaced through dep-chain analysis
+- What requires user input to resolve (truly irreducible residuals — not facts already on disk)
+
+## Constraints — what NOT to do
+
+- Do NOT design this as a SaaS dashboard with AI features layered on. The agent IS the runtime.
+- Do NOT reduce the product to a chat interface only. Memory, filesystem state, skills, and hooks are first-class.
+- Do NOT bolt bstack on after the fact. It is substrate, present from line zero.
+- Do NOT use persona prompting ("act as a senior architect…"). Load substantive context. Per P17, persona rewrites are forbidden.
+- Do NOT skip the dep-chain enumeration. Concrete file paths and function names, or the step did not happen.
+- Do NOT skip the snapshot. Plans built on stale state fail silently.
+- Do NOT settle for generic repo boilerplate. The repo's first commit already carries bstack discipline.
+- Do NOT bypass `/cross-review` (P20) for substantive proposals. Single-model echo chambers ship slop.
+- Do NOT interview the user for facts already on disk in memory, knowledge graph, CV, or project docs. Read first; ask only for residuals.
+- Do NOT start from screens. Inside-out reasoning, always.
+- Do NOT conflate history, memory, artifacts, and operational state without clear boundaries.
+
+## Quality bar
+
+- Mode A or B explicitly chosen and justified
+- P14 dep-chain present with concrete file paths
+- P15 snapshot surfaced (git state, PRs, tickets, deploy state, related projects)
+- Inside-out reasoning order respected (primitives → ontology → entities → runtime → UX → onboarding → sequence)
+- Bstack inheritance table present (P1-P20 → platform manifestation)
+- Implementation sequence is dependency-aware, not abstract
+- P5 Fanout opportunities identified and dispatched where useful
+- P20 Cross-Review fired and verdict logged before final sign-off
+- For repo creation: governance files present in first commit (CLAUDE.md, AGENTS.md, METALAYER.md, policy.yaml, schemas, hooks)
+
+## Definition of done
+
+- The platform's purpose is defined in one paragraph without buzzwords
+- The bstack substrate inheritance is explicit (table present, P1-P20 covered)
+- The dep-chain is enumerated concretely (file paths, function names, in-flight PRs)
+- The mode (A or B) is chosen and justified with substrate citations
+- A repo (or set of repos) has been scaffolded per the chosen mode, carrying bstack discipline from day one
+- The runtime model is coherent at ontology, persistence, runtime, and UX levels
+- A Linear umbrella ticket exists with sub-tickets for the parallelizable streams (P3 + P5)
+- Cross-model adversarial review has been fired and the verdict logged (P20)
+- Memory entries written or updated where new patterns surfaced (P6 bookkeeping reflex)
+
+## Final output
+
+Return a structured proposal with all ten sections, plus:
+
+- Repo(s) created and their initial structure (paths, governance files, skills, hooks)
+- Skills and hooks wired in from day one
+- First PR(s) opened (if any code was written) with link
+- Linear ticket links (umbrella + sub-tickets)
+- Cross-review verdict (Strata fired, anti-slop score, fix rounds if any)
+- Memory entries written or updated
+- Open questions for the user (irreducible residuals only)
+
+Think deeply and step by step across the chain of dependencies. The goal is to define an AI-native platform whose architecture is coherent at the level of ontology, runtime, memory, control, and user experience — and which inherits the bstack substrate by construction, not by addition.

--- a/apps/broomva/lib/prompts/mirror.ts
+++ b/apps/broomva/lib/prompts/mirror.ts
@@ -32,17 +32,20 @@ export async function mirrorIfAdmin(
   }
 }
 
-// RFC 7230 §3.2.6: header values are restricted to VCHAR + SP + HTAB.
-// Node/undici's Headers.append throws on CR/LF/NUL and other control chars
-// (TypeError: invalid header value). An upstream GitHub error string may
-// contain newlines (multi-line JSON bodies), which would 500 the route
-// during response construction — defeating the whole point of catching the
-// mirror failure. We strip the unsafe range and cap length defensively.
+// RFC 7230 §3.2.6 restricts header values to VCHAR + SP + HTAB, but Node /
+// undici's `Headers` enforces the stricter ByteString contract: any code
+// point outside 0x20-0x7E throws TypeError on append. Upstream GitHub
+// error bodies (taken raw from res.text() in github-commit.ts) can carry
+// both control chars (multi-line JSON) and non-ASCII (Unicode in error
+// messages) — either would 500 the route during response construction,
+// outside mirrorIfAdmin's catch. We replace anything outside printable
+// ASCII with '?' and cap length defensively. The full raw error remains
+// in the JSON body for callers that need it.
 const MAX_WARN_TEXT = 512;
 
 function sanitizeHeaderText(value: string): string {
   return value
-    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/[^\x20-\x7e]/g, "?")
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
     .slice(0, MAX_WARN_TEXT);

--- a/apps/broomva/lib/prompts/mirror.ts
+++ b/apps/broomva/lib/prompts/mirror.ts
@@ -32,18 +32,34 @@ export async function mirrorIfAdmin(
   }
 }
 
+// RFC 7230 §3.2.6: header values are restricted to VCHAR + SP + HTAB.
+// Node/undici's Headers.append throws on CR/LF/NUL and other control chars
+// (TypeError: invalid header value). An upstream GitHub error string may
+// contain newlines (multi-line JSON bodies), which would 500 the route
+// during response construction — defeating the whole point of catching the
+// mirror failure. We strip the unsafe range and cap length defensively.
+const MAX_WARN_TEXT = 512;
+
+function sanitizeHeaderText(value: string): string {
+  return value
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .slice(0, MAX_WARN_TEXT);
+}
+
 /**
  * Build the `Warning` response header for a failed mirror. Returns an empty
  * object when there's nothing to warn about.
  *
  * Header value follows RFC 7234 §5.5 (`warn-code SP warn-agent SP warn-text`).
- * Backslashes and double-quotes inside the error string are escaped so the
- * quoted-string parses cleanly regardless of the upstream error shape.
+ * Error text is sanitized to fit RFC 7230 §3.2.6 header rules and capped at
+ * 512 chars to avoid reverse-proxy header-size limits.
  */
 export function mirrorWarningHeaders(
   status: GithubMirrorStatus | null,
 ): Record<string, string> {
   if (!status || status.ok) return {};
-  const escaped = status.error.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return { Warning: `199 - "GitHub mirror failed: ${escaped}"` };
+  const safe = sanitizeHeaderText(status.error);
+  return { Warning: `199 - "GitHub mirror failed: ${safe}"` };
 }

--- a/apps/broomva/lib/prompts/mirror.ts
+++ b/apps/broomva/lib/prompts/mirror.ts
@@ -1,0 +1,49 @@
+import { isAdmin } from "@/lib/prompts/admin";
+import { commitPromptToGitHub } from "@/lib/prompts/github-commit";
+
+export type GithubMirrorStatus =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Mirror an admin's prompt to the GitHub MDX repo and return a structured
+ * status the route can surface to the caller. Returns `null` for non-admin
+ * callers (no mirror is attempted, no field is emitted).
+ *
+ * Catches throws from `commitPromptToGitHub` (network, DNS, TLS, parse) so
+ * an admin POST/PUT never 500s on a transient failure — the DB write is
+ * preserved and the failure is reported alongside it.
+ */
+export async function mirrorIfAdmin(
+  email: string | undefined | null,
+  prompt: Parameters<typeof commitPromptToGitHub>[0],
+): Promise<GithubMirrorStatus | null> {
+  if (!isAdmin(email)) return null;
+  try {
+    const ghResult = await commitPromptToGitHub(prompt);
+    if (ghResult.success) return { ok: true };
+    const error = ghResult.error ?? "unknown";
+    console.error("GitHub commit failed:", error);
+    return { ok: false, error };
+  } catch (e) {
+    const error = e instanceof Error ? e.message : String(e);
+    console.error("GitHub commit threw:", error);
+    return { ok: false, error };
+  }
+}
+
+/**
+ * Build the `Warning` response header for a failed mirror. Returns an empty
+ * object when there's nothing to warn about.
+ *
+ * Header value follows RFC 7234 §5.5 (`warn-code SP warn-agent SP warn-text`).
+ * Backslashes and double-quotes inside the error string are escaped so the
+ * quoted-string parses cleanly regardless of the upstream error shape.
+ */
+export function mirrorWarningHeaders(
+  status: GithubMirrorStatus | null,
+): Record<string, string> {
+  if (!status || status.ok) return {};
+  const escaped = status.error.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return { Warning: `199 - "GitHub mirror failed: ${escaped}"` };
+}


### PR DESCRIPTION
## Summary

The public `/prompts` page is MDX-backed (`getContentList("prompts")` → `apps/broomva/content/prompts/*.mdx`). Admin POSTs/PUTs to `/api/prompts` create DB rows AND should mirror them back to MDX via `commitPromptToGitHub`. When that mirror fails (e.g., `GITHUB_TOKEN` missing — confirmed today: not set in any Vercel env), the routes were swallowing the failure with `console.error` and returning 200/201 OK. Admin-pushed prompts landed in DB only and never reached the page.

- Hardens POST + PUT to surface `githubMirror: { ok, error }` in the body + a sanitized `Warning:` header
- Extracts `lib/prompts/mirror.ts` with `try/catch` around `commitPromptToGitHub` so a thrown network/DNS/TLS error no longer 500s the route (and loses the successful DB write)
- Backfills two prompts already in DB but missing from MDX (`ai-native-platform-architect`, `bstack-native-ai-platform-architect`) — they appear on the live `/api/prompts` (31 entries) but not on the live page (29 entries) until this lands

Linear: [BRO-1181](https://linear.app/broomva/issue/BRO-1181)

## What changed

| File | Change |
|---|---|
| `apps/broomva/lib/prompts/mirror.ts` | **NEW** — `mirrorIfAdmin` (try/catch), `mirrorWarningHeaders` (ASCII-safe sanitizer) |
| `apps/broomva/app/api/prompts/route.ts` | POST uses the helper, response carries `githubMirror` + `Warning` |
| `apps/broomva/app/api/prompts/[slug]/route.ts` | PUT uses the helper, same shape |
| `apps/broomva/app/api/prompts/route.test.ts` | +5 POST tests (success / mirror-failure / non-admin / throw / CR-LF / Unicode) |
| `apps/broomva/app/api/prompts/[slug]/route.test.ts` | +5 PUT tests (same matrix) |
| `apps/broomva/content/prompts/ai-native-platform-architect.mdx` | **NEW** backfill |
| `apps/broomva/content/prompts/bstack-native-ai-platform-architect.mdx` | **NEW** backfill |

## Test plan

- [x] `bunx vitest run app/api/prompts/` — 19/19 unit tests pass
- [x] `bunx biome lint app/api/prompts/ lib/prompts/mirror.ts` — 0 errors
- [x] `bunx tsc --noEmit` — clean on changed files (pre-existing errors elsewhere unrelated)
- [ ] Vercel preview deploy — verify `/prompts` page renders 31 prompts (was 29)
- [ ] Vercel preview deploy — `curl preview/api/prompts/ai-native-platform-architect` returns body
- [ ] Post-merge — verify production `/prompts` page lists both backfilled prompts after Vercel deploy

## P20 cross-review verdict

Strata C (`pr-review-toolkit:silent-failure-hunter`) round 1 caught the **CRITICAL** missing `try/catch` around `commitPromptToGitHub` — a throw would have bypassed the new structured-failure contract and 500'd the response (ironic given the PR's purpose). Fixed in `34be30c` with `mirror.ts` extraction.

Strata A (Codex `gpt-5.4`) three rounds:
- **Round 1: 6/10 REVISE** — CR/LF in Warning header throws `Headers.append`
- **Round 2: 6/10 REVISE** — CR/LF fixed but Unicode/emoji still throws (Web Headers enforces ByteString)
- **Round 3: 8/10 APPROVE** — sanitizer now bounds to `[0x20, 0x7E]` before escape; full POST + PUT regression coverage for both CR/LF and Unicode

Each round's deductions were applied as fix-up commits (`34be30c`, `8af5091`, `c62a148`, `0181b5a`). Non-blocking note from Codex round 3: truncation after escape could leave a trailing odd `\` — bounded behaviour, doesn't crash, malformed-only. Filed for follow-up.

## Out of scope (filed as follow-ups)

- [BRO-1182](https://linear.app/broomva/issue/BRO-1182) — `buildMdx` interpolates YAML strings unescaped; admin titles with `"` or `\n` produce invalid MDX (mirror-success ≠ valid MDX). Caught by Codex round 1.
- [BRO-1183](https://linear.app/broomva/issue/BRO-1183) — CLI consumer (`broomva-cli`) ignores the new `githubMirror` field and `Warning` header; admin push still looks silent until this lands. Caught by silent-failure-hunter.
- [BRO-1184](https://linear.app/broomva/issue/BRO-1184) — Operator action: set `GITHUB_TOKEN` (Contents:Write on `broomva/broomva.tech`) in Vercel Production env. Until done, every admin push will surface `{ok:false, error:"GITHUB_TOKEN not set"}` — which is now correctly visible instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>