### PR TITLE
fix(proxy): add /api/v1 to PUBLIC_API_PREFIXES [BRO-1219]

### DIFF
--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -64,6 +64,14 @@ const PUBLIC_API_PREFIXES = [
   // to no-op for anonymous readers (`NextResponse.json(null)` on GET, 401 on
   // POST). The proxy must let the request through so the handler can pick.
   "/api/audio-playback",
+  // Edge endpoints (BRO-1208): Anthropic Messages + OpenAI Chat Completions
+  // canonical surfaces. Both routes do their own Tier-1 JWT verification
+  // inside the handler — header bearer (BROOMVA_TOKEN / Tier-1 cap) OR
+  // Neon Auth session → minted Tier-1 — and return Anthropic/OpenAI-shape
+  // 401 JSON envelopes when auth is missing. They MUST NOT be redirected
+  // to /login because external SDK callers (curl, @anthropic-ai/sdk,
+  // openai) cannot follow HTML auth redirects.
+  "/api/v1",
 ] as const;
 
 /** Metadata / SEO routes always allowed. */


### PR DESCRIPTION
## Summary

Unblocks PR-1 ([BRO-1209](https://linear.app/broomva/issue/BRO-1209), #188 merged) production deploy. Empirical smoke after the merge showed:

```
$ curl -i -X POST https://broomva.tech/api/v1/messages -H 'Origin: https://broomva.github.io' -d '{}'
HTTP/2 307
location: /login
```

The route handler never ran. Root cause: `apps/broomva/proxy.ts` (the active Next.js 16 middleware) didn't have `/api/v1` in `PUBLIC_API_PREFIXES`, so the auth gate redirected the unauthenticated POST to `/login` before our handler could return a proper 401 JSON envelope.

## Fix

One-line addition to `PUBLIC_API_PREFIXES`. The routes already do their own Tier-1 verification internally (header bearer OR Neon Auth session → minted Tier-1 cap forwarded to lifegw). They need to be reached so they can return the right error envelope — external SDK callers can't follow HTML redirects.

## Separate finding (flagged, NOT fixed here)

Both `apps/broomva/middleware.ts` (added by PR #187 — dynamic CORS for allowlist origins) AND `apps/broomva/proxy.ts` (older auth gate) exist on `origin/main`. Next.js 16 picks `proxy.ts`, so **PR #187's CORS middleware never deployed**. Prod responses show stale CORS:

```
access-control-allow-origin: https://broomva.tech    # hardcoded, not echoed
access-control-allow-headers: Content-Type, Authorization   # missing X-Requested-With
# no Vary: Origin
```

Fix is to merge middleware.ts's dynamic-CORS logic into `withSecurityHeaders` in proxy.ts then delete middleware.ts. Tracked under [BRO-1208](https://linear.app/broomva/issue/BRO-1208) for a follow-up PR; out of scope here to keep this unblocker minimal.

## Test plan

- [ ] CI green
- [ ] After auto-merge + Vercel deploy: \`curl -i -X POST https://broomva.tech/api/v1/messages -H 'Authorization: Bearer not-a-real-token' -d '{}'\` returns 401 JSON (NOT 307 to /login)

Closes BRO-1219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)