### PR TITLE
feat(api): /api/v1/messages Anthropic Messages edge endpoint [BRO-1209]

### DIFF
--- a/apps/broomva/app/api/v1/messages/__tests__/contract.test.ts
+++ b/apps/broomva/app/api/v1/messages/__tests__/contract.test.ts
@@ -1,0 +1,227 @@
+// Contract test: byte-faithful Anthropic SSE stream.
+//
+// The audit gate for PR-1 of BRO-1208. Translates a canned canonical
+// event stream into Anthropic SSE bytes and asserts the output matches
+// a hand-written fixture verbatim. Any deviation from the documented
+// Anthropic Messages API wire shape breaks this test — that's the
+// point.
+//
+// The fixture is hand-written (not vendored from `@anthropic-ai/sdk`)
+// because the SDK isn't a direct dependency of the broomva.tech app
+// (only `@ai-sdk/anthropic` is). Hand-writing also makes the fixture
+// self-documenting: every event in the expected output is visible in
+// this file and the assertion is a single string equality.
+//
+// What this test locks in:
+//   1. Event ORDER: message_start → content_block_start → ... → message_stop.
+//   2. Event NAMES: exact strings per Anthropic Messages API.
+//   3. Payload SHAPE: `type` / `index` / `delta` / `usage` / `stop_reason`
+//      fields with no extras and no missing keys.
+//   4. Wire FORMAT: `event: <name>\ndata: <json>\n\n` (no carriage returns,
+//      no leading BOM, JSON.stringify defaults).
+//
+// File under test: ../../../lib/life-runtime/edge-adapter/anthropic-sse.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import { canonicalToAnthropicSse } from "@/lib/life-runtime/edge-adapter/anthropic-sse";
+
+// ---------------------------------------------------------------------------
+// Helpers (duplicated minimally from anthropic-sse.test.ts to keep the
+// contract test self-contained — it must remain stable even if helpers
+// elsewhere are refactored).
+// ---------------------------------------------------------------------------
+
+async function* iterate(
+  events: CanonicalAgentEvent["event"][],
+): AsyncIterable<CanonicalAgentEvent> {
+  let i = 0n;
+  for (const ev of events) {
+    yield { seq: ++i, at: "2026-05-20T00:00:00.000Z", event: ev };
+  }
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  let done = false;
+  while (!done) {
+    const r = await reader.read();
+    done = r.done;
+    if (r.value) out += decoder.decode(r.value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical event stream — what a typical lifed agent run produces for a
+ * 2-token, text-only response. Mirrors what the SDK would see if hitting
+ * api.anthropic.com directly for "Hello, world!" output.
+ */
+const CANONICAL_TEXT_ONLY: CanonicalAgentEvent["event"][] = [
+  { kind: "token", delta: "Hello, " },
+  { kind: "token", delta: "world!" },
+  {
+    kind: "finish",
+    reason: "stop",
+    usage: { inputTokens: 10, outputTokens: 5 },
+  },
+];
+
+/**
+ * Expected byte-for-byte SSE wire output for the canonical stream above.
+ *
+ * The Anthropic Messages API publishes these event shapes — see
+ *   https://docs.claude.com/en/api/messages
+ * for the canonical reference. The fields, types, and ordering below
+ * are the documented contract; the only flex is the `id` and `model`
+ * strings which we control at the call site.
+ *
+ * Newlines are explicit `\n` so the assertion fails legibly on any
+ * extra/missing whitespace.
+ */
+const EXPECTED_TEXT_ONLY_WIRE =
+  // 1. message_start — opens the message envelope.
+  "event: message_start\n" +
+  'data: {"type":"message_start",' +
+  '"message":{"id":"msg_FIXTURE_001",' +
+  '"type":"message",' +
+  '"role":"assistant",' +
+  '"content":[],' +
+  '"model":"claude-sonnet-4-20250514",' +
+  '"stop_reason":null,' +
+  '"stop_sequence":null,' +
+  '"usage":{"input_tokens":0,"output_tokens":0}}}\n\n' +
+  // 2. content_block_start (text @ index 0).
+  "event: content_block_start\n" +
+  'data: {"type":"content_block_start",' +
+  '"index":0,' +
+  '"content_block":{"type":"text","text":""}}\n\n' +
+  // 3. content_block_delta — first token.
+  "event: content_block_delta\n" +
+  'data: {"type":"content_block_delta",' +
+  '"index":0,' +
+  '"delta":{"type":"text_delta","text":"Hello, "}}\n\n' +
+  // 4. content_block_delta — second token.
+  "event: content_block_delta\n" +
+  'data: {"type":"content_block_delta",' +
+  '"index":0,' +
+  '"delta":{"type":"text_delta","text":"world!"}}\n\n' +
+  // 5. content_block_stop — close text block.
+  "event: content_block_stop\n" +
+  'data: {"type":"content_block_stop","index":0}\n\n' +
+  // 6. message_delta — final stop_reason + usage.
+  "event: message_delta\n" +
+  'data: {"type":"message_delta",' +
+  '"delta":{"stop_reason":"end_turn","stop_sequence":null},' +
+  '"usage":{"input_tokens":10,"output_tokens":5}}\n\n' +
+  // 7. message_stop — terminator.
+  "event: message_stop\n" +
+  'data: {"type":"message_stop"}\n\n';
+
+/**
+ * Canonical event stream for a tool-use round-trip.
+ *
+ * The motivating alpine-cabin use case: agent issues an `update_cabin_params`
+ * tool call mid-response. The client parses the tool_use block, applies
+ * the update, and (in a follow-up turn) sends a tool_result back.
+ *
+ * For this stream we test the tool_use emission only — the tool_result
+ * round-trip lands in a future test once D3 ships.
+ */
+const CANONICAL_TOOL_USE: CanonicalAgentEvent["event"][] = [
+  { kind: "token", delta: "Sure — " },
+  {
+    kind: "tool_call_pending",
+    call: {
+      callId: "toolu_01ABCdef",
+      toolName: "update_cabin_params",
+      inputJson: '{"updates":{"platform.width_m":3.5}}',
+      requestedCapabilities: [],
+    },
+  },
+  { kind: "finish", reason: "tool_use" },
+];
+
+const EXPECTED_TOOL_USE_WIRE =
+  "event: message_start\n" +
+  'data: {"type":"message_start",' +
+  '"message":{"id":"msg_FIXTURE_002",' +
+  '"type":"message",' +
+  '"role":"assistant",' +
+  '"content":[],' +
+  '"model":"claude-opus-4-20250514",' +
+  '"stop_reason":null,' +
+  '"stop_sequence":null,' +
+  '"usage":{"input_tokens":0,"output_tokens":0}}}\n\n' +
+  // Text block opens for "Sure — ".
+  "event: content_block_start\n" +
+  'data: {"type":"content_block_start",' +
+  '"index":0,' +
+  '"content_block":{"type":"text","text":""}}\n\n' +
+  "event: content_block_delta\n" +
+  'data: {"type":"content_block_delta",' +
+  '"index":0,' +
+  '"delta":{"type":"text_delta","text":"Sure — "}}\n\n' +
+  // Text block closes before tool block opens.
+  "event: content_block_stop\n" +
+  'data: {"type":"content_block_stop","index":0}\n\n' +
+  // tool_use block @ index 1.
+  "event: content_block_start\n" +
+  'data: {"type":"content_block_start",' +
+  '"index":1,' +
+  '"content_block":{"type":"tool_use",' +
+  '"id":"toolu_01ABCdef",' +
+  '"name":"update_cabin_params",' +
+  '"input":{}}}\n\n' +
+  // input_json_delta carries the structured payload.
+  "event: content_block_delta\n" +
+  'data: {"type":"content_block_delta",' +
+  '"index":1,' +
+  '"delta":{"type":"input_json_delta",' +
+  '"partial_json":"{\\"updates\\":{\\"platform.width_m\\":3.5}}"}}\n\n' +
+  // Close tool_use block.
+  "event: content_block_stop\n" +
+  'data: {"type":"content_block_stop","index":1}\n\n' +
+  // message_delta carries `stop_reason: tool_use` per Anthropic convention.
+  "event: message_delta\n" +
+  'data: {"type":"message_delta",' +
+  '"delta":{"stop_reason":"tool_use","stop_sequence":null},' +
+  '"usage":{"input_tokens":0,"output_tokens":0}}\n\n' +
+  "event: message_stop\n" +
+  'data: {"type":"message_stop"}\n\n';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("contract — Anthropic SSE wire-byte equivalence", () => {
+  it("text-only stream matches the fixture verbatim", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate(CANONICAL_TEXT_ONLY),
+      "claude-sonnet-4-20250514",
+      "msg_FIXTURE_001",
+    );
+    const wire = await drain(stream);
+    expect(wire).toBe(EXPECTED_TEXT_ONLY_WIRE);
+  });
+
+  it("tool-use stream matches the fixture verbatim", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate(CANONICAL_TOOL_USE),
+      "claude-opus-4-20250514",
+      "msg_FIXTURE_002",
+    );
+    const wire = await drain(stream);
+    expect(wire).toBe(EXPECTED_TOOL_USE_WIRE);
+  });
+});

--- a/apps/broomva/app/api/v1/messages/__tests__/route.test.ts
+++ b/apps/broomva/app/api/v1/messages/__tests__/route.test.ts
@@ -1,0 +1,561 @@
+// Integration tests for POST /api/v1/messages.
+//
+// We mock:
+//   - `LifedWsAgentSessionClient` — via the `__setSessionClientFactoryForTests`
+//     seam exported from the route module.
+//   - `@/lib/auth` — `getSafeSession` returns whatever the test sets.
+//   - `@/lib/ai/vault/jwt` — `verifyLifeJWT` returns a fake claim or null.
+//   - `@/lib/auth/lifegw-jwt` — `mintTier1ForConsumer` returns a fake cap.
+//
+// The mocks let us exercise the full route handler without standing up
+// lifegw, Neon Auth, or the JWT signer.
+//
+// File under test: ../route.ts
+
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// 1. Auth-related modules. Each must be mocked BEFORE the route imports
+//    them at module load time. The vi.mock factory hoists to the top
+//    of the file, so the mock functions must be created INSIDE the
+//    factory and then re-exported via `vi.hoisted` for per-test
+//    overrides. `vi.hoisted` is the documented escape hatch for
+//    shared state across hoisted factories.
+const mocks = vi.hoisted(() => ({
+  getSafeSession: vi.fn(),
+  verifyLifeJWT: vi.fn(),
+  mintTier1ForConsumer: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSafeSession: mocks.getSafeSession,
+  hasNeonAuth: false,
+  auth: {},
+}));
+
+vi.mock("@/lib/ai/vault/jwt", () => ({
+  verifyLifeJWT: mocks.verifyLifeJWT,
+  JWT_ACCESS_EXPIRY_MS: 24 * 60 * 60 * 1000,
+  JWT_REFRESH_EXPIRY_MS: 7 * 24 * 60 * 60 * 1000,
+  generateRefreshToken: () => "ref",
+  hashRefreshToken: (s: string) => s,
+  signLifeJWT: async () => "fake-jwt",
+}));
+
+vi.mock("@/lib/auth/lifegw-jwt", () => ({
+  mintTier1ForConsumer: mocks.mintTier1ForConsumer,
+}));
+
+// 2. `next/headers` — `getSafeSession`'s mock above doesn't actually
+//    use the headers, but the route awaits `headers()` regardless.
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
+// Aliases for legibility — these still point at the same vi.fn instances
+// the mocks were registered with.
+const mockGetSafeSession = mocks.getSafeSession;
+const mockVerifyLifeJWT = mocks.verifyLifeJWT;
+const mockMintTier1 = mocks.mintTier1ForConsumer;
+
+import type { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type {
+  AgentStreamInput,
+  CanonicalAgentEvent,
+} from "@/lib/life-runtime/agent-session/types";
+// 3. Bring in the route AFTER all mocks are registered.
+import { __setSessionClientFactoryForTests, POST } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fake LifedWsAgentSessionClient
+// ---------------------------------------------------------------------------
+
+interface FakeOpts {
+  /** Events the stream should yield. Defaults to a single token + finish. */
+  events?: CanonicalAgentEvent["event"][];
+  /** If set, createSession throws this. */
+  createSessionError?: Error;
+  /** Captured createSession input — populated on call. */
+  createSessionCalls?: Array<{ resumeSid?: string; userId: string }>;
+  /** Captured stream input — populated on call. */
+  streamCalls?: AgentStreamInput[];
+}
+
+function makeFakeClient(opts: FakeOpts): LifedWsAgentSessionClient {
+  const events = opts.events ?? [
+    { kind: "token", delta: "Hello!" },
+    { kind: "finish", reason: "stop" },
+  ];
+  const fake = {
+    backendId: "lifed-ws" as const,
+    async createSession(input: {
+      capability: { token: string };
+      userId: string;
+      projectSlug: string;
+      resumeSid?: string;
+    }) {
+      if (opts.createSessionError) throw opts.createSessionError;
+      opts.createSessionCalls?.push({
+        resumeSid: input.resumeSid,
+        userId: input.userId,
+      });
+      return {
+        sid: input.resumeSid ?? "fresh-sid",
+        agentId: `agent_${input.userId}`,
+        userId: input.userId,
+        projectId: input.projectSlug,
+        createdAtUnix: Math.floor(Date.now() / 1000),
+      };
+    },
+    async sendMessage() {},
+    async health() {
+      return { backendId: "lifed-ws", reachable: true };
+    },
+    async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
+      opts.streamCalls?.push(input);
+      let i = 0n;
+      for (const ev of events) {
+        yield { seq: ++i, at: new Date().toISOString(), event: ev };
+      }
+    },
+  };
+  return fake as unknown as LifedWsAgentSessionClient;
+}
+
+// ---------------------------------------------------------------------------
+// Request helper
+// ---------------------------------------------------------------------------
+
+function makeRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): import("next/server").NextRequest {
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  };
+  // NextRequest extends Request — we cast to satisfy the route's
+  // `NextRequest` parameter type. The route only reads `.headers`,
+  // `.json()`, and `.signal`, all of which Request supports.
+  return new Request(
+    "https://broomva.tech/api/v1/messages",
+    init,
+  ) as unknown as import("next/server").NextRequest;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGetSafeSession.mockReset();
+  mockVerifyLifeJWT.mockReset();
+  mockMintTier1.mockReset();
+  // Default behaviours — overridden per-test as needed.
+  mockGetSafeSession.mockResolvedValue({ data: null, error: null });
+  mockVerifyLifeJWT.mockResolvedValue(null);
+  mockMintTier1.mockResolvedValue({
+    token: "fake-tier1-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 900,
+  });
+  vi.stubEnv("LIFED_GATEWAY_URL", "https://gw.example.test");
+});
+
+afterEach(() => {
+  __setSessionClientFactoryForTests(undefined);
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/messages — auth", () => {
+  it("returns 401 with Anthropic error envelope when no auth", async () => {
+    const req = makeRequest({
+      model: "claude-3.5-sonnet",
+      messages: [{ role: "user", content: "Hi" }],
+      max_tokens: 100,
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(401);
+    const body = (await resp.json()) as {
+      type: string;
+      error: { type: string; message: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("authentication_error");
+  });
+
+  it("returns 401 when bearer token verification fails", async () => {
+    mockVerifyLifeJWT.mockResolvedValue(null);
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer bad-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(401);
+  });
+
+  it("accepts valid bearer token and proceeds to lifed", async () => {
+    mockVerifyLifeJWT.mockResolvedValue({
+      sub: "user_alice",
+      email: "alice@test",
+    });
+    const createSessionCalls: Array<{ resumeSid?: string; userId: string }> =
+      [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer good-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls[0].userId).toBe("user_alice");
+    // mintTier1 was called to convert the HS256 caller token into the
+    // ES256 lifegw cap.
+    expect(mockMintTier1).toHaveBeenCalledWith({
+      consumer: { kind: "user", id: "user_alice" },
+      projectSlug: "default",
+    });
+  });
+
+  it("accepts Neon Auth session when no bearer header is present", async () => {
+    mockGetSafeSession.mockResolvedValue({
+      data: { user: { id: "user_bob", email: "bob@test" } },
+      error: null,
+    });
+    const createSessionCalls: Array<{ resumeSid?: string; userId: string }> =
+      [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+    const req = makeRequest({
+      model: "claude-3.5-sonnet",
+      messages: [{ role: "user", content: "Hi" }],
+      max_tokens: 100,
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(createSessionCalls[0].userId).toBe("user_bob");
+  });
+});
+
+describe("POST /api/v1/messages — model resolution", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({
+      sub: "user_alice",
+      email: "alice@test",
+    });
+  });
+
+  it("returns 400 with model_not_supported on unknown model", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-9000-imagined",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer good-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as {
+      type: string;
+      error: { type: string; message: string };
+    };
+    expect(body.type).toBe("error");
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.message).toContain("model_not_supported");
+    expect(body.error.message).toContain("claude-9000-imagined");
+  });
+
+  it("accepts both namespaced and bare model ids", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const baseBody = {
+      messages: [{ role: "user", content: "Hi" }],
+      max_tokens: 100,
+    };
+    const r1 = await POST(
+      makeRequest(
+        { ...baseBody, model: "anthropic/claude-3.5-sonnet" },
+        { authorization: "Bearer x" },
+      ),
+    );
+    const r2 = await POST(
+      makeRequest(
+        { ...baseBody, model: "claude-3.5-sonnet" },
+        { authorization: "Bearer x" },
+      ),
+    );
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+
+describe("POST /api/v1/messages — request validation", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns 400 on empty messages[]", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 when last message is not a user message", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hello" },
+        ],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 on missing required field", async () => {
+    const req = makeRequest(
+      { model: "claude-3.5-sonnet" },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+});
+
+describe("POST /api/v1/messages — sticky session id", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("re-uses the same sid for two requests with the same prefix", async () => {
+    const createSessionCalls: Array<{ resumeSid?: string; userId: string }> =
+      [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+
+    const sharedPrefix = [
+      { role: "user", content: "Tell me about cats." },
+      { role: "assistant", content: "Cats are mammals." },
+    ];
+
+    await POST(
+      makeRequest(
+        {
+          model: "claude-3.5-sonnet",
+          messages: [...sharedPrefix, { role: "user", content: "More?" }],
+          max_tokens: 100,
+        },
+        { authorization: "Bearer x" },
+      ),
+    );
+    await POST(
+      makeRequest(
+        {
+          model: "claude-3.5-sonnet",
+          messages: [
+            ...sharedPrefix,
+            { role: "user", content: "Different follow-up." },
+          ],
+          max_tokens: 100,
+        },
+        { authorization: "Bearer x" },
+      ),
+    );
+
+    expect(createSessionCalls).toHaveLength(2);
+    expect(createSessionCalls[0].resumeSid).toBeDefined();
+    expect(createSessionCalls[0].resumeSid).toBe(
+      createSessionCalls[1].resumeSid,
+    );
+  });
+});
+
+describe("POST /api/v1/messages — non-stream response", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns an Anthropic-shape JSON envelope when stream=false", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          { kind: "token", delta: "Hello, " },
+          { kind: "token", delta: "world!" },
+          {
+            kind: "finish",
+            reason: "stop",
+            usage: { inputTokens: 10, outputTokens: 5 },
+          },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Greet me" }],
+        max_tokens: 100,
+        stream: false,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toContain("application/json");
+    const body = (await resp.json()) as {
+      type: string;
+      role: string;
+      content: Array<{ type: string; text?: string }>;
+      model: string;
+      stop_reason: string;
+      usage: { input_tokens: number; output_tokens: number };
+    };
+    expect(body.type).toBe("message");
+    expect(body.role).toBe("assistant");
+    expect(body.content).toHaveLength(1);
+    expect(body.content[0].type).toBe("text");
+    expect(body.content[0].text).toBe("Hello, world!");
+    expect(body.model).toBe("claude-3.5-sonnet");
+    expect(body.stop_reason).toBe("end_turn");
+    expect(body.usage.input_tokens).toBe(10);
+    expect(body.usage.output_tokens).toBe(5);
+  });
+});
+
+describe("POST /api/v1/messages — streaming response", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns text/event-stream when stream=true", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          { kind: "token", delta: "Hi!" },
+          { kind: "finish", reason: "stop" },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Greet" }],
+        max_tokens: 100,
+        stream: true,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(resp.headers.get("Cache-Control")).toContain("no-cache");
+
+    // Drain the body and confirm it contains the expected Anthropic event names.
+    const text = await resp.text();
+    expect(text).toContain("event: message_start");
+    expect(text).toContain("event: content_block_start");
+    expect(text).toContain("event: content_block_delta");
+    expect(text).toContain("event: content_block_stop");
+    expect(text).toContain("event: message_delta");
+    expect(text).toContain("event: message_stop");
+    expect(text).toContain('"text":"Hi!"');
+  });
+});
+
+describe("POST /api/v1/messages — error mapping", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns 503 when LIFED_GATEWAY_URL is unset", async () => {
+    vi.stubEnv("LIFED_GATEWAY_URL", "");
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(503);
+  });
+
+  it("returns 502 when createSession throws a generic error", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        createSessionError: new Error("connect ECONNREFUSED"),
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 100,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(502);
+  });
+
+  it("returns a non-2xx Anthropic error envelope when lifed yields an error event (non-stream path)", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          {
+            kind: "error",
+            code: "lifed-ws.transport_error",
+            message: "lifed went away",
+          },
+          { kind: "finish", reason: "error" },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 100,
+        stream: false,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBeGreaterThanOrEqual(400);
+    const body = (await resp.json()) as { type: string; error: unknown };
+    expect(body.type).toBe("error");
+  });
+});

--- a/apps/broomva/app/api/v1/messages/route.ts
+++ b/apps/broomva/app/api/v1/messages/route.ts
@@ -1,0 +1,477 @@
+/**
+ * `POST /api/v1/messages` — Anthropic Messages API edge endpoint.
+ *
+ * First sub-PR of BRO-1208 — closes the gap between the existing
+ * `/api/chat` (Arcan-direct, Vercel-AI-SDK shape) and the canonical
+ * lifegw-routed agent stack. Off-the-shelf `@anthropic-ai/sdk` callers
+ * (browser, CLI, third-party) can point at this URL and get byte-faithful
+ * Anthropic SSE.
+ *
+ * Architecture (per the spec):
+ *
+ *   client ─POST /api/v1/messages──┐
+ *                                   │
+ *                  ┌────────────────▼────────────────┐
+ *                  │ resolveEdgeAuth                  │
+ *                  │   (Tier-1 header OR Neon Auth    │
+ *                  │    session → mint lifegw cap)    │
+ *                  └────────────────┬────────────────┘
+ *                                   │
+ *                                   ▼
+ *                          resolveModel(req.model)
+ *                                   │
+ *                                   ▼
+ *                       buildStickySessionId(msgs)
+ *                                   │
+ *                                   ▼
+ *                    LifedWsAgentSessionClient
+ *                       .createSession(resume_sid=sid)
+ *                       .stream({ sessionId=sid, ... })
+ *                                   │
+ *                                   ▼
+ *                    canonicalToAnthropicSse(...)
+ *                                   │
+ *                                   ▼
+ *                          Anthropic SSE stream
+ *
+ * Out of scope (PR-3 territory): per-tier credit gate, tool flag gating,
+ * MCP injection. Those belong on `/api/chat` (the in-app surface), not
+ * this external API.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ */
+
+import "server-only";
+import { type NextRequest, NextResponse } from "next/server";
+import { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import { canonicalToAnthropicSse } from "@/lib/life-runtime/edge-adapter/anthropic-sse";
+import { resolveEdgeAuth } from "@/lib/life-runtime/edge-adapter/auth";
+import { buildStickySessionId } from "@/lib/life-runtime/edge-adapter/build-session-id";
+import { resolveModel } from "@/lib/life-runtime/edge-adapter/model-registry";
+import type {
+  AnthropicErrorBody,
+  AnthropicMessage,
+  AnthropicMessagesRequest,
+  AnthropicMessagesResponse,
+  AnthropicStopReason,
+  AnthropicTextContentBlock,
+  AnthropicToolUseContentBlock,
+  EdgeAuthContext,
+} from "@/lib/life-runtime/edge-adapter/types";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Factory injection point for tests. Production code lets this be
+ * `undefined`; tests pass a mock client via the symbol on the route
+ * module. Kept module-local (not exported as a route handler concern)
+ * so production callers see the simple `POST` export.
+ */
+type SessionClientFactory = (baseUrl: string) => LifedWsAgentSessionClient;
+let testClientFactory: SessionClientFactory | undefined;
+
+/**
+ * Test-only hook — installs a mock `LifedWsAgentSessionClient` factory
+ * for the next call. The test file imports this symbol and calls it in
+ * `beforeEach`; the route reads `testClientFactory` lazily so the
+ * normal export shape stays clean.
+ */
+export function __setSessionClientFactoryForTests(
+  factory: SessionClientFactory | undefined,
+): void {
+  testClientFactory = factory;
+}
+
+function getBaseUrl(): string | null {
+  const url = process.env.LIFED_GATEWAY_URL;
+  return url && url.length > 0 ? url : null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function errorBody(
+  type: AnthropicErrorBody["error"]["type"],
+  message: string,
+): AnthropicErrorBody {
+  return { type: "error", error: { type, message } };
+}
+
+function errorJson(
+  type: AnthropicErrorBody["error"]["type"],
+  message: string,
+  status: number,
+): NextResponse {
+  return NextResponse.json(errorBody(type, message), { status });
+}
+
+/**
+ * Pull plain text out of an Anthropic content array. The Messages API
+ * lets `content` be either a raw `string` or an array of structured
+ * blocks; for the user-message we forward downstream, we concatenate
+ * text-block bodies and drop tool/image blocks. (Tool-result round-trip
+ * is the spec D3 concern — out of scope for PR-1.)
+ */
+function extractText(content: AnthropicMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && block.type === "text") {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("");
+}
+
+function isAnthropicMessagesRequest(v: unknown): v is AnthropicMessagesRequest {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.model === "string" &&
+    Array.isArray(r.messages) &&
+    typeof r.max_tokens === "number"
+  );
+}
+
+function validateRequest(
+  body: unknown,
+):
+  | { ok: true; req: AnthropicMessagesRequest }
+  | { ok: false; status: number; message: string } {
+  if (!isAnthropicMessagesRequest(body)) {
+    return {
+      ok: false,
+      status: 400,
+      message:
+        "Request body must be an Anthropic Messages API object with `model`, `messages`, and `max_tokens`.",
+    };
+  }
+  if (body.messages.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      message: "messages must not be empty.",
+    };
+  }
+  const last = body.messages[body.messages.length - 1];
+  if (!last || last.role !== "user") {
+    return {
+      ok: false,
+      status: 400,
+      message:
+        "The final entry in messages must have role 'user' (the current turn).",
+    };
+  }
+  if (body.max_tokens <= 0 || !Number.isFinite(body.max_tokens)) {
+    return {
+      ok: false,
+      status: 400,
+      message: "max_tokens must be a positive integer.",
+    };
+  }
+  return { ok: true, req: body };
+}
+
+/**
+ * Map a lifed-ws error code (yielded as a CanonicalAgentEvent.error) to
+ * an HTTP status. Used by the non-stream code path; the streaming path
+ * lets the canonical→SSE translator surface errors as `event: error`
+ * inside the stream instead.
+ */
+function statusFromLifedErrorCode(code: string): number {
+  if (code.startsWith("lifed-ws.auth")) return 401;
+  if (code.startsWith("lifed-ws.ip_blocked")) return 403;
+  if (code === "lifed-ws.aborted") return 499; // client-cancelled
+  if (code.startsWith("lifed-ws.transient_4002")) return 429;
+  if (code.startsWith("lifed-ws.transient_4004")) return 502;
+  if (code.startsWith("lifed-ws.transient_")) return 503;
+  if (code.startsWith("lifed-ws.unexpected_")) return 502;
+  if (code.startsWith("lifed-ws.sequence_retired")) return 410;
+  return 500;
+}
+
+function statusFromCreateSessionError(err: unknown): number {
+  if (err && typeof err === "object" && "httpStatus" in err) {
+    const s = (err as { httpStatus?: number }).httpStatus;
+    if (typeof s === "number") {
+      // The lifegw HTTP/JSON wrapper already maps tonic codes to HTTP
+      // statuses (see `crates/life-runtime/lifegw/src/services/agent_http.rs`),
+      // so we just forward what it returned.
+      return s;
+    }
+  }
+  return 502;
+}
+
+// ---------------------------------------------------------------------------
+// POST handler
+// ---------------------------------------------------------------------------
+
+export async function POST(req: NextRequest): Promise<Response> {
+  // 1. Parse + validate request body.
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (err) {
+    return errorJson(
+      "invalid_request_error",
+      `Failed to parse JSON body: ${(err as Error).message}`,
+      400,
+    );
+  }
+  const validated = validateRequest(body);
+  if (!validated.ok) {
+    return errorJson(
+      "invalid_request_error",
+      validated.message,
+      validated.status,
+    );
+  }
+  const messagesRequest = validated.req;
+
+  // 2. Resolve model.
+  const resolved = resolveModel(messagesRequest.model);
+  if (!resolved) {
+    return errorJson(
+      "invalid_request_error",
+      `model_not_supported: ${messagesRequest.model}`,
+      400,
+    );
+  }
+
+  // 3. Resolve auth (header bearer first, then Neon Auth session).
+  const auth = await resolveEdgeAuth(req);
+  if (auth instanceof NextResponse) {
+    return auth;
+  }
+  const authCtx: EdgeAuthContext = auth;
+
+  // 4. Confirm lifegw is configured. In dev without LIFED_GATEWAY_URL
+  //    we return 503 rather than silently falling back to InProcess —
+  //    this is the external edge surface; in-process makes no sense
+  //    here (no auth chain, no observability, no billing).
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return errorJson(
+      "api_error",
+      "lifegw is not configured for this deployment (LIFED_GATEWAY_URL unset).",
+      503,
+    );
+  }
+
+  // 5. Compute sticky session id.
+  const sid = buildStickySessionId(messagesRequest.messages);
+
+  // 6. Construct the lifed WS client.
+  const client = testClientFactory
+    ? testClientFactory(baseUrl)
+    : new LifedWsAgentSessionClient({ baseUrl });
+
+  // 7. Open the lifed session (resume sticky sid if it already exists,
+  //    else lifed creates fresh).
+  try {
+    await client.createSession({
+      capability: { token: authCtx.tier1Token },
+      userId: authCtx.userId,
+      projectSlug: authCtx.projectId,
+      resumeSid: sid,
+      signal: req.signal,
+    });
+  } catch (err) {
+    const status = statusFromCreateSessionError(err);
+    const message = err instanceof Error ? err.message : String(err);
+    const type =
+      status === 401 || status === 403
+        ? "authentication_error"
+        : status === 429
+          ? "rate_limit_error"
+          : status >= 500
+            ? "api_error"
+            : "invalid_request_error";
+    return errorJson(type, `Failed to open lifed session: ${message}`, status);
+  }
+
+  // 8. Open the streaming turn. PR-1 uses per-turn mode — each
+  //    request opens a single-turn stream and closes. Multi-turn
+  //    continuity is provided by the sticky sid + lifed's session
+  //    cache, not by an open WS that spans HTTP requests.
+  const lastMessage =
+    messagesRequest.messages[messagesRequest.messages.length - 1];
+  const latestUserText = extractText(lastMessage.content);
+  const requestId = `msg_${randomId()}`;
+
+  const streamIter = client.stream({
+    sessionId: sid,
+    agentId: `user:${authCtx.userId}`,
+    projectSlug: authCtx.projectId,
+    userMessage: latestUserText,
+    history: [], // lifed accumulates server-side via the sticky sid.
+    kernelCtx: {
+      sessionId: sid,
+      agentId: `user:${authCtx.userId}`,
+    },
+    capability: {
+      token: authCtx.tier1Token,
+      // expiresAt is informational on the client; lifegw owns enforcement.
+      expiresAt: Math.floor(Date.now() / 1000) + 60 * 15,
+    },
+    signal: req.signal,
+  });
+
+  // 9. Either stream as SSE or buffer for non-stream response.
+  if (messagesRequest.stream === true) {
+    const sseBody = canonicalToAnthropicSse(
+      streamIter,
+      resolved.anthropicId,
+      requestId,
+    );
+    return new Response(sseBody, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  // Non-stream: buffer the canonical events into a single JSON response.
+  return await bufferToNonStreamResponse(
+    streamIter,
+    resolved.anthropicId,
+    requestId,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Non-stream buffering — collects all events into a single JSON envelope.
+// ---------------------------------------------------------------------------
+
+async function bufferToNonStreamResponse(
+  events: AsyncIterable<CanonicalAgentEvent>,
+  modelId: string,
+  requestId: string,
+): Promise<Response> {
+  const content: Array<
+    AnthropicTextContentBlock | AnthropicToolUseContentBlock
+  > = [];
+  let textBuffer = "";
+  let stopReason: AnthropicStopReason = "end_turn";
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  try {
+    for await (const envelope of events) {
+      const ev = envelope.event;
+      switch (ev.kind) {
+        case "token":
+          textBuffer += ev.delta;
+          break;
+        case "tool_call_pending": {
+          // Flush any buffered text before recording the tool block.
+          if (textBuffer.length > 0) {
+            content.push({ type: "text", text: textBuffer });
+            textBuffer = "";
+          }
+          let parsedInput: Record<string, unknown> = {};
+          try {
+            parsedInput = ev.call.inputJson
+              ? (JSON.parse(ev.call.inputJson) as Record<string, unknown>)
+              : {};
+          } catch {
+            parsedInput = {};
+          }
+          content.push({
+            type: "tool_use",
+            id: ev.call.callId || `toolu_${randomId()}`,
+            name: ev.call.toolName || "unknown_tool",
+            input: parsedInput,
+          });
+          stopReason = "tool_use";
+          break;
+        }
+        case "finish":
+          if (ev.usage) {
+            inputTokens = ev.usage.inputTokens ?? 0;
+            outputTokens = ev.usage.outputTokens ?? 0;
+          }
+          stopReason = mapFinishReasonForBuffer(ev.reason, stopReason);
+          break;
+        case "error": {
+          // Mid-stream lifed error — surface as a non-2xx Anthropic
+          // error envelope.
+          const status = statusFromLifedErrorCode(ev.code || "");
+          const type =
+            status === 401 || status === 403
+              ? "authentication_error"
+              : status === 429
+                ? "rate_limit_error"
+                : "api_error";
+          return errorJson(
+            type,
+            ev.message || ev.code || "lifed-ws stream errored",
+            status,
+          );
+        }
+        default:
+          // Telemetry events — ignore for the non-stream response.
+          break;
+      }
+    }
+  } catch (err) {
+    return errorJson(
+      "api_error",
+      `lifed-ws stream failed: ${(err as Error).message}`,
+      500,
+    );
+  }
+
+  if (textBuffer.length > 0) {
+    content.push({ type: "text", text: textBuffer });
+  }
+
+  const resp: AnthropicMessagesResponse = {
+    id: requestId,
+    type: "message",
+    role: "assistant",
+    content,
+    model: modelId,
+    stop_reason: stopReason,
+    stop_sequence: null,
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+  };
+  return NextResponse.json(resp, { status: 200 });
+}
+
+function mapFinishReasonForBuffer(
+  reason: string | undefined,
+  current: AnthropicStopReason,
+): AnthropicStopReason {
+  switch (reason) {
+    case "stop":
+    case "end_turn":
+      return current === "tool_use" ? "tool_use" : "end_turn";
+    case "max_tokens":
+      return "max_tokens";
+    case "stop_sequence":
+      return "stop_sequence";
+    case "tool_use":
+      return "tool_use";
+    default:
+      return current;
+  }
+}
+
+function randomId(): string {
+  // 22 url-safe-ish chars — collision-resistant enough for ids that
+  // are only meaningful within a single request lifecycle.
+  return (
+    Math.random().toString(36).slice(2, 12) +
+    Math.random().toString(36).slice(2, 12)
+  );
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/anthropic-sse.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/anthropic-sse.test.ts
@@ -1,0 +1,377 @@
+// Unit tests for the canonical → Anthropic SSE translator.
+//
+// Covers:
+//   1. Each canonical agent_kind translates to the documented Anthropic
+//      event with the correct payload shape.
+//   2. The wire envelope is `event: <name>\ndata: <json>\n\n` (no extra
+//      whitespace, no leading BOM).
+//   3. content_block_start opens BEFORE the first delta; content_block_stop
+//      closes after the last delta; message_delta + message_stop
+//      terminate cleanly.
+//   4. ERROR aborts the stream — no terminal message_delta is emitted.
+//   5. Tool-use round-trip: content_block_start (tool_use) → optional
+//      input_json_delta → content_block_stop → stop_reason: tool_use.
+//
+// File under test: ../anthropic-sse.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import { canonicalToAnthropicSse, encodeSseEvent } from "../anthropic-sse";
+import type { AnthropicStreamEvent } from "../types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function envelope(
+  seq: bigint,
+  event: CanonicalAgentEvent["event"],
+): CanonicalAgentEvent {
+  return { seq, at: "2026-05-20T00:00:00Z", event };
+}
+
+async function* iterate(
+  events: CanonicalAgentEvent["event"][],
+): AsyncIterable<CanonicalAgentEvent> {
+  let i = 0n;
+  for (const ev of events) {
+    yield envelope(++i, ev);
+  }
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  let done = false;
+  while (!done) {
+    const r = await reader.read();
+    done = r.done;
+    if (r.value) out += decoder.decode(r.value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+/**
+ * Parse the wire output back into the structured event list. Each event
+ * block ends with `\n\n`; events with empty `data` (impossible in our
+ * encoder, but defensive) are skipped.
+ */
+function parseSseStream(wire: string): AnthropicStreamEvent[] {
+  const blocks = wire.split("\n\n").filter((b) => b.length > 0);
+  const out: AnthropicStreamEvent[] = [];
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    let dataLine = "";
+    let eventLine = "";
+    for (const line of lines) {
+      if (line.startsWith("data: ")) dataLine = line.slice("data: ".length);
+      else if (line.startsWith("event: "))
+        eventLine = line.slice("event: ".length);
+    }
+    if (dataLine.length === 0) continue;
+    const parsed = JSON.parse(dataLine) as AnthropicStreamEvent;
+    // Sanity: the `event:` line MUST match the `type` field inside `data:`.
+    expect(parsed.type).toBe(eventLine);
+    out.push(parsed);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — wire envelope shape
+// ---------------------------------------------------------------------------
+
+describe("encodeSseEvent — wire-byte shape", () => {
+  it("emits `event: <name>\\ndata: <json>\\n\\n`", () => {
+    const out = encodeSseEvent({ type: "message_stop" });
+    expect(out).toBe('event: message_stop\ndata: {"type":"message_stop"}\n\n');
+  });
+
+  it("emits exact JSON (no pretty-print)", () => {
+    const out = encodeSseEvent({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "Hello" },
+    });
+    expect(out).toContain('"index":0');
+    // No newlines INSIDE the JSON; only the two terminators.
+    expect(out.split("\n\n").length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — happy-path streams
+// ---------------------------------------------------------------------------
+
+describe("canonicalToAnthropicSse — token-only stream", () => {
+  it("emits message_start → content_block_start → deltas → content_block_stop → message_delta → message_stop", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate([
+        { kind: "token", delta: "Hello, " },
+        { kind: "token", delta: "world!" },
+        {
+          kind: "finish",
+          reason: "stop",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      ]),
+      "claude-sonnet-4-20250514",
+      "msg_test123",
+    );
+    const wire = await drain(stream);
+    const events = parseSseStream(wire);
+
+    expect(events.map((e) => e.type)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+
+    // message_start envelope.
+    const start = events[0] as Extract<
+      AnthropicStreamEvent,
+      { type: "message_start" }
+    >;
+    expect(start.message.id).toBe("msg_test123");
+    expect(start.message.model).toBe("claude-sonnet-4-20250514");
+    expect(start.message.role).toBe("assistant");
+    expect(start.message.type).toBe("message");
+    expect(start.message.content).toEqual([]);
+    expect(start.message.stop_reason).toBeNull();
+    expect(start.message.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+    });
+
+    // content_block_start (text, index 0).
+    const cbStart = events[1] as Extract<
+      AnthropicStreamEvent,
+      { type: "content_block_start" }
+    >;
+    expect(cbStart.index).toBe(0);
+    expect(cbStart.content_block).toEqual({ type: "text", text: "" });
+
+    // Token deltas.
+    const d1 = events[2] as Extract<
+      AnthropicStreamEvent,
+      { type: "content_block_delta" }
+    >;
+    expect(d1.index).toBe(0);
+    expect(d1.delta).toEqual({ type: "text_delta", text: "Hello, " });
+    const d2 = events[3] as Extract<
+      AnthropicStreamEvent,
+      { type: "content_block_delta" }
+    >;
+    expect(d2.delta).toEqual({ type: "text_delta", text: "world!" });
+
+    // content_block_stop, message_delta, message_stop.
+    const cbStop = events[4] as Extract<
+      AnthropicStreamEvent,
+      { type: "content_block_stop" }
+    >;
+    expect(cbStop.index).toBe(0);
+    const msgDelta = events[5] as Extract<
+      AnthropicStreamEvent,
+      { type: "message_delta" }
+    >;
+    expect(msgDelta.delta.stop_reason).toBe("end_turn");
+    expect(msgDelta.usage).toEqual({ input_tokens: 10, output_tokens: 5 });
+    expect(events[6].type).toBe("message_stop");
+  });
+});
+
+describe("canonicalToAnthropicSse — tool-call streams", () => {
+  it("emits content_block_start of type tool_use, optional input_json_delta, then content_block_stop", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate([
+        { kind: "token", delta: "Let me check." },
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "toolu_abc123",
+            toolName: "update_cabin_params",
+            inputJson: '{"updates":{"platform.width_m":3.5}}',
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "claude-opus-4-20250514",
+      "msg_tool_test",
+    );
+    const wire = await drain(stream);
+    const events = parseSseStream(wire);
+
+    expect(events.map((e) => e.type)).toEqual([
+      "message_start",
+      "content_block_start", // text @ 0
+      "content_block_delta", // text_delta @ 0
+      "content_block_stop", // close text @ 0
+      "content_block_start", // tool_use @ 1
+      "content_block_delta", // input_json_delta @ 1
+      "content_block_stop", // close tool_use @ 1
+      "message_delta",
+      "message_stop",
+    ]);
+
+    // Tool_use start carries id + name + empty input.
+    const toolStart = events[4] as Extract<
+      AnthropicStreamEvent,
+      { type: "content_block_start" }
+    >;
+    expect(toolStart.index).toBe(1);
+    expect(toolStart.content_block).toEqual({
+      type: "tool_use",
+      id: "toolu_abc123",
+      name: "update_cabin_params",
+      input: {},
+    });
+
+    // input_json_delta carries the partial_json payload.
+    const inputDelta = events[5] as Extract<
+      AnthropicStreamEvent,
+      { type: "content_block_delta" }
+    >;
+    expect(inputDelta.index).toBe(1);
+    expect(inputDelta.delta).toEqual({
+      type: "input_json_delta",
+      partial_json: '{"updates":{"platform.width_m":3.5}}',
+    });
+
+    // message_delta.stop_reason is `tool_use`.
+    const msgDelta = events[7] as Extract<
+      AnthropicStreamEvent,
+      { type: "message_delta" }
+    >;
+    expect(msgDelta.delta.stop_reason).toBe("tool_use");
+  });
+
+  it("skips the input_json_delta when inputJson is empty/`{}`", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate([
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "toolu_x",
+            toolName: "no_args",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "claude-sonnet-4",
+      "msg_no_input",
+    );
+    const wire = await drain(stream);
+    const events = parseSseStream(wire);
+    // No input_json_delta — just start/stop for the tool block.
+    const types = events.map((e) => e.type);
+    expect(types).toEqual([
+      "message_start",
+      "content_block_start", // tool_use @ 0
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — error path
+// ---------------------------------------------------------------------------
+
+describe("canonicalToAnthropicSse — error event", () => {
+  it("emits `event: error` and does NOT emit message_delta/message_stop", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate([
+        { kind: "token", delta: "Partial " },
+        {
+          kind: "error",
+          code: "lifed-ws.transport_error",
+          message: "socket closed unexpectedly",
+        },
+      ]),
+      "claude-3.5-sonnet",
+      "msg_err",
+    );
+    const wire = await drain(stream);
+    const events = parseSseStream(wire);
+
+    // message_start → text block start → text delta → text block stop → error.
+    expect(events.map((e) => e.type)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "error",
+    ]);
+    const errEv = events[4] as Extract<AnthropicStreamEvent, { type: "error" }>;
+    expect(errEv.error.type).toBe("api_error");
+    expect(errEv.error.message).toBe("socket closed unexpectedly");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — telemetry events drop silently
+// ---------------------------------------------------------------------------
+
+describe("canonicalToAnthropicSse — telemetry events are dropped", () => {
+  it("ignores warning / haima_billed / vigil_span / nous_score / etc.", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate([
+        { kind: "warning", code: "stale", message: "minor" },
+        {
+          kind: "haima_billed",
+          microcredits: 1000,
+          rail: "credits",
+        },
+        { kind: "vigil_span", name: "inference", durationMs: 12, status: "ok" },
+        { kind: "token", delta: "ok" },
+        { kind: "finish", reason: "stop" },
+      ]),
+      "claude-3.5-sonnet",
+      "msg_telemetry",
+    );
+    const wire = await drain(stream);
+    const events = parseSseStream(wire);
+    expect(events.map((e) => e.type)).toEqual([
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — empty stream
+// ---------------------------------------------------------------------------
+
+describe("canonicalToAnthropicSse — empty body", () => {
+  it("emits message_start → message_delta → message_stop when finish is the only event", async () => {
+    const stream = canonicalToAnthropicSse(
+      iterate([{ kind: "finish", reason: "stop" }]),
+      "claude-3.5-sonnet",
+      "msg_empty",
+    );
+    const wire = await drain(stream);
+    const events = parseSseStream(wire);
+    expect(events.map((e) => e.type)).toEqual([
+      "message_start",
+      "message_delta",
+      "message_stop",
+    ]);
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/build-session-id.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/build-session-id.test.ts
@@ -1,0 +1,136 @@
+// Unit tests for the sticky-session id derivation.
+//
+// Covers the D1 contract:
+//   1. Same prefix (everything except the latest message) → same sid,
+//      regardless of what the latest message is.
+//   2. Different prefix → different sid.
+//   3. First-turn calls (length ≤ 1) include the latest message in the
+//      hash so distinct openers don't collide.
+//   4. Output is 32 hex characters (truncated SHA-256).
+//   5. Canonical-JSON serialisation: client-side key reordering does NOT
+//      change the sid.
+//
+// File under test: ../build-session-id.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { buildStickySessionId } from "../build-session-id";
+import type { AnthropicMessage } from "../types";
+
+const helloUser: AnthropicMessage = { role: "user", content: "Hello." };
+const greetingAssistant: AnthropicMessage = {
+  role: "assistant",
+  content: "Hi! How can I help?",
+};
+const followupUser: AnthropicMessage = {
+  role: "user",
+  content: "Tell me a joke.",
+};
+const otherFollowup: AnthropicMessage = {
+  role: "user",
+  content: "What's the weather?",
+};
+
+describe("buildStickySessionId — output shape", () => {
+  it("returns 32 lowercase hex characters", () => {
+    const sid = buildStickySessionId([helloUser]);
+    expect(sid).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("returns a non-empty hex string for an empty messages array", () => {
+    // Defensive: even though the route rejects empty messages, the
+    // hash function itself should not throw.
+    const sid = buildStickySessionId([]);
+    expect(sid).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("buildStickySessionId — multi-turn continuity (D1 core)", () => {
+  it("produces the SAME sid for two turns sharing the same prefix", () => {
+    // Conversation: user → assistant → user. Second user message
+    // varies but the prefix [user, assistant] is identical.
+    const sidA = buildStickySessionId([
+      helloUser,
+      greetingAssistant,
+      followupUser,
+    ]);
+    const sidB = buildStickySessionId([
+      helloUser,
+      greetingAssistant,
+      otherFollowup,
+    ]);
+    expect(sidA).toBe(sidB);
+  });
+
+  it("produces DIFFERENT sids when the prefix differs", () => {
+    // Two distinct conversations — different first user message →
+    // different prefix → different sid.
+    const sidA = buildStickySessionId([
+      helloUser,
+      greetingAssistant,
+      followupUser,
+    ]);
+    const sidB = buildStickySessionId([
+      { role: "user", content: "Something totally different." },
+      greetingAssistant,
+      followupUser,
+    ]);
+    expect(sidA).not.toBe(sidB);
+  });
+
+  it("first-turn calls with the same single message collapse to the same sid", () => {
+    // Two cold-opens with identical first message → same sticky sid →
+    // lifed sees the resume hit and re-attaches the existing session.
+    // This is the deduplication property the spec calls out: a CLI tool
+    // accidentally re-firing the same first turn doesn't waste a new
+    // session.
+    const sidA = buildStickySessionId([helloUser]);
+    const sidB = buildStickySessionId([helloUser]);
+    expect(sidA).toBe(sidB);
+  });
+
+  it("first-turn calls with different messages produce different sids", () => {
+    // Empty prefix BUT we mix in the latest message — so two fresh
+    // conversations with distinct openers don't collide.
+    const sidA = buildStickySessionId([helloUser]);
+    const sidB = buildStickySessionId([
+      { role: "user", content: "Different opener." },
+    ]);
+    expect(sidA).not.toBe(sidB);
+  });
+
+  it("zero-message array does not throw, returns a stable constant", () => {
+    const sidA = buildStickySessionId([]);
+    const sidB = buildStickySessionId([]);
+    expect(sidA).toBe(sidB);
+  });
+});
+
+describe("buildStickySessionId — canonical JSON (key-order independence)", () => {
+  it("key-reordered prefix messages produce the same sid", () => {
+    // Some clients build message objects via `{role: ..., content: ...}`
+    // while others build via `{content: ..., role: ...}`. Both should
+    // hash identically.
+    const msgA: AnthropicMessage = { role: "user", content: "Hi" };
+    const msgB = { content: "Hi", role: "user" } as AnthropicMessage;
+    const sidA = buildStickySessionId([msgA, greetingAssistant, followupUser]);
+    const sidB = buildStickySessionId([msgB, greetingAssistant, followupUser]);
+    expect(sidA).toBe(sidB);
+  });
+
+  it("structured content blocks with reordered keys hash identically", () => {
+    const msgA: AnthropicMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Hi" }],
+    };
+    const msgB = {
+      role: "user",
+      content: [{ text: "Hi", type: "text" }],
+    } as AnthropicMessage;
+    const sidA = buildStickySessionId([msgA, greetingAssistant, followupUser]);
+    const sidB = buildStickySessionId([msgB, greetingAssistant, followupUser]);
+    expect(sidA).toBe(sidB);
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/model-registry.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/model-registry.test.ts
@@ -1,0 +1,89 @@
+// Unit tests for edge-adapter model resolution.
+//
+// Covers D2:
+//   1. Namespaced form (`anthropic/claude-3.5-sonnet`) resolves.
+//   2. Un-namespaced form (`claude-3.5-sonnet`) resolves.
+//   3. Date-snapshot form (`claude-sonnet-4-20250514`) resolves to the
+//      latest-by-base entry when the dated id isn't directly in the
+//      registry, OR to the dated entry when it IS.
+//   4. Unknown id → null (route turns this into a 400).
+//   5. Malformed inputs (empty, double-prefixed, cross-provider) → null.
+//
+// File under test: ../model-registry.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { resolveModel } from "../model-registry";
+
+describe("resolveModel — namespaced + un-namespaced forms", () => {
+  it("accepts the bare anthropic id `claude-3.5-sonnet`", () => {
+    const r = resolveModel("claude-3.5-sonnet");
+    expect(r).not.toBeNull();
+    expect(r!.canonical).toBe("anthropic/claude-3.5-sonnet");
+    expect(r!.anthropicId).toBe("claude-3.5-sonnet");
+  });
+
+  it("accepts the namespaced form `anthropic/claude-3.5-sonnet`", () => {
+    const r = resolveModel("anthropic/claude-3.5-sonnet");
+    expect(r).not.toBeNull();
+    expect(r!.canonical).toBe("anthropic/claude-3.5-sonnet");
+    expect(r!.anthropicId).toBe("claude-3.5-sonnet");
+  });
+
+  it("accepts a model that's directly registered with a date suffix", () => {
+    // `anthropic/claude-3.5-sonnet-20240620` is in the registry as-is.
+    const r = resolveModel("claude-3.5-sonnet-20240620");
+    expect(r).not.toBeNull();
+    expect(r!.canonical).toBe("anthropic/claude-3.5-sonnet-20240620");
+    expect(r!.anthropicId).toBe("claude-3.5-sonnet-20240620");
+  });
+});
+
+describe("resolveModel — date-suffix fallback", () => {
+  it("strips a trailing -YYYYMMDD to find the base entry", () => {
+    // The registry tracks `anthropic/claude-sonnet-4` (no date), but
+    // the caller sends today's snapshot id `claude-sonnet-4-20250514`.
+    // We resolve to the base canonical id and preserve the dated id
+    // as `anthropicId`.
+    const r = resolveModel("claude-sonnet-4-20250514");
+    expect(r).not.toBeNull();
+    expect(r!.canonical).toBe("anthropic/claude-sonnet-4");
+    // anthropicId preserves the snapshot.
+    expect(r!.anthropicId).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("works with the namespaced + dated form too", () => {
+    const r = resolveModel("anthropic/claude-opus-4-20250514");
+    expect(r).not.toBeNull();
+    expect(r!.canonical).toBe("anthropic/claude-opus-4");
+    expect(r!.anthropicId).toBe("claude-opus-4-20250514");
+  });
+});
+
+describe("resolveModel — unknown / malformed inputs", () => {
+  it("returns null for an unknown id", () => {
+    expect(resolveModel("claude-9000-imagined")).toBeNull();
+  });
+
+  it("returns null for cross-provider namespaced ids", () => {
+    expect(resolveModel("openai/gpt-4o")).toBeNull();
+  });
+
+  it("returns null for double-prefixed ids", () => {
+    expect(resolveModel("anthropic/anthropic/claude-3.5-sonnet")).toBeNull();
+  });
+
+  it("returns null for empty / non-string input", () => {
+    expect(resolveModel("")).toBeNull();
+    // @ts-expect-error — runtime guard test
+    expect(resolveModel(undefined)).toBeNull();
+    // @ts-expect-error — runtime guard test
+    expect(resolveModel(null)).toBeNull();
+  });
+
+  it("returns null for an id that's only the namespace prefix", () => {
+    expect(resolveModel("anthropic/")).toBeNull();
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/anthropic-sse.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/anthropic-sse.ts
@@ -1,0 +1,392 @@
+/**
+ * `CanonicalAgentEvent` → Anthropic Messages SSE byte translator.
+ *
+ * Emits the EXACT byte sequence the official `@anthropic-ai/sdk` parser
+ * expects (per the public Messages API docs + the spec's wire-mapping
+ * table). Off-the-shelf SDK clients can point at this endpoint and the
+ * stream parses byte-faithfully.
+ *
+ * Wire shape (Anthropic Messages API):
+ *
+ *   event: message_start
+ *   data: { "type": "message_start", "message": { id, type, role, content,
+ *                                                  model, stop_reason: null,
+ *                                                  stop_sequence: null, usage } }
+ *
+ *   ( per content block — text or tool_use )
+ *     event: content_block_start
+ *     data: { "type": "content_block_start", "index": <i>,
+ *             "content_block": { "type": "text" | "tool_use", … } }
+ *
+ *     event: content_block_delta
+ *     data: { "type": "content_block_delta", "index": <i>,
+ *             "delta": { "type": "text_delta" | "input_json_delta", … } }
+ *     … repeats …
+ *
+ *     event: content_block_stop
+ *     data: { "type": "content_block_stop", "index": <i> }
+ *
+ *   event: message_delta
+ *   data: { "type": "message_delta",
+ *           "delta": { "stop_reason": "end_turn", "stop_sequence": null },
+ *           "usage": { input_tokens, output_tokens } }
+ *
+ *   event: message_stop
+ *   data: { "type": "message_stop" }
+ *
+ * On error mid-stream:
+ *
+ *   event: error
+ *   data: { "type": "error", "error": { "type": "api_error", "message": "…" } }
+ *
+ * Each frame is `event: <name>\ndata: <json>\n\n` — the standard SSE
+ * format. Comment-pings can be inserted with `: ping\n\n` but we don't
+ * emit any in v1 (no heartbeat needed for the typical sub-30-second
+ * Messages turn).
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ *       (§"Wire shape — Anthropic Messages API")
+ */
+
+import "server-only";
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import type {
+  AnthropicStopReason,
+  AnthropicStreamEvent,
+  AnthropicUsage,
+} from "./types";
+
+/**
+ * Encode one Anthropic SSE event as the canonical 3-line wire form.
+ *
+ * Exported for unit tests that want to assert byte-faithfulness against
+ * a fixture. Production code calls `canonicalToAnthropicSse` instead.
+ */
+export function encodeSseEvent(event: AnthropicStreamEvent): string {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+/**
+ * Translate a `CanonicalAgentEvent` async iterable into an Anthropic
+ * Messages SSE byte stream.
+ *
+ * State machine: we open at most ONE text block per stream (the first
+ * TOKEN opens index 0, subsequent TOKENs append). Tool-use blocks each
+ * occupy their own index, opened on TOOL_CALL_PENDING and closed when
+ * a non-input-delta event lands. On FINISH we close any open block,
+ * emit message_delta + message_stop. On ERROR we emit an `error` event
+ * and stop.
+ *
+ * `modelId` is what we echo back in the `message_start.message.model`
+ * field — should be the caller's original `model` request param so the
+ * SDK sees the id it asked for.
+ *
+ * `requestId` is the `msg_*` id we emit in `message_start.message.id`.
+ * Callers typically use a freshly-generated UUID; collisions across
+ * sessions are not load-bearing for Anthropic SDK correctness.
+ */
+export function canonicalToAnthropicSse(
+  events: AsyncIterable<CanonicalAgentEvent>,
+  modelId: string,
+  requestId: string,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const enqueue = (event: AnthropicStreamEvent) => {
+        controller.enqueue(encoder.encode(encodeSseEvent(event)));
+      };
+
+      // 1. message_start — always first, full envelope shape.
+      const usage: AnthropicUsage = { input_tokens: 0, output_tokens: 0 };
+      enqueue({
+        type: "message_start",
+        message: {
+          id: requestId,
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: modelId,
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { ...usage },
+        },
+      });
+
+      // 2. Stream body — tokens, tool calls, finish, errors.
+      const state: BlockState = {
+        textIndex: null,
+        toolBlocks: new Map<string, { index: number }>(),
+        nextIndex: 0,
+      };
+      let stopReason: AnthropicStopReason = "end_turn";
+      let errored = false;
+      let finalUsage: AnthropicUsage = { ...usage };
+
+      try {
+        for await (const evt of events) {
+          const result = handleEvent(evt, state, enqueue);
+          if (result.errored) {
+            errored = true;
+            break;
+          }
+          if (result.finishReason) {
+            stopReason = result.finishReason;
+          }
+          if (result.usage) {
+            finalUsage = result.usage;
+          }
+          if (result.terminal) {
+            break;
+          }
+        }
+      } catch (err) {
+        // Iterator threw — surface as a terminal error event so the SDK
+        // sees a structured failure instead of a stream hang.
+        const message = err instanceof Error ? err.message : String(err);
+        enqueue({
+          type: "error",
+          error: { type: "api_error", message },
+        });
+        controller.close();
+        return;
+      }
+
+      // 3. Close any still-open content blocks (defensive — should have
+      //    been closed by handleEvent on FINISH/ERROR transitions).
+      closeOpenBlocks(state, enqueue);
+
+      if (errored) {
+        // The error event itself was already emitted by handleEvent;
+        // do NOT emit message_delta/message_stop in that case — the
+        // Anthropic SDK treats `event: error` as terminal.
+        controller.close();
+        return;
+      }
+
+      // 4. message_delta + message_stop — terminal pair.
+      enqueue({
+        type: "message_delta",
+        delta: { stop_reason: stopReason, stop_sequence: null },
+        usage: finalUsage,
+      });
+      enqueue({ type: "message_stop" });
+      controller.close();
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Implementation detail
+// ---------------------------------------------------------------------------
+
+interface BlockState {
+  /**
+   * The currently-open text block's index, or `null` if no text block
+   * is open. Anthropic streams typically use a SINGLE text block per
+   * message (index 0), reopened only after a tool_use round-trip.
+   */
+  textIndex: number | null;
+  /**
+   * Map of tool-call id → assigned index. Tool blocks each get their
+   * own index, opened on TOOL_CALL_PENDING and tracked here so subsequent
+   * `input_json_delta` frames go to the right index.
+   */
+  toolBlocks: Map<string, { index: number }>;
+  /** Monotonic index counter. */
+  nextIndex: number;
+}
+
+interface HandleResult {
+  /** When set, finalises `stop_reason` for the terminal message_delta. */
+  finishReason?: AnthropicStopReason;
+  /** When set, finalises `usage` for the terminal message_delta. */
+  usage?: AnthropicUsage;
+  /** When true, an error event was emitted; skip the terminal pair. */
+  errored?: boolean;
+  /** When true, stop iterating (FINISH lands here). */
+  terminal?: boolean;
+}
+
+function handleEvent(
+  envelope: CanonicalAgentEvent,
+  state: BlockState,
+  enqueue: (e: AnthropicStreamEvent) => void,
+): HandleResult {
+  const ev = envelope.event;
+
+  switch (ev.kind) {
+    case "token": {
+      const delta = ev.delta;
+      if (!delta) return {};
+      // Lazily open the text block on first token.
+      if (state.textIndex === null) {
+        // If a tool block is currently open, close it before opening
+        // text — Anthropic's content_block model is sequential.
+        closeOpenTools(state, enqueue);
+        const idx = state.nextIndex++;
+        state.textIndex = idx;
+        enqueue({
+          type: "content_block_start",
+          index: idx,
+          content_block: { type: "text", text: "" },
+        });
+      }
+      enqueue({
+        type: "content_block_delta",
+        index: state.textIndex,
+        delta: { type: "text_delta", text: delta },
+      });
+      return {};
+    }
+
+    case "tool_call_pending": {
+      const call = ev.call;
+      const callId = call.callId || synthCallId();
+      const name = call.toolName || "unknown_tool";
+      // Closing the text block before opening a tool block keeps the
+      // Anthropic SDK's content array linear (text — tool_use — text…).
+      if (state.textIndex !== null) {
+        enqueue({ type: "content_block_stop", index: state.textIndex });
+        state.textIndex = null;
+      }
+      const idx = state.nextIndex++;
+      state.toolBlocks.set(callId, { index: idx });
+      // tool_use blocks start with an empty `input` object; the schema
+      // populates via input_json_delta frames that the SDK reassembles.
+      enqueue({
+        type: "content_block_start",
+        index: idx,
+        content_block: {
+          type: "tool_use",
+          id: callId,
+          name,
+          input: {},
+        },
+      });
+      // If lifed already gave us the full input as JSON, stream it as
+      // a single input_json_delta. The SDK reassembles correctly either
+      // way — partial or whole.
+      if (call.inputJson && call.inputJson !== "{}") {
+        enqueue({
+          type: "content_block_delta",
+          index: idx,
+          delta: { type: "input_json_delta", partial_json: call.inputJson },
+        });
+      }
+      // Close immediately — lifed currently emits TOOL_CALL_PENDING as
+      // a single complete event; no incremental input streaming. If
+      // that changes in a future spec, this site adds a stateful
+      // accumulator.
+      enqueue({ type: "content_block_stop", index: idx });
+      state.toolBlocks.delete(callId);
+      // A tool-use call implies the assistant's turn ends here pending
+      // a tool_result — `stop_reason: tool_use` is the Anthropic
+      // convention for that.
+      return { finishReason: "tool_use" };
+    }
+
+    case "finish": {
+      // Close any still-open blocks before we emit the terminal pair.
+      closeOpenBlocks(state, enqueue);
+      const usage = ev.usage;
+      return {
+        finishReason: mapFinishReason(ev.reason),
+        usage: usage
+          ? {
+              input_tokens: usage.inputTokens ?? 0,
+              output_tokens: usage.outputTokens ?? 0,
+            }
+          : undefined,
+        terminal: true,
+      };
+    }
+
+    case "error": {
+      // Close anything open, then emit a terminal `error` event. We
+      // do NOT also emit message_delta/message_stop — `event: error`
+      // is itself the terminator on the SDK side.
+      closeOpenBlocks(state, enqueue);
+      enqueue({
+        type: "error",
+        error: {
+          type: "api_error",
+          message: ev.message || ev.code || "unknown error",
+        },
+      });
+      return { errored: true, terminal: true };
+    }
+
+    // The following events are runtime telemetry that don't map onto
+    // any Anthropic SSE event — drop silently. Future versions could
+    // emit them as `ping` events with metadata if the SDK ever grows
+    // a hook for them.
+    case "text_start":
+    case "text_end":
+    case "thinking_start":
+    case "thinking_end":
+    case "tool_result":
+    case "approval_required":
+    case "fs_op":
+    case "nous_score":
+    case "autonomic":
+    case "haima_billed":
+    case "vigil_span":
+    case "warning":
+    case "turn_end":
+    case "open":
+      return {};
+    default: {
+      // Exhaustive guard — `ev` should be `never` here. If the canonical
+      // event type grows a new variant, TS forces us to handle it.
+      const _exhaustive: never = ev;
+      void _exhaustive;
+      return {};
+    }
+  }
+}
+
+function closeOpenBlocks(
+  state: BlockState,
+  enqueue: (e: AnthropicStreamEvent) => void,
+): void {
+  closeOpenTools(state, enqueue);
+  if (state.textIndex !== null) {
+    enqueue({ type: "content_block_stop", index: state.textIndex });
+    state.textIndex = null;
+  }
+}
+
+function closeOpenTools(
+  state: BlockState,
+  enqueue: (e: AnthropicStreamEvent) => void,
+): void {
+  for (const { index } of state.toolBlocks.values()) {
+    enqueue({ type: "content_block_stop", index });
+  }
+  state.toolBlocks.clear();
+}
+
+function mapFinishReason(reason: string | undefined): AnthropicStopReason {
+  switch (reason) {
+    case "stop":
+    case "end_turn":
+      return "end_turn";
+    case "max_tokens":
+      return "max_tokens";
+    case "stop_sequence":
+      return "stop_sequence";
+    case "tool_use":
+      return "tool_use";
+    default:
+      return "end_turn";
+  }
+}
+
+function synthCallId(): string {
+  // tool_use ids should be globally unique; if lifed didn't supply one
+  // (defensive), fall back to a synthesised id with the Anthropic-style
+  // `toolu_` prefix the SDK expects.
+  return `toolu_${Math.random().toString(36).slice(2, 12)}`;
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/auth.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/auth.ts
@@ -1,0 +1,149 @@
+/**
+ * Edge auth resolution for `/api/v1/messages` (and, in PR-2, the OpenAI
+ * route).
+ *
+ * Decision D5 (locked in PR-1 of BRO-1208): exactly TWO accepted auth
+ * sources, in priority order:
+ *
+ *   1. `Authorization: Bearer <jwt>` header — for CLI / SDK / BROOMVA_TOKEN
+ *      callers. Verified via `verifyLifeJWT` (HS256, broomva.tech-issued
+ *      access_token from `/api/auth/api-token` or `/api/auth/device/token`).
+ *   2. Neon Auth session cookie — for browser callers from `broomva.tech`,
+ *      `www.broomva.tech`, `broomva.github.io`, etc.
+ *
+ * Whichever path resolves the user, we then mint a FRESH ES256 lifegw
+ * Tier-1 cap via `mintTier1ForConsumer` and forward THAT downstream. The
+ * caller's HS256 token never leaves the edge — lifegw only ever sees the
+ * ES256 cap signed with the key published at `/api/auth/jwks.json`.
+ * This matches the spec's "mints a tier-1 JWT internally, and forwards"
+ * and keeps the surface area for token-handling bugs minimal.
+ *
+ * Anonymous calls are explicitly NOT supported (spec line 115).
+ *
+ * Returns either an `EdgeAuthContext` ready for the route to use, OR a
+ * `NextResponse` with the Anthropic-shape error envelope already set —
+ * the route just `return`s it.
+ */
+
+import "server-only";
+import { headers } from "next/headers";
+import { type NextRequest, NextResponse } from "next/server";
+import { verifyLifeJWT } from "@/lib/ai/vault/jwt";
+import { getSafeSession } from "@/lib/auth";
+import { mintTier1ForConsumer } from "@/lib/auth/lifegw-jwt";
+import type { AnthropicErrorBody, EdgeAuthContext } from "./types";
+
+/**
+ * Default project slug attached to the Tier-1 mint when the caller
+ * didn't explicitly scope to a project. `/api/v1/messages` is a global
+ * edge endpoint, not project-scoped, so "default" is the right tag —
+ * downstream consumers can re-scope on session creation.
+ */
+const DEFAULT_PROJECT_SLUG = "default";
+
+function authError(message: string, status: number): NextResponse {
+  const body: AnthropicErrorBody = {
+    type: "error",
+    error: {
+      type: status === 401 ? "authentication_error" : "permission_error",
+      message,
+    },
+  };
+  return NextResponse.json(body, { status });
+}
+
+/**
+ * Resolve a per-request auth context. Either returns a populated
+ * `EdgeAuthContext` (the caller is authenticated and we have a fresh
+ * lifegw Tier-1 cap ready to forward) OR a 401 `NextResponse` shaped
+ * as an Anthropic error envelope.
+ *
+ * The function never throws on auth-related failures — it returns the
+ * 401 response so the caller code path stays linear (`if (instanceof
+ * NextResponse) return ctx;`).
+ */
+export async function resolveEdgeAuth(
+  req: NextRequest,
+): Promise<EdgeAuthContext | NextResponse> {
+  // 1. Bearer header takes precedence over session cookie. CLI / SDK
+  //    callers and browser callers that ALSO have a session cookie set
+  //    (e.g. someone debugging from the broomva.tech tab) should use
+  //    the bearer they explicitly attached — that's the lower-friction
+  //    auth path and the one their API client expects.
+  const bearer = extractBearer(req);
+  if (bearer) {
+    const claims = await verifyLifeJWT(bearer);
+    if (!claims) {
+      return authError(
+        "Invalid or expired bearer token (HS256 verify against AUTH_SECRET failed)",
+        401,
+      );
+    }
+    return mintAndReturn(claims.sub, "header");
+  }
+
+  // 2. Fall back to Neon Auth session cookie (browser flow). We read
+  //    headers explicitly because Next 15's `getSafeSession` wants the
+  //    fetchOptions threaded through; on the edge route the
+  //    `headers()` helper returns the inbound request headers.
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  if (session?.user?.id) {
+    return mintAndReturn(session.user.id, "session");
+  }
+
+  return authError(
+    "Authentication required: provide an Authorization: Bearer header or sign in at broomva.tech.",
+    401,
+  );
+}
+
+/**
+ * Mint a fresh ES256 lifegw Tier-1 cap for the resolved user and pack
+ * it into an `EdgeAuthContext`. Mint failures are surfaced as 500s —
+ * the most likely cause is the operator forgetting to set
+ * `LIFEGW_TIER1_SIGNING_JWK` in production (see `lifegw-jwt.ts` for
+ * the explicit error message).
+ */
+async function mintAndReturn(
+  userId: string,
+  source: EdgeAuthContext["source"],
+): Promise<EdgeAuthContext | NextResponse> {
+  try {
+    const cap = await mintTier1ForConsumer({
+      consumer: { kind: "user", id: userId },
+      projectSlug: DEFAULT_PROJECT_SLUG,
+    });
+    return {
+      tier1Token: cap.token,
+      userId,
+      projectId: DEFAULT_PROJECT_SLUG,
+      source,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const body: AnthropicErrorBody = {
+      type: "error",
+      error: {
+        type: "api_error",
+        message: `Failed to mint internal lifegw cap: ${message}`,
+      },
+    };
+    return NextResponse.json(body, { status: 500 });
+  }
+}
+
+/**
+ * Parse a `Bearer <token>` header. Returns `null` for any malformed or
+ * missing header — the route should NOT treat that as an auth error
+ * directly; the session-cookie fallback runs after.
+ */
+function extractBearer(req: NextRequest): string | null {
+  const raw = req.headers.get("authorization");
+  if (!raw) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(raw.trim());
+  if (!m) return null;
+  const tok = m[1].trim();
+  return tok.length > 0 ? tok : null;
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/build-session-id.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/build-session-id.ts
@@ -1,0 +1,96 @@
+/**
+ * Sticky-session derivation for the `/api/v1/messages` edge endpoint.
+ *
+ * Decision D1 (locked in PR-1 of BRO-1208): the Anthropic + OpenAI wire
+ * shapes don't carry a `session_id` field, but lifed's WS bridge needs a
+ * stable sid per conversation (the routing cache populates on
+ * `Agent.CreateSession`, then `Agent.StreamSession` matches against it).
+ *
+ * The trick: hash everything in `messages[]` EXCEPT the latest entry. The
+ * latest entry is the user's current turn; everything before it is the
+ * conversation history. Two requests in the same conversation differ only
+ * in the latest entry; both produce the SAME prefix hash; both resolve to
+ * the same sid. A brand-new conversation has either an empty prefix
+ * (first turn — single user message) or a different prefix; new sid.
+ *
+ * The hash input is canonical-serialised JSON so the same logical messages
+ * always produce the same byte sequence (Node's JSON.stringify is stable
+ * for objects with the same key insertion order; we sort keys explicitly
+ * to be safe against client-side key reordering).
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ *       (Decision D1 — sticky-session hash strategy)
+ */
+
+import "server-only";
+import { createHash } from "node:crypto";
+import type { AnthropicMessage } from "./types";
+
+/**
+ * Compute the sticky session id for a request.
+ *
+ * - If `messages.length === 0` or `messages.length === 1`, the prefix is
+ *   empty and the hash collapses to a single deterministic constant. That
+ *   constant is acceptable as the sid for the FIRST turn of a brand-new
+ *   conversation — lifed will create a fresh session on `resume_sid` miss.
+ *   But two distinct first-turn conversations would collide on this sid,
+ *   so when `messages.length <= 1` we mix in a SECOND hash domain — the
+ *   latest message content itself — so distinct opens get distinct sids.
+ *
+ *   For `messages.length >= 2`, the prefix `messages[:-1]` is the
+ *   stable carrier across turns; the latest entry varies but is excluded
+ *   from the hash. Subsequent turns reuse the same sid.
+ *
+ * - Returns 32 hex characters (truncated SHA-256). That's 128 bits of
+ *   entropy — enough to avoid collisions across billions of sessions and
+ *   short enough to stay readable in logs.
+ */
+export function buildStickySessionId(messages: AnthropicMessage[]): string {
+  const prefix = messages.slice(0, Math.max(0, messages.length - 1));
+
+  const h = createHash("sha256");
+  if (prefix.length === 0) {
+    // First turn of a brand-new conversation. The latest message is the
+    // ONLY signal we have — mix it in so distinct openers don't collide.
+    // The downstream lifed Agent.CreateSession sees this as a `resume_sid`
+    // and either resumes an existing session (re-open with the same first
+    // user message) or creates a fresh one (`not_found`).
+    h.update("anthropic-messages-v1:cold-open\n");
+    const last = messages[messages.length - 1];
+    if (last) {
+      h.update(canonicalize(last));
+    }
+  } else {
+    h.update("anthropic-messages-v1:prefix\n");
+    for (const m of prefix) {
+      h.update(canonicalize(m));
+      h.update("\n");
+    }
+  }
+
+  return h.digest("hex").slice(0, 32);
+}
+
+/**
+ * Canonical JSON serialiser — sorts object keys recursively so the same
+ * logical value produces the same byte sequence regardless of client-side
+ * key ordering. Arrays preserve order (semantically meaningful).
+ */
+function canonicalize(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = sortKeys(obj[key]);
+    }
+    return out;
+  }
+  return value;
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/model-registry.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/model-registry.ts
@@ -1,0 +1,97 @@
+/**
+ * Model-id resolution for the edge adapter.
+ *
+ * Decision D2 (locked in PR-1 of BRO-1208): the adapter accepts BOTH
+ * `claude-sonnet-4-20250514` (raw Anthropic id) AND
+ * `anthropic/claude-sonnet-4-20250514` (namespaced, AI-SDK-gateway style).
+ * Either form normalises to a single canonical id; unknown ids return
+ * `null` and the route surfaces a 400 with the Anthropic-shape error body.
+ *
+ * The match strategy:
+ *
+ *   1. Strip a single leading `anthropic/` prefix if present.
+ *   2. Try exact match against `models.generated.ts` (the registry uses
+ *      the `anthropic/<id>` form natively, so we prepend the prefix
+ *      back on lookup).
+ *   3. If no exact hit AND the id has a trailing `-YYYYMMDD` date stamp
+ *      (the canonical Anthropic naming scheme — see model snapshots like
+ *      `claude-sonnet-4-20250514`), try the date-stripped form. This lets
+ *      callers send today's dated id while the registry tracks the
+ *      latest-by-base form.
+ *
+ * The returned `anthropicId` is what the caller sent (post-prefix-strip)
+ * — preserving the snapshot date downstream consumers may care about.
+ * The returned `canonical` is the registry hit (used for billing /
+ * observability tags).
+ */
+
+import "server-only";
+import {
+  generatedForGateway,
+  models as generatedModels,
+} from "@/lib/ai/models.generated";
+
+/** Set of registry-known canonical ids (e.g. `anthropic/claude-sonnet-4`). */
+const KNOWN_IDS: ReadonlySet<string> = new Set(
+  generatedForGateway === "vercel" ? generatedModels.map((m) => m.id) : [],
+);
+
+/** Suffix matcher for date-stamped Anthropic ids — `-YYYYMMDD` at the end. */
+const DATE_SUFFIX_RE = /-(\d{8})$/;
+
+export interface ResolvedModel {
+  /** Registry-canonical id (e.g. `anthropic/claude-sonnet-4`). */
+  canonical: string;
+  /**
+   * The Anthropic-side id the caller sent (post-prefix-strip). May or
+   * may not equal `canonical.slice("anthropic/".length)` depending on
+   * whether the caller used a date-snapshot id.
+   */
+  anthropicId: string;
+}
+
+/**
+ * Resolve a caller-supplied `model` field. Returns `null` if the model
+ * is not in the registry — the route translates that into a 400.
+ *
+ * The function is deliberately namespace-permissive on input but strict
+ * on the inner id — `anthropic/anthropic/foo`, `openai/foo`, and other
+ * surprising shapes don't match anything in the registry and return
+ * `null`. We don't try to be clever about cross-provider aliasing in
+ * PR-1; that's PR-2's concern.
+ */
+export function resolveModel(modelId: string): ResolvedModel | null {
+  if (typeof modelId !== "string" || modelId.length === 0) return null;
+
+  // Strip a single leading `anthropic/` prefix. Don't recurse — the
+  // resulting id must not itself carry another slash-prefix (signals
+  // a typo or cross-provider id we don't handle here).
+  const inner = modelId.startsWith("anthropic/")
+    ? modelId.slice("anthropic/".length)
+    : modelId;
+
+  if (inner.length === 0 || inner.includes("/")) return null;
+
+  const namespaced = `anthropic/${inner}`;
+
+  // 1. Exact match (covers both `anthropic/claude-3.5-sonnet` and
+  //    `anthropic/claude-3.5-sonnet-20240620` — both are in the registry).
+  if (KNOWN_IDS.has(namespaced)) {
+    return { canonical: namespaced, anthropicId: inner };
+  }
+
+  // 2. Date-stripped form. The registry tracks `anthropic/claude-sonnet-4`
+  //    while callers may send `claude-sonnet-4-20250514`; map back.
+  const m = DATE_SUFFIX_RE.exec(inner);
+  if (m) {
+    const baseInner = inner.slice(0, inner.length - m[0].length);
+    const baseNamespaced = `anthropic/${baseInner}`;
+    if (KNOWN_IDS.has(baseNamespaced)) {
+      // Preserve the caller's dated id — downstream telemetry may want to
+      // know the snapshot they pinned to, even if billing uses canonical.
+      return { canonical: baseNamespaced, anthropicId: inner };
+    }
+  }
+
+  return null;
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/types.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/types.ts
@@ -1,0 +1,241 @@
+/**
+ * Shared types for the `/api/v1/messages` (Anthropic Messages) edge
+ * adapter — and, in later PRs, `/api/v1/chat/completions` (OpenAI).
+ *
+ * These mirror the public surface of `@anthropic-ai/sdk` so byte-faithful
+ * round-trip with off-the-shelf SDK callers is possible. We intentionally
+ * keep the wire shape narrow (no internal-only fields) so the adapter is
+ * a strict translation boundary, not a "shape with extras" surface.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ */
+
+import "server-only";
+
+// ---------------------------------------------------------------------------
+// Auth context — populated by `resolveEdgeAuth`
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolved per-request auth state. The edge route gets this OR a 401.
+ *
+ * The `tier1Token` is ALWAYS an ES256 lifegw Tier-1 cap minted via
+ * `mintTier1ForConsumer`. When the caller presented an HS256 broomva.tech
+ * access_token in the Authorization header, the adapter re-minted into
+ * lifegw form internally — callers downstream never see the original.
+ *
+ * `source` distinguishes how the user was identified so observability can
+ * tag the run (CLI/SDK vs browser).
+ */
+export interface EdgeAuthContext {
+  tier1Token: string;
+  userId: string;
+  projectId: string;
+  source: "header" | "session";
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic Messages API — request
+// ---------------------------------------------------------------------------
+
+export interface AnthropicTextContentBlock {
+  type: "text";
+  text: string;
+}
+
+export interface AnthropicImageContentBlock {
+  type: "image";
+  source:
+    | {
+        type: "base64";
+        media_type: string;
+        data: string;
+      }
+    | {
+        type: "url";
+        url: string;
+      };
+}
+
+export interface AnthropicToolUseContentBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface AnthropicToolResultContentBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content?:
+    | string
+    | Array<AnthropicTextContentBlock | AnthropicImageContentBlock>;
+  is_error?: boolean;
+}
+
+export type AnthropicContentBlock =
+  | AnthropicTextContentBlock
+  | AnthropicImageContentBlock
+  | AnthropicToolUseContentBlock
+  | AnthropicToolResultContentBlock;
+
+export interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+}
+
+export interface AnthropicTool {
+  name: string;
+  description?: string;
+  input_schema: {
+    type: "object";
+    properties?: Record<string, unknown>;
+    required?: string[];
+    [k: string]: unknown;
+  };
+}
+
+export type AnthropicToolChoice =
+  | { type: "auto"; disable_parallel_tool_use?: boolean }
+  | { type: "any"; disable_parallel_tool_use?: boolean }
+  | { type: "tool"; name: string; disable_parallel_tool_use?: boolean }
+  | { type: "none" };
+
+export interface AnthropicMessagesRequest {
+  model: string;
+  messages: AnthropicMessage[];
+  max_tokens: number;
+  system?: string | AnthropicTextContentBlock[];
+  temperature?: number;
+  top_p?: number;
+  top_k?: number;
+  stop_sequences?: string[];
+  stream?: boolean;
+  tools?: AnthropicTool[];
+  tool_choice?: AnthropicToolChoice;
+  metadata?: { user_id?: string; [k: string]: unknown };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic Messages API — non-stream response
+// ---------------------------------------------------------------------------
+
+export interface AnthropicUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+export type AnthropicStopReason =
+  | "end_turn"
+  | "max_tokens"
+  | "stop_sequence"
+  | "tool_use"
+  | "pause_turn"
+  | "refusal";
+
+export interface AnthropicMessagesResponse {
+  id: string;
+  type: "message";
+  role: "assistant";
+  content: Array<AnthropicTextContentBlock | AnthropicToolUseContentBlock>;
+  model: string;
+  stop_reason: AnthropicStopReason | null;
+  stop_sequence: string | null;
+  usage: AnthropicUsage;
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic Messages API — SSE event stream
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union over the SSE events Anthropic publishes for a
+ * streaming Messages request. The adapter emits these in the exact order
+ * the SDK expects:
+ *
+ *   message_start
+ *     [ content_block_start, content_block_delta…, content_block_stop ] ×N
+ *   message_delta
+ *   message_stop
+ *
+ * `ping` is allowed at any point (we emit none today; reserved for
+ * heartbeat).
+ * `error` may terminate the stream at any point.
+ */
+export type AnthropicStreamEvent =
+  | {
+      type: "message_start";
+      message: {
+        id: string;
+        type: "message";
+        role: "assistant";
+        content: [];
+        model: string;
+        stop_reason: null;
+        stop_sequence: null;
+        usage: AnthropicUsage;
+      };
+    }
+  | {
+      type: "content_block_start";
+      index: number;
+      content_block:
+        | { type: "text"; text: "" }
+        | {
+            type: "tool_use";
+            id: string;
+            name: string;
+            input: Record<string, unknown>;
+          };
+    }
+  | {
+      type: "content_block_delta";
+      index: number;
+      delta:
+        | { type: "text_delta"; text: string }
+        | { type: "input_json_delta"; partial_json: string };
+    }
+  | {
+      type: "content_block_stop";
+      index: number;
+    }
+  | {
+      type: "message_delta";
+      delta: {
+        stop_reason: AnthropicStopReason | null;
+        stop_sequence: string | null;
+      };
+      usage: AnthropicUsage;
+    }
+  | { type: "message_stop" }
+  | { type: "ping" }
+  | {
+      type: "error";
+      error: {
+        type: string;
+        message: string;
+      };
+    };
+
+// ---------------------------------------------------------------------------
+// Anthropic error envelope (non-stream)
+// ---------------------------------------------------------------------------
+
+export interface AnthropicErrorBody {
+  type: "error";
+  error: {
+    type:
+      | "invalid_request_error"
+      | "authentication_error"
+      | "permission_error"
+      | "not_found_error"
+      | "request_too_large"
+      | "rate_limit_error"
+      | "api_error"
+      | "overloaded_error"
+      | string;
+    message: string;
+  };
+}


### PR DESCRIPTION
## Summary

First sub-PR of [BRO-1208](https://linear.app/broomva/issue/BRO-1208). Adds the `/api/v1/messages` external edge endpoint:

- Anthropic Messages API request/SSE shape, byte-faithful per spec
- Routes through `lifed-ws-client.ts` → lifegw → lifed → Anthropic provider
- Sticky-session: SHA-256 hash of `messages[:-1]` (D1 locked)
- Auth: 2 modes (header bearer + Neon Auth session)
- Namespace-preserving model registry (D2 locked)

## Wire mapping (spec §"Wire shape — Anthropic Messages API")

| Internal `agent_kind` | Anthropic SSE |
| --- | --- |
| `TOKEN` | `content_block_delta` with `text_delta` |
| `TOOL_CALL_PENDING` | `content_block_start` (tool_use) + `input_json_delta` + `content_block_stop` |
| `FINISH` | `message_delta` (stop_reason) + `message_stop` |
| `ERROR` | `event: error` (terminal — skips message_delta/stop) |

`message_start` is always emitted first; telemetry events (warning, vigil_span, etc.) drop silently.

## Out of scope (intentional)

- Anonymous flow — spec line 115 explicitly disallows
- Per-tier credit gate, tool flag gating, MCP — stay on in-app `/api/chat` surface, handled in PR-3
- OpenAI shape — that's PR-2 (BRO-1210), stacked on this branch
- D3 tool-result message round-trip — PR-2 territory

## Test plan

- [x] `bun run test:unit` — 44/44 new tests pass
  - `build-session-id.test.ts` — 9 tests (sticky-sid D1 contract)
  - `model-registry.test.ts` — 9 tests (D2 namespace handling + date suffix)
  - `anthropic-sse.test.ts` — 8 tests (per-event mapping, error path, telemetry drop)
  - `route.test.ts` — 12 tests (auth modes, model rejection, sid stickiness, stream/non-stream, error mapping)
  - `contract.test.ts` — 2 byte-equivalence golden tests (text-only + tool-use streams)
- [x] `bun run test:types` — clean (no new TS errors)
- [x] `bunx biome check` over new files — 0 errors, 0 warnings
- [ ] After deploy: curl POST /api/v1/messages from https://broomva.github.io origin with a Tier-1 token returns valid Anthropic SSE

Closes BRO-1209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)