### PR TITLE
feat(api): /api/v1/chat/completions OpenAI Chat Completions edge endpoint [BRO-1210]

### DIFF
--- a/apps/broomva/app/api/v1/chat/completions/__tests__/contract.test.ts
+++ b/apps/broomva/app/api/v1/chat/completions/__tests__/contract.test.ts
@@ -1,0 +1,279 @@
+// Contract test: byte-faithful OpenAI Chat Completions SSE stream.
+//
+// The audit gate for PR-2 of BRO-1208. Translates a canned canonical
+// event stream into OpenAI SSE bytes and asserts the output matches
+// hand-written fixtures verbatim. Any deviation from the documented
+// OpenAI Chat Completions wire shape breaks this test — that's the
+// point.
+//
+// The fixtures are hand-written (not vendored from `openai`) because
+// the `openai` package is not a direct dependency of the broomva.tech
+// app (we use the AI-SDK abstractions, not the OpenAI SDK directly).
+// Hand-writing also makes the fixture self-documenting: every byte in
+// the expected output is visible in this file and the assertion is a
+// single string equality.
+//
+// What this test locks in:
+//   1. Chunk shape: `data: {...}\n\n` with NO `event:` prefix.
+//   2. First chunk announces role: `delta: {role: "assistant", content: ""}`.
+//   3. Content deltas: `delta: {content: "..."}`.
+//   4. Tool-call envelope chunk: `{index, id, type: "function",
+//       function: {name, arguments: ""}}` followed by arguments-only chunk.
+//   5. Terminal chunk: `delta: {}, finish_reason: <reason>`.
+//   6. `data: [DONE]\n\n` terminator.
+//   7. Constant `id`, `object: "chat.completion.chunk"`, `model`, `created`
+//      across every chunk.
+//
+// References:
+//   - OpenAI Chat Completions streaming:
+//     https://platform.openai.com/docs/api-reference/chat/streaming
+//   - Vercel AI SDK openai-compatible provider expectations:
+//     https://sdk.vercel.ai/providers/openai-compatible-providers
+//
+// File under test: ../../../../lib/life-runtime/edge-adapter/openai-sse.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import { canonicalToOpenaiSse } from "@/lib/life-runtime/edge-adapter/openai-sse";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function* iterate(
+  events: CanonicalAgentEvent["event"][],
+): AsyncIterable<CanonicalAgentEvent> {
+  let i = 0n;
+  for (const ev of events) {
+    yield { seq: ++i, at: "2026-05-20T00:00:00.000Z", event: ev };
+  }
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  let done = false;
+  while (!done) {
+    const r = await reader.read();
+    done = r.done;
+    if (r.value) out += decoder.decode(r.value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+/**
+ * Strip the variable `created` Unix timestamp from each chunk so the
+ * assertion is stable across test runs. The contract test cares about
+ * structure + every other field; `created` is captured at stream
+ * construction time and isn't load-bearing for parser correctness.
+ */
+function freezeCreated(wire: string): string {
+  return wire.replace(/"created":\d+/g, '"created":1700000000');
+}
+
+// ---------------------------------------------------------------------------
+// Fixture 1 — token-only stream
+// ---------------------------------------------------------------------------
+
+const CANONICAL_TEXT_ONLY: CanonicalAgentEvent["event"][] = [
+  { kind: "token", delta: "Hello, " },
+  { kind: "token", delta: "world!" },
+  {
+    kind: "finish",
+    reason: "stop",
+    usage: { inputTokens: 10, outputTokens: 5 },
+  },
+];
+
+/**
+ * Expected byte-for-byte SSE output. Every chunk is `data: <json>\n\n`,
+ * no `event:` prefix, no extra whitespace, terminated with `data: [DONE]\n\n`.
+ *
+ * Chunk order:
+ *   [0] role announce: `delta: {role: "assistant", content: ""}`
+ *   [1] content: `delta: {content: "Hello, "}`
+ *   [2] content: `delta: {content: "world!"}`
+ *   [3] terminal: `delta: {}, finish_reason: "stop"`
+ *   [4] `data: [DONE]\n\n`
+ */
+const EXPECTED_TEXT_ONLY_WIRE =
+  // [0] role announce
+  'data: {"id":"chatcmpl-FIXTURE-001",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-sonnet-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"role":"assistant","content":""},' +
+  '"finish_reason":null}]}\n\n' +
+  // [1] content delta — "Hello, "
+  'data: {"id":"chatcmpl-FIXTURE-001",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-sonnet-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"content":"Hello, "},' +
+  '"finish_reason":null}]}\n\n' +
+  // [2] content delta — "world!"
+  'data: {"id":"chatcmpl-FIXTURE-001",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-sonnet-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"content":"world!"},' +
+  '"finish_reason":null}]}\n\n' +
+  // [3] terminal — empty delta, finish_reason="stop"
+  'data: {"id":"chatcmpl-FIXTURE-001",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-sonnet-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{},' +
+  '"finish_reason":"stop"}]}\n\n' +
+  // [4] sentinel
+  "data: [DONE]\n\n";
+
+// ---------------------------------------------------------------------------
+// Fixture 2 — tool-use round-trip
+// ---------------------------------------------------------------------------
+
+const CANONICAL_TOOL_USE: CanonicalAgentEvent["event"][] = [
+  { kind: "token", delta: "Sure — " },
+  {
+    kind: "tool_call_pending",
+    call: {
+      callId: "call_01ABCdef",
+      toolName: "update_cabin_params",
+      inputJson: '{"updates":{"platform.width_m":3.5}}',
+      requestedCapabilities: [],
+    },
+  },
+  { kind: "finish", reason: "tool_use" },
+];
+
+/**
+ * Expected wire for the tool-use stream.
+ *
+ * Chunk order:
+ *   [0] role announce
+ *   [1] content "Sure — "
+ *   [2] tool-call envelope (index 0, id, type, name, arguments="")
+ *   [3] tool-call arguments-only (index 0, function.arguments=<json>)
+ *   [4] terminal: `delta: {}, finish_reason: "tool_calls"`
+ *   [5] `[DONE]`
+ */
+const EXPECTED_TOOL_USE_WIRE =
+  // [0] role announce
+  'data: {"id":"chatcmpl-FIXTURE-002",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-opus-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"role":"assistant","content":""},' +
+  '"finish_reason":null}]}\n\n' +
+  // [1] content delta — "Sure — "
+  'data: {"id":"chatcmpl-FIXTURE-002",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-opus-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"content":"Sure — "},' +
+  '"finish_reason":null}]}\n\n' +
+  // [2] tool-call envelope
+  'data: {"id":"chatcmpl-FIXTURE-002",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-opus-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"tool_calls":[{"index":0,' +
+  '"id":"call_01ABCdef",' +
+  '"type":"function",' +
+  '"function":{"name":"update_cabin_params","arguments":""}}]},' +
+  '"finish_reason":null}]}\n\n' +
+  // [3] tool-call arguments-only
+  'data: {"id":"chatcmpl-FIXTURE-002",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-opus-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{"tool_calls":[{"index":0,' +
+  '"function":{"arguments":"{\\"updates\\":{\\"platform.width_m\\":3.5}}"}}]},' +
+  '"finish_reason":null}]}\n\n' +
+  // [4] terminal — finish_reason "tool_calls"
+  'data: {"id":"chatcmpl-FIXTURE-002",' +
+  '"object":"chat.completion.chunk",' +
+  '"created":1700000000,' +
+  '"model":"claude-opus-4-20250514",' +
+  '"choices":[{"index":0,' +
+  '"delta":{},' +
+  '"finish_reason":"tool_calls"}]}\n\n' +
+  // [5] sentinel
+  "data: [DONE]\n\n";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("contract — OpenAI Chat Completions SSE wire-byte equivalence", () => {
+  it("text-only stream matches the fixture verbatim", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate(CANONICAL_TEXT_ONLY),
+      "claude-sonnet-4-20250514",
+      "chatcmpl-FIXTURE-001",
+    );
+    const wire = freezeCreated(await drain(stream));
+    expect(wire).toBe(EXPECTED_TEXT_ONLY_WIRE);
+  });
+
+  it("tool-use stream matches the fixture verbatim", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate(CANONICAL_TOOL_USE),
+      "claude-opus-4-20250514",
+      "chatcmpl-FIXTURE-002",
+    );
+    const wire = freezeCreated(await drain(stream));
+    expect(wire).toBe(EXPECTED_TOOL_USE_WIRE);
+  });
+
+  it("never emits an `event:` line (OpenAI shape is bare data only)", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate(CANONICAL_TEXT_ONLY),
+      "m",
+      "id",
+    );
+    const wire = await drain(stream);
+    expect(wire).not.toMatch(/^event: /m);
+  });
+
+  it("terminates with `data: [DONE]\\n\\n` on clean finish", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate(CANONICAL_TEXT_ONLY),
+      "m",
+      "id",
+    );
+    const wire = await drain(stream);
+    expect(wire.endsWith("data: [DONE]\n\n")).toBe(true);
+  });
+
+  it("does NOT terminate with [DONE] on error stream", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "Partial" },
+        {
+          kind: "error",
+          code: "lifed-ws.transport_error",
+          message: "socket closed",
+        },
+      ]),
+      "m",
+      "id",
+    );
+    const wire = await drain(stream);
+    expect(wire).not.toContain("[DONE]");
+    expect(wire).toContain('"error"');
+  });
+});

--- a/apps/broomva/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/broomva/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -1,0 +1,780 @@
+// Integration tests for POST /api/v1/chat/completions.
+//
+// Mirrors the PR-1 pattern in `/api/v1/messages/__tests__/route.test.ts`.
+//
+// We mock:
+//   - `LifedWsAgentSessionClient` — via the
+//     `__setSessionClientFactoryForTests` seam exported from the route module.
+//   - `@/lib/auth` — `getSafeSession` returns whatever the test sets.
+//   - `@/lib/ai/vault/jwt` — `verifyLifeJWT` returns a fake claim or null.
+//   - `@/lib/auth/lifegw-jwt` — `mintTier1ForConsumer` returns a fake cap.
+//
+// File under test: ../route.ts
+
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getSafeSession: vi.fn(),
+  verifyLifeJWT: vi.fn(),
+  mintTier1ForConsumer: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSafeSession: mocks.getSafeSession,
+  hasNeonAuth: false,
+  auth: {},
+}));
+
+vi.mock("@/lib/ai/vault/jwt", () => ({
+  verifyLifeJWT: mocks.verifyLifeJWT,
+  JWT_ACCESS_EXPIRY_MS: 24 * 60 * 60 * 1000,
+  JWT_REFRESH_EXPIRY_MS: 7 * 24 * 60 * 60 * 1000,
+  generateRefreshToken: () => "ref",
+  hashRefreshToken: (s: string) => s,
+  signLifeJWT: async () => "fake-jwt",
+}));
+
+vi.mock("@/lib/auth/lifegw-jwt", () => ({
+  mintTier1ForConsumer: mocks.mintTier1ForConsumer,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
+const mockGetSafeSession = mocks.getSafeSession;
+const mockVerifyLifeJWT = mocks.verifyLifeJWT;
+const mockMintTier1 = mocks.mintTier1ForConsumer;
+
+import type { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type {
+  AgentStreamInput,
+  CanonicalAgentEvent,
+} from "@/lib/life-runtime/agent-session/types";
+// 3. Bring in the route AFTER all mocks are registered.
+import { __setSessionClientFactoryForTests, POST } from "../route";
+
+// ---------------------------------------------------------------------------
+// Fake LifedWsAgentSessionClient
+// ---------------------------------------------------------------------------
+
+interface FakeOpts {
+  events?: CanonicalAgentEvent["event"][];
+  createSessionError?: Error;
+  createSessionCalls?: Array<{ resumeSid?: string; userId: string }>;
+  streamCalls?: AgentStreamInput[];
+}
+
+function makeFakeClient(opts: FakeOpts): LifedWsAgentSessionClient {
+  const events = opts.events ?? [
+    { kind: "token", delta: "Hello!" },
+    { kind: "finish", reason: "stop" },
+  ];
+  const fake = {
+    backendId: "lifed-ws" as const,
+    async createSession(input: {
+      capability: { token: string };
+      userId: string;
+      projectSlug: string;
+      resumeSid?: string;
+    }) {
+      if (opts.createSessionError) throw opts.createSessionError;
+      opts.createSessionCalls?.push({
+        resumeSid: input.resumeSid,
+        userId: input.userId,
+      });
+      return {
+        sid: input.resumeSid ?? "fresh-sid",
+        agentId: `agent_${input.userId}`,
+        userId: input.userId,
+        projectId: input.projectSlug,
+        createdAtUnix: Math.floor(Date.now() / 1000),
+      };
+    },
+    async sendMessage() {},
+    async health() {
+      return { backendId: "lifed-ws", reachable: true };
+    },
+    async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
+      opts.streamCalls?.push(input);
+      let i = 0n;
+      for (const ev of events) {
+        yield { seq: ++i, at: new Date().toISOString(), event: ev };
+      }
+    },
+  };
+  return fake as unknown as LifedWsAgentSessionClient;
+}
+
+// ---------------------------------------------------------------------------
+// Request helper
+// ---------------------------------------------------------------------------
+
+function makeRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): import("next/server").NextRequest {
+  const init: RequestInit = {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  };
+  return new Request(
+    "https://broomva.tech/api/v1/chat/completions",
+    init,
+  ) as unknown as import("next/server").NextRequest;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGetSafeSession.mockReset();
+  mockVerifyLifeJWT.mockReset();
+  mockMintTier1.mockReset();
+  mockGetSafeSession.mockResolvedValue({ data: null, error: null });
+  mockVerifyLifeJWT.mockResolvedValue(null);
+  mockMintTier1.mockResolvedValue({
+    token: "fake-tier1-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 900,
+  });
+  vi.stubEnv("LIFED_GATEWAY_URL", "https://gw.example.test");
+});
+
+afterEach(() => {
+  __setSessionClientFactoryForTests(undefined);
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — auth", () => {
+  it("returns 401 with OpenAI error envelope when no auth", async () => {
+    const req = makeRequest({
+      model: "claude-3.5-sonnet",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(401);
+    const body = (await resp.json()) as {
+      error: { message: string; type: string; code?: string };
+    };
+    // OpenAI shape: top-level `error` object, NOT `{type, error}` (Anthropic).
+    expect(body.error).toBeDefined();
+    expect(body.error.type).toBe("authentication_error");
+    expect(typeof body.error.message).toBe("string");
+  });
+
+  it("returns 401 when bearer token verification fails", async () => {
+    mockVerifyLifeJWT.mockResolvedValue(null);
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      { authorization: "Bearer bad-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(401);
+    const body = (await resp.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("authentication_error");
+  });
+
+  it("accepts valid bearer token and proceeds to lifed", async () => {
+    mockVerifyLifeJWT.mockResolvedValue({
+      sub: "user_alice",
+      email: "alice@test",
+    });
+    const createSessionCalls: Array<{ resumeSid?: string; userId: string }> =
+      [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      { authorization: "Bearer good-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls[0].userId).toBe("user_alice");
+    expect(mockMintTier1).toHaveBeenCalledWith({
+      consumer: { kind: "user", id: "user_alice" },
+      projectSlug: "default",
+    });
+  });
+
+  it("accepts Neon Auth session when no bearer header is present", async () => {
+    mockGetSafeSession.mockResolvedValue({
+      data: { user: { id: "user_bob", email: "bob@test" } },
+      error: null,
+    });
+    const createSessionCalls: Array<{ resumeSid?: string; userId: string }> =
+      [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+    const req = makeRequest({
+      model: "claude-3.5-sonnet",
+      messages: [{ role: "user", content: "Hi" }],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(createSessionCalls[0].userId).toBe("user_bob");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Model resolution (D2)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — model resolution", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({
+      sub: "user_alice",
+      email: "alice@test",
+    });
+  });
+
+  it("returns 400 with model_not_supported on unknown model", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-9000-imagined",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      { authorization: "Bearer good-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as {
+      error: { message: string; type: string; code?: string };
+    };
+    expect(body.error.type).toBe("invalid_request_error");
+    expect(body.error.code).toBe("model_not_supported");
+    expect(body.error.message).toContain("model_not_supported");
+    expect(body.error.message).toContain("claude-9000-imagined");
+  });
+
+  it("returns 400 model_not_supported for gpt-* (no real GPT backend in PR-2)", async () => {
+    const req = makeRequest(
+      {
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      { authorization: "Bearer good-token" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as {
+      error: { type: string; code?: string };
+    };
+    expect(body.error.code).toBe("model_not_supported");
+  });
+
+  it("accepts both namespaced and bare Claude model ids", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const baseBody = {
+      messages: [{ role: "user", content: "Hi" }],
+    };
+    const r1 = await POST(
+      makeRequest(
+        { ...baseBody, model: "anthropic/claude-3.5-sonnet" },
+        { authorization: "Bearer x" },
+      ),
+    );
+    const r2 = await POST(
+      makeRequest(
+        { ...baseBody, model: "claude-3.5-sonnet" },
+        { authorization: "Bearer x" },
+      ),
+    );
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Request validation
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — request validation", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns 400 on empty messages[]", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [],
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 when last message is not a user message", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hello" },
+        ],
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 when last message is a tool result (cannot be the final entry)", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [
+          { role: "user", content: "What time is it?" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [
+              {
+                id: "call_x",
+                type: "function",
+                function: { name: "now", arguments: "{}" },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_x", content: "12:00" },
+        ],
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 on missing required field (model)", async () => {
+    const req = makeRequest(
+      { messages: [{ role: "user", content: "Hi" }] },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 when n > 1 (multi-choice generation not supported)", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        n: 3,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error: { message: string } };
+    expect(body.error.message).toContain("n must be 1");
+  });
+
+  it("accepts n=1 (explicit)", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        n: 1,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+  });
+
+  it("returns 400 on invalid max_tokens", async () => {
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        max_tokens: 0,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sticky session id
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — sticky session id", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("re-uses the same sid for two requests with the same prefix", async () => {
+    const createSessionCalls: Array<{ resumeSid?: string; userId: string }> =
+      [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+
+    const sharedPrefix = [
+      { role: "user", content: "Tell me about cats." },
+      { role: "assistant", content: "Cats are mammals." },
+    ];
+
+    await POST(
+      makeRequest(
+        {
+          model: "claude-3.5-sonnet",
+          messages: [...sharedPrefix, { role: "user", content: "More?" }],
+        },
+        { authorization: "Bearer x" },
+      ),
+    );
+    await POST(
+      makeRequest(
+        {
+          model: "claude-3.5-sonnet",
+          messages: [
+            ...sharedPrefix,
+            { role: "user", content: "Different follow-up." },
+          ],
+        },
+        { authorization: "Bearer x" },
+      ),
+    );
+
+    expect(createSessionCalls).toHaveLength(2);
+    expect(createSessionCalls[0].resumeSid).toBeDefined();
+    expect(createSessionCalls[0].resumeSid).toBe(
+      createSessionCalls[1].resumeSid,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-stream response
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — non-stream response", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns an OpenAI-shape JSON envelope when stream=false (default)", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          { kind: "token", delta: "Hello, " },
+          { kind: "token", delta: "world!" },
+          {
+            kind: "finish",
+            reason: "stop",
+            usage: { inputTokens: 10, outputTokens: 5 },
+          },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Greet me" }],
+        stream: false,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toContain("application/json");
+    const body = (await resp.json()) as {
+      id: string;
+      object: string;
+      model: string;
+      choices: Array<{
+        index: number;
+        message: { role: string; content: string | null };
+        finish_reason: string;
+      }>;
+      usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+      };
+    };
+    expect(body.object).toBe("chat.completion");
+    expect(body.model).toBe("claude-3.5-sonnet");
+    expect(body.id).toMatch(/^chatcmpl-/);
+    expect(body.choices).toHaveLength(1);
+    expect(body.choices[0].index).toBe(0);
+    expect(body.choices[0].message.role).toBe("assistant");
+    expect(body.choices[0].message.content).toBe("Hello, world!");
+    expect(body.choices[0].finish_reason).toBe("stop");
+    expect(body.usage).toBeDefined();
+    expect(body.usage!.prompt_tokens).toBe(10);
+    expect(body.usage!.completion_tokens).toBe(5);
+    expect(body.usage!.total_tokens).toBe(15);
+  });
+
+  it("omits usage block when lifed reports no token counts", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          { kind: "token", delta: "ok" },
+          { kind: "finish", reason: "stop" },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        stream: false,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    const body = (await resp.json()) as { usage?: unknown };
+    expect(body.usage).toBeUndefined();
+  });
+
+  it("emits tool_calls in the assistant message when present", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          { kind: "token", delta: "Calling tool: " },
+          {
+            kind: "tool_call_pending",
+            call: {
+              callId: "call_xyz",
+              toolName: "update_cabin_params",
+              inputJson: '{"width":3.5}',
+              requestedCapabilities: [],
+            },
+          },
+          { kind: "finish", reason: "tool_use" },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "make it taller" }],
+        stream: false,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      choices: Array<{
+        message: {
+          content: string | null;
+          tool_calls?: Array<{
+            id: string;
+            type: string;
+            function: { name: string; arguments: string };
+          }>;
+        };
+        finish_reason: string;
+      }>;
+    };
+    expect(body.choices[0].message.content).toBe("Calling tool: ");
+    expect(body.choices[0].message.tool_calls).toBeDefined();
+    expect(body.choices[0].message.tool_calls).toHaveLength(1);
+    expect(body.choices[0].message.tool_calls![0].id).toBe("call_xyz");
+    expect(body.choices[0].message.tool_calls![0].function.name).toBe(
+      "update_cabin_params",
+    );
+    expect(body.choices[0].message.tool_calls![0].function.arguments).toBe(
+      '{"width":3.5}',
+    );
+    expect(body.choices[0].finish_reason).toBe("tool_calls");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming response
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — streaming response", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns text/event-stream when stream=true", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          { kind: "token", delta: "Hi!" },
+          { kind: "finish", reason: "stop" },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Greet" }],
+        stream: true,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(resp.headers.get("Cache-Control")).toContain("no-cache");
+
+    const text = await resp.text();
+    // OpenAI SSE — bare `data:` lines, NO `event:` lines.
+    expect(text).not.toContain("event:");
+    expect(text).toContain('"role":"assistant"');
+    expect(text).toContain('"content":"Hi!"');
+    expect(text).toContain('"finish_reason":"stop"');
+    // [DONE] sentinel as the terminator.
+    expect(text).toContain("data: [DONE]\n\n");
+    expect(text.endsWith("data: [DONE]\n\n")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — error mapping", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("returns 503 when LIFED_GATEWAY_URL is unset", async () => {
+    vi.stubEnv("LIFED_GATEWAY_URL", "");
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(503);
+    const body = (await resp.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("api_error");
+  });
+
+  it("returns 502 when createSession throws a generic error", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        createSessionError: new Error("connect ECONNREFUSED"),
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(502);
+  });
+
+  it("returns OpenAI-shape error envelope when lifed yields an error (non-stream)", async () => {
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({
+        events: [
+          {
+            kind: "error",
+            code: "lifed-ws.transport_error",
+            message: "lifed went away",
+          },
+          { kind: "finish", reason: "error" },
+        ],
+      }),
+    );
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [{ role: "user", content: "Hi" }],
+        stream: false,
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBeGreaterThanOrEqual(400);
+    const body = (await resp.json()) as {
+      error: { message: string; type: string };
+    };
+    // OpenAI-shape (`{error: {...}}`), NOT Anthropic-shape (`{type:"error", error: {...}}`).
+    expect(body.error).toBeDefined();
+    expect(body.error.message).toContain("lifed went away");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// User message extraction (route → translator integration)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/v1/chat/completions — user message extraction", () => {
+  beforeEach(() => {
+    mockVerifyLifeJWT.mockResolvedValue({ sub: "user_alice", email: "" });
+  });
+
+  it("forwards the latest user message text to lifed.stream", async () => {
+    const streamCalls: AgentStreamInput[] = [];
+    __setSessionClientFactoryForTests(() => makeFakeClient({ streamCalls }));
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [
+          { role: "system", content: "Be helpful." },
+          { role: "user", content: "First question." },
+          { role: "assistant", content: "First answer." },
+          { role: "user", content: "Latest question." },
+        ],
+      },
+      { authorization: "Bearer x" },
+    );
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(streamCalls).toHaveLength(1);
+    expect(streamCalls[0].userMessage).toBe("Latest question.");
+  });
+
+  it("handles array-shaped content with text parts", async () => {
+    const streamCalls: AgentStreamInput[] = [];
+    __setSessionClientFactoryForTests(() => makeFakeClient({ streamCalls }));
+    const req = makeRequest(
+      {
+        model: "claude-3.5-sonnet",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Hi " },
+              { type: "text", text: "there." },
+            ],
+          },
+        ],
+      },
+      { authorization: "Bearer x" },
+    );
+    await POST(req);
+    expect(streamCalls[0].userMessage).toBe("Hi there.");
+  });
+});

--- a/apps/broomva/app/api/v1/chat/completions/route.ts
+++ b/apps/broomva/app/api/v1/chat/completions/route.ts
@@ -1,0 +1,588 @@
+/**
+ * `POST /api/v1/chat/completions` — OpenAI Chat Completions API
+ * edge endpoint.
+ *
+ * Second sub-PR of BRO-1208 — sibling of `/api/v1/messages` (Anthropic
+ * Messages shape). Off-the-shelf `openai` SDK + Vercel AI SDK's
+ * `openai-compatible` provider can point at this URL and get
+ * byte-faithful OpenAI SSE.
+ *
+ * Architecture (per the spec; mirrors PR-1):
+ *
+ *   client ─POST /api/v1/chat/completions───┐
+ *                                            │
+ *                  ┌─────────────────────────▼─────────────────────────┐
+ *                  │ resolveEdgeAuth                                    │
+ *                  │   (Tier-1 header OR Neon Auth session              │
+ *                  │    → mint lifegw cap)                              │
+ *                  └─────────────────────────┬─────────────────────────┘
+ *                                            │
+ *                                            ▼
+ *                                    resolveModel(req.model)
+ *                                            │
+ *                                            ▼
+ *                                buildStickySessionId(messages)
+ *                                            │
+ *                                            ▼
+ *                             LifedWsAgentSessionClient
+ *                                .createSession(resume_sid=sid)
+ *                                .stream({ sessionId=sid, ... })
+ *                                            │
+ *                                            ▼
+ *                             canonicalToOpenaiSse(...)  OR
+ *                             bufferToNonStream(...)
+ *                                            │
+ *                                            ▼
+ *                                   OpenAI SSE / JSON
+ *
+ * Decisions reused from PR-1 (locked, do NOT re-debate):
+ *   - D1: sticky-session sid from `buildStickySessionId(messages)` —
+ *     same hash works for OpenAI's shape because the prefix is a
+ *     stable JSON blob and the hash is content-only.
+ *   - D2: `resolveModel()` — registry-known Claude id ⇒ accept;
+ *     `gpt-*` ⇒ 400 model_not_supported (no real GPT backend yet).
+ *   - D3: OpenAI `role: "tool"` messages translate to Anthropic
+ *     `tool_result` blocks (see `openai-translators.ts`).
+ *   - D5: `resolveEdgeAuth()` — Bearer header OR Neon Auth session.
+ *     No anon. HS256-in / ES256-out re-mint internal.
+ *
+ * Out of scope (PR-3+ territory): real GPT backend, image inputs,
+ * `n > 1` choices, function-call legacy shape.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ */
+
+import "server-only";
+import { type NextRequest, NextResponse } from "next/server";
+import { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import { resolveEdgeAuth } from "@/lib/life-runtime/edge-adapter/auth";
+import { buildStickySessionId } from "@/lib/life-runtime/edge-adapter/build-session-id";
+import { resolveModel } from "@/lib/life-runtime/edge-adapter/model-registry";
+import {
+  canonicalToOpenaiSse,
+  type OpenAIFinishReason,
+} from "@/lib/life-runtime/edge-adapter/openai-sse";
+import {
+  type OpenAIMessage,
+  type OpenAITool,
+  openaiMessagesToLatestUserText,
+  openaiToolsToAnthropicTools,
+} from "@/lib/life-runtime/edge-adapter/openai-translators";
+import type {
+  AnthropicMessage,
+  EdgeAuthContext,
+} from "@/lib/life-runtime/edge-adapter/types";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Factory injection point for tests — mirrors the PR-1 pattern in
+ * `/api/v1/messages/route.ts`. Production code lets this be
+ * `undefined`; tests install a mock via `__setSessionClientFactoryForTests`.
+ */
+type SessionClientFactory = (baseUrl: string) => LifedWsAgentSessionClient;
+let testClientFactory: SessionClientFactory | undefined;
+
+export function __setSessionClientFactoryForTests(
+  factory: SessionClientFactory | undefined,
+): void {
+  testClientFactory = factory;
+}
+
+function getBaseUrl(): string | null {
+  const url = process.env.LIFED_GATEWAY_URL;
+  return url && url.length > 0 ? url : null;
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-shape error envelope
+// ---------------------------------------------------------------------------
+
+interface OpenAIErrorBody {
+  error: {
+    message: string;
+    type: string;
+    code?: string;
+    param?: string;
+  };
+}
+
+function openaiError(
+  message: string,
+  type: string,
+  code?: string,
+): OpenAIErrorBody {
+  const body: OpenAIErrorBody = { error: { message, type } };
+  if (code) body.error.code = code;
+  return body;
+}
+
+function openaiErrorJson(
+  message: string,
+  type: string,
+  status: number,
+  code?: string,
+): NextResponse {
+  return NextResponse.json(openaiError(message, type, code), { status });
+}
+
+// ---------------------------------------------------------------------------
+// Request shape + validation
+// ---------------------------------------------------------------------------
+
+interface OpenAIChatCompletionsRequest {
+  model: string;
+  messages: OpenAIMessage[];
+  stream?: boolean;
+  tools?: OpenAITool[];
+  tool_choice?:
+    | "none"
+    | "auto"
+    | "required"
+    | { type: "function"; function: { name: string } };
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  n?: number;
+  user?: string;
+  stop?: string | string[];
+}
+
+function isOpenAIRequest(v: unknown): v is OpenAIChatCompletionsRequest {
+  if (!v || typeof v !== "object") return false;
+  const r = v as Record<string, unknown>;
+  return typeof r.model === "string" && Array.isArray(r.messages);
+}
+
+function validateRequest(body: unknown):
+  | { ok: true; req: OpenAIChatCompletionsRequest }
+  | {
+      ok: false;
+      status: number;
+      message: string;
+      type: string;
+      code?: string;
+    } {
+  if (!isOpenAIRequest(body)) {
+    return {
+      ok: false,
+      status: 400,
+      message:
+        "Request body must be an OpenAI Chat Completions object with `model` and `messages`.",
+      type: "invalid_request_error",
+    };
+  }
+  if (body.messages.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      message: "messages must not be empty.",
+      type: "invalid_request_error",
+    };
+  }
+  // OpenAI permits any role to be the last entry in some niche flows
+  // (an assistant-only continuation request), but our forwarding model
+  // requires the final entry to carry the user's current turn. Reject
+  // assistant- or tool-tail requests here so the failure mode is
+  // explicit (mirrors the Anthropic-side validation in PR-1).
+  const last = body.messages[body.messages.length - 1];
+  if (!last || last.role !== "user") {
+    return {
+      ok: false,
+      status: 400,
+      message:
+        "The final entry in messages must have role 'user' (the current turn). Tool-result messages cannot be the final entry; the model expects a follow-up user message.",
+      type: "invalid_request_error",
+    };
+  }
+  // Enforce `n=1` only — multi-choice generation isn't supported by the
+  // lifed agent loop, and silently returning a single choice when the
+  // caller asked for multiple would be a misleading API. Spec §Request.
+  if (typeof body.n === "number" && body.n !== 1) {
+    return {
+      ok: false,
+      status: 400,
+      message: `n must be 1; received n=${body.n}. Multi-choice generation is not supported.`,
+      type: "invalid_request_error",
+    };
+  }
+  if (
+    typeof body.max_tokens === "number" &&
+    (body.max_tokens <= 0 || !Number.isFinite(body.max_tokens))
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      message: "max_tokens must be a positive integer when provided.",
+      type: "invalid_request_error",
+    };
+  }
+  return { ok: true, req: body };
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping — lifed-ws codes → OpenAI envelope
+// ---------------------------------------------------------------------------
+
+function statusFromLifedErrorCode(code: string): number {
+  if (code.startsWith("lifed-ws.auth")) return 401;
+  if (code.startsWith("lifed-ws.ip_blocked")) return 403;
+  if (code === "lifed-ws.aborted") return 499;
+  if (code.startsWith("lifed-ws.transient_4002")) return 429;
+  if (code.startsWith("lifed-ws.transient_4004")) return 502;
+  if (code.startsWith("lifed-ws.transient_")) return 503;
+  if (code.startsWith("lifed-ws.unexpected_")) return 502;
+  if (code.startsWith("lifed-ws.sequence_retired")) return 410;
+  return 500;
+}
+
+function statusFromCreateSessionError(err: unknown): number {
+  if (err && typeof err === "object" && "httpStatus" in err) {
+    const s = (err as { httpStatus?: number }).httpStatus;
+    if (typeof s === "number") return s;
+  }
+  return 502;
+}
+
+function openaiErrorTypeFromStatus(status: number): string {
+  if (status === 401) return "authentication_error";
+  if (status === 403) return "permission_error";
+  if (status === 429) return "rate_limit_error";
+  if (status === 404) return "not_found_error";
+  if (status >= 500) return "api_error";
+  return "invalid_request_error";
+}
+
+// ---------------------------------------------------------------------------
+// POST handler
+// ---------------------------------------------------------------------------
+
+export async function POST(req: NextRequest): Promise<Response> {
+  // 1. Parse + validate request body.
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (err) {
+    return openaiErrorJson(
+      `Failed to parse JSON body: ${(err as Error).message}`,
+      "invalid_request_error",
+      400,
+    );
+  }
+  const validated = validateRequest(body);
+  if (!validated.ok) {
+    return openaiErrorJson(
+      validated.message,
+      validated.type,
+      validated.status,
+      validated.code,
+    );
+  }
+  const completionsRequest = validated.req;
+
+  // 2. Resolve model. `gpt-*` and other non-registered ids return null;
+  //    we surface as `model_not_supported` per spec D2.
+  const resolved = resolveModel(completionsRequest.model);
+  if (!resolved) {
+    return openaiErrorJson(
+      `model_not_supported: ${completionsRequest.model}`,
+      "invalid_request_error",
+      400,
+      "model_not_supported",
+    );
+  }
+
+  // 3. Resolve auth. `resolveEdgeAuth` returns an Anthropic-shape
+  //    NextResponse on failure (PR-1 inherits its envelope); we
+  //    repackage as OpenAI-shape here so external callers see the
+  //    expected error envelope no matter which surface they're on.
+  const auth = await resolveEdgeAuth(req);
+  if (auth instanceof NextResponse) {
+    return repackageAuthError(auth);
+  }
+  const authCtx: EdgeAuthContext = auth;
+
+  // 4. Lifegw must be configured. Same defensive 503 as PR-1.
+  const baseUrl = getBaseUrl();
+  if (!baseUrl) {
+    return openaiErrorJson(
+      "lifegw is not configured for this deployment (LIFED_GATEWAY_URL unset).",
+      "api_error",
+      503,
+    );
+  }
+
+  // 5. Sticky session id — `buildStickySessionId` is provider-agnostic;
+  //    the hash is over canonical JSON of the messages[] prefix, and
+  //    OpenAI messages serialise stably enough for the hash to be
+  //    reused across providers. (The same caller swapping shapes mid-
+  //    conversation would get a new sid; that's intentional — distinct
+  //    wire shapes are distinct conversations from lifed's POV.)
+  //
+  //    NOTE: build-session-id.ts declares the input as `AnthropicMessage[]`,
+  //    but it only reads `role` + `content` via the canonical-JSON
+  //    walker — which handles arbitrary shapes. We cast to satisfy
+  //    the type signature; the runtime is identical.
+  const sid = buildStickySessionId(
+    completionsRequest.messages as unknown as AnthropicMessage[],
+  );
+
+  // 6. Construct the lifed WS client (test seam mirrors PR-1).
+  const client = testClientFactory
+    ? testClientFactory(baseUrl)
+    : new LifedWsAgentSessionClient({ baseUrl });
+
+  // 7. Open the lifed session — sticky sid resumes existing if present,
+  //    fresh-creates otherwise. Mirrors PR-1 exactly.
+  try {
+    await client.createSession({
+      capability: { token: authCtx.tier1Token },
+      userId: authCtx.userId,
+      projectSlug: authCtx.projectId,
+      resumeSid: sid,
+      signal: req.signal,
+    });
+  } catch (err) {
+    const status = statusFromCreateSessionError(err);
+    const message = err instanceof Error ? err.message : String(err);
+    return openaiErrorJson(
+      `Failed to open lifed session: ${message}`,
+      openaiErrorTypeFromStatus(status),
+      status,
+    );
+  }
+
+  // 8. Open the streaming turn. PR-2 uses per-turn mode (same as PR-1):
+  //    each HTTP request opens one streaming turn, closes after FINISH.
+  //    Multi-turn continuity comes from the sticky sid + lifed's
+  //    session cache, not from a persistent WS.
+  const latestUserText = openaiMessagesToLatestUserText(
+    completionsRequest.messages,
+  );
+  // Tools translation — currently informational only; the lifed
+  // `stream()` API doesn't yet take a `tools[]` parameter (per
+  // AgentStreamInput in agent-session/types.ts), so the translated
+  // shape is computed but not forwarded. Reserved for the future
+  // surface that does carry per-call tool overrides. The translator
+  // call is kept here so any caller validation of tool shapes
+  // surfaces at request boundary, not deep inside lifed.
+  const _toolsAnthropic = openaiToolsToAnthropicTools(completionsRequest.tools);
+  void _toolsAnthropic;
+
+  const requestId = `chatcmpl-${randomId()}`;
+
+  const streamIter = client.stream({
+    sessionId: sid,
+    agentId: `user:${authCtx.userId}`,
+    projectSlug: authCtx.projectId,
+    userMessage: latestUserText,
+    history: [],
+    kernelCtx: {
+      sessionId: sid,
+      agentId: `user:${authCtx.userId}`,
+    },
+    capability: {
+      token: authCtx.tier1Token,
+      expiresAt: Math.floor(Date.now() / 1000) + 60 * 15,
+    },
+    signal: req.signal,
+  });
+
+  // 9. Stream or buffer.
+  if (completionsRequest.stream === true) {
+    const sseBody = canonicalToOpenaiSse(
+      streamIter,
+      resolved.anthropicId,
+      requestId,
+    );
+    return new Response(sseBody, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  return await bufferToNonStreamResponse(
+    streamIter,
+    resolved.anthropicId,
+    requestId,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Auth-error repackaging
+// ---------------------------------------------------------------------------
+
+/**
+ * `resolveEdgeAuth` (PR-1) returns an Anthropic-shape error envelope on
+ * failure because it was authored for `/api/v1/messages`. The OpenAI
+ * endpoint needs an OpenAI-shape envelope for SDK clients that key off
+ * `body.error.message` rather than `body.error.type`. We pluck the
+ * message + status out and rewrap.
+ */
+async function repackageAuthError(resp: NextResponse): Promise<NextResponse> {
+  const status = resp.status;
+  let message = "Authentication required.";
+  try {
+    const body = (await resp.json()) as {
+      error?: { message?: string; type?: string };
+    };
+    if (body?.error?.message) message = body.error.message;
+  } catch {
+    // Fall through with the default message — original body was
+    // already an OpenAI-shape failure or malformed JSON.
+  }
+  return openaiErrorJson(message, openaiErrorTypeFromStatus(status), status);
+}
+
+// ---------------------------------------------------------------------------
+// Non-stream buffering
+// ---------------------------------------------------------------------------
+
+interface OpenAIChatCompletionUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+interface OpenAINonStreamChoice {
+  index: 0;
+  message: {
+    role: "assistant";
+    content: string | null;
+    tool_calls?: Array<{
+      id: string;
+      type: "function";
+      function: { name: string; arguments: string };
+    }>;
+  };
+  finish_reason: OpenAIFinishReason;
+}
+
+interface OpenAINonStreamResponse {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: [OpenAINonStreamChoice];
+  usage?: OpenAIChatCompletionUsage;
+}
+
+async function bufferToNonStreamResponse(
+  events: AsyncIterable<CanonicalAgentEvent>,
+  modelId: string,
+  requestId: string,
+): Promise<Response> {
+  let textBuffer = "";
+  const toolCalls: NonNullable<OpenAINonStreamChoice["message"]["tool_calls"]> =
+    [];
+  let finishReason: OpenAIFinishReason = "stop";
+  let hadToolCall = false;
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  try {
+    for await (const envelope of events) {
+      const ev = envelope.event;
+      switch (ev.kind) {
+        case "token":
+          textBuffer += ev.delta;
+          break;
+        case "tool_call_pending": {
+          hadToolCall = true;
+          toolCalls.push({
+            id: ev.call.callId || `call_${randomId()}`,
+            type: "function",
+            function: {
+              name: ev.call.toolName || "unknown_tool",
+              arguments: ev.call.inputJson || "{}",
+            },
+          });
+          break;
+        }
+        case "finish":
+          if (ev.usage) {
+            inputTokens = ev.usage.inputTokens ?? 0;
+            outputTokens = ev.usage.outputTokens ?? 0;
+          }
+          finishReason = mapFinishReasonForBuffer(ev.reason, hadToolCall);
+          break;
+        case "error": {
+          const status = statusFromLifedErrorCode(ev.code || "");
+          return openaiErrorJson(
+            ev.message || ev.code || "lifed-ws stream errored",
+            openaiErrorTypeFromStatus(status),
+            status,
+            ev.code || undefined,
+          );
+        }
+        default:
+          break;
+      }
+    }
+  } catch (err) {
+    return openaiErrorJson(
+      `lifed-ws stream failed: ${(err as Error).message}`,
+      "api_error",
+      500,
+    );
+  }
+
+  const message: OpenAINonStreamChoice["message"] = {
+    role: "assistant",
+    content: textBuffer.length > 0 ? textBuffer : null,
+  };
+  if (toolCalls.length > 0) {
+    message.tool_calls = toolCalls;
+    if (finishReason === "stop") finishReason = "tool_calls";
+  }
+
+  const resp: OpenAINonStreamResponse = {
+    id: requestId,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: modelId,
+    choices: [{ index: 0, message, finish_reason: finishReason }],
+  };
+  // Usage block is best-effort — emit when lifed reported tokens,
+  // skip otherwise so consumers don't get misleading zeroes.
+  if (inputTokens > 0 || outputTokens > 0) {
+    resp.usage = {
+      prompt_tokens: inputTokens,
+      completion_tokens: outputTokens,
+      total_tokens: inputTokens + outputTokens,
+    };
+  }
+
+  return NextResponse.json(resp, { status: 200 });
+}
+
+function mapFinishReasonForBuffer(
+  reason: string | undefined,
+  hadToolCall: boolean,
+): OpenAIFinishReason {
+  switch (reason) {
+    case "stop":
+    case "end_turn":
+      return hadToolCall ? "tool_calls" : "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "tool_calls";
+    default:
+      return hadToolCall ? "tool_calls" : "stop";
+  }
+}
+
+function randomId(): string {
+  return (
+    Math.random().toString(36).slice(2, 12) +
+    Math.random().toString(36).slice(2, 12)
+  );
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/openai-sse.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/openai-sse.test.ts
@@ -1,0 +1,540 @@
+// Unit tests for the canonical → OpenAI Chat Completions SSE translator.
+//
+// Covers:
+//   1. Wire envelope shape: `data: <json>\n\n` (NO `event:` prefix —
+//      OpenAI SSE doesn't use named events).
+//   2. First chunk announces role (`delta: {role:"assistant",content:""}`).
+//   3. TOKEN → `delta: {content: "<text>"}` chunks.
+//   4. FINISH → terminal chunk with `delta: {}, finish_reason: "<reason>"`
+//      followed by `data: [DONE]\n\n`.
+//   5. TOOL_CALL_PENDING → first chunk full envelope
+//      (`tool_calls: [{index, id, type:"function", function:{name, arguments:""}}]`),
+//      second chunk arguments-only when inputJson present.
+//   6. tool_calls finish_reason normalization.
+//   7. ERROR → emit `data: {"error":...}\n\n`, NO `[DONE]` terminator.
+//   8. Telemetry events drop silently.
+//   9. Multiple tool calls in one turn — each gets a distinct index.
+//
+// File under test: ../openai-sse.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import {
+  canonicalToOpenaiSse,
+  encodeOpenAiChunk,
+  OPENAI_DONE_SENTINEL,
+  type OpenAIChatCompletionChunk,
+  type OpenAIErrorChunk,
+} from "../openai-sse";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function envelope(
+  seq: bigint,
+  event: CanonicalAgentEvent["event"],
+): CanonicalAgentEvent {
+  return { seq, at: "2026-05-20T00:00:00Z", event };
+}
+
+async function* iterate(
+  events: CanonicalAgentEvent["event"][],
+): AsyncIterable<CanonicalAgentEvent> {
+  let i = 0n;
+  for (const ev of events) {
+    yield envelope(++i, ev);
+  }
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  let done = false;
+  while (!done) {
+    const r = await reader.read();
+    done = r.done;
+    if (r.value) out += decoder.decode(r.value, { stream: true });
+  }
+  out += decoder.decode();
+  return out;
+}
+
+/**
+ * Parse the wire output into a list of `data:` payloads. The OpenAI
+ * SSE format is bare-`data:` chunks separated by `\n\n`. Returns the
+ * decoded JSON for chunks; `[DONE]` lands as the literal string sentinel.
+ */
+function parseSseStream(
+  wire: string,
+): Array<OpenAIChatCompletionChunk | OpenAIErrorChunk | "[DONE]"> {
+  const blocks = wire.split("\n\n").filter((b) => b.length > 0);
+  const out: Array<OpenAIChatCompletionChunk | OpenAIErrorChunk | "[DONE]"> =
+    [];
+  for (const block of blocks) {
+    const lines = block.split("\n");
+    let dataLine = "";
+    let hadEventLine = false;
+    for (const line of lines) {
+      if (line.startsWith("data: ")) {
+        dataLine = line.slice("data: ".length);
+      } else if (line.startsWith("event: ")) {
+        hadEventLine = true;
+      }
+    }
+    // OpenAI SSE MUST NOT use `event:` lines — fail loudly if we
+    // accidentally emit one.
+    expect(hadEventLine).toBe(false);
+    if (dataLine.length === 0) continue;
+    if (dataLine === "[DONE]") {
+      out.push("[DONE]");
+      continue;
+    }
+    out.push(JSON.parse(dataLine));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Wire envelope shape
+// ---------------------------------------------------------------------------
+
+describe("encodeOpenAiChunk — wire-byte shape", () => {
+  it("emits `data: <json>\\n\\n` with no `event:` prefix", () => {
+    const out = encodeOpenAiChunk({
+      id: "x",
+      object: "chat.completion.chunk",
+      created: 1700000000,
+      model: "m",
+      choices: [{ index: 0, delta: { content: "hi" }, finish_reason: null }],
+    });
+    expect(out).toBe(
+      'data: {"id":"x","object":"chat.completion.chunk","created":1700000000,"model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n',
+    );
+    expect(out).not.toContain("event:");
+  });
+
+  it("[DONE] sentinel is the exact literal", () => {
+    expect(OPENAI_DONE_SENTINEL).toBe("data: [DONE]\n\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token-only happy path
+// ---------------------------------------------------------------------------
+
+describe("canonicalToOpenaiSse — token-only stream", () => {
+  it("emits role-announcement chunk first, then content deltas, finish, [DONE]", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "Hello, " },
+        { kind: "token", delta: "world!" },
+        {
+          kind: "finish",
+          reason: "stop",
+          usage: { inputTokens: 10, outputTokens: 5 },
+        },
+      ]),
+      "claude-sonnet-4-20250514",
+      "chatcmpl-test-001",
+    );
+    const wire = await drain(stream);
+    const items = parseSseStream(wire);
+
+    // Expect 4 chunks + [DONE] sentinel:
+    //   [0] role announce
+    //   [1] "Hello, "
+    //   [2] "world!"
+    //   [3] terminal (finish_reason: "stop")
+    //   [4] "[DONE]"
+    expect(items).toHaveLength(5);
+    expect(items[4]).toBe("[DONE]");
+
+    const c0 = items[0] as OpenAIChatCompletionChunk;
+    expect(c0.id).toBe("chatcmpl-test-001");
+    expect(c0.object).toBe("chat.completion.chunk");
+    expect(c0.model).toBe("claude-sonnet-4-20250514");
+    expect(c0.choices).toHaveLength(1);
+    expect(c0.choices[0].delta).toEqual({ role: "assistant", content: "" });
+    expect(c0.choices[0].finish_reason).toBeNull();
+
+    const c1 = items[1] as OpenAIChatCompletionChunk;
+    expect(c1.choices[0].delta).toEqual({ content: "Hello, " });
+    expect(c1.choices[0].finish_reason).toBeNull();
+    // Subsequent chunks should NOT carry `role` — that lives on the
+    // opener only.
+    expect(c1.choices[0].delta.role).toBeUndefined();
+
+    const c2 = items[2] as OpenAIChatCompletionChunk;
+    expect(c2.choices[0].delta).toEqual({ content: "world!" });
+
+    const c3 = items[3] as OpenAIChatCompletionChunk;
+    expect(c3.choices[0].delta).toEqual({});
+    expect(c3.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("uses the same `id` and `model` across every chunk", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "ok" },
+        { kind: "finish", reason: "stop" },
+      ]),
+      "claude-3.5-sonnet",
+      "chatcmpl-AAAA",
+    );
+    const wire = await drain(stream);
+    const items = parseSseStream(wire);
+    const chunks = items.filter(
+      (i): i is OpenAIChatCompletionChunk =>
+        typeof i === "object" && "object" in i,
+    );
+    for (const c of chunks) {
+      expect(c.id).toBe("chatcmpl-AAAA");
+      expect(c.model).toBe("claude-3.5-sonnet");
+    }
+  });
+
+  it("does not include `[DONE]` mid-stream", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "x" },
+        { kind: "finish", reason: "stop" },
+      ]),
+      "m",
+      "id-1",
+    );
+    const wire = await drain(stream);
+    // [DONE] only appears once, at the very end.
+    const occurrences = wire.split("data: [DONE]\n\n").length - 1;
+    expect(occurrences).toBe(1);
+    expect(wire.endsWith("data: [DONE]\n\n")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finish_reason mapping
+// ---------------------------------------------------------------------------
+
+describe("canonicalToOpenaiSse — finish_reason mapping", () => {
+  it("maps reason=max_tokens to finish_reason=length", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "x" },
+        { kind: "finish", reason: "max_tokens" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const terminal = items[items.length - 2] as OpenAIChatCompletionChunk;
+    expect(terminal.choices[0].finish_reason).toBe("length");
+  });
+
+  it("maps reason=tool_use to finish_reason=tool_calls", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "call_x",
+            toolName: "t",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const terminal = items[items.length - 2] as OpenAIChatCompletionChunk;
+    expect(terminal.choices[0].finish_reason).toBe("tool_calls");
+  });
+
+  it("normalizes stop+hadToolCall to tool_calls (assistant ended on tool call)", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "Calling: " },
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "call_x",
+            toolName: "t",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "stop" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const terminal = items[items.length - 2] as OpenAIChatCompletionChunk;
+    expect(terminal.choices[0].finish_reason).toBe("tool_calls");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool calls
+// ---------------------------------------------------------------------------
+
+describe("canonicalToOpenaiSse — tool_call_pending", () => {
+  it("emits first chunk with full envelope, second chunk with arguments only", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "call_abc123",
+            toolName: "update_cabin_params",
+            inputJson: '{"updates":{"platform.width_m":3.5}}',
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "claude-opus-4",
+      "chatcmpl-tool",
+    );
+    const items = parseSseStream(await drain(stream));
+
+    // Expect:
+    //   [0] role announce
+    //   [1] tool-call envelope (id, name, empty arguments)
+    //   [2] tool-call arguments-only chunk
+    //   [3] terminal (finish_reason: tool_calls)
+    //   [4] "[DONE]"
+    expect(items).toHaveLength(5);
+    expect(items[4]).toBe("[DONE]");
+
+    const envelope = items[1] as OpenAIChatCompletionChunk;
+    expect(envelope.choices[0].delta.tool_calls).toEqual([
+      {
+        index: 0,
+        id: "call_abc123",
+        type: "function",
+        function: { name: "update_cabin_params", arguments: "" },
+      },
+    ]);
+
+    const args = items[2] as OpenAIChatCompletionChunk;
+    expect(args.choices[0].delta.tool_calls).toEqual([
+      {
+        index: 0,
+        function: { arguments: '{"updates":{"platform.width_m":3.5}}' },
+      },
+    ]);
+    // Arguments-only chunks must NOT re-emit `id`, `type`, or
+    // `function.name` — the SDK threads them via `index`.
+    expect(args.choices[0].delta.tool_calls![0].id).toBeUndefined();
+    expect(args.choices[0].delta.tool_calls![0].type).toBeUndefined();
+    expect(args.choices[0].delta.tool_calls![0].function?.name).toBeUndefined();
+  });
+
+  it("skips the arguments chunk when inputJson is empty/`{}`", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "call_y",
+            toolName: "noop",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    // Expect 4 items: announce, envelope, terminal, [DONE] — NO args chunk.
+    expect(items).toHaveLength(4);
+    expect(items[3]).toBe("[DONE]");
+    const envelope = items[1] as OpenAIChatCompletionChunk;
+    expect(envelope.choices[0].delta.tool_calls).toBeDefined();
+  });
+
+  it("assigns distinct indices to multiple tool calls in one stream", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "call_a",
+            toolName: "t1",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "call_b",
+            toolName: "t2",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const env1 = items[1] as OpenAIChatCompletionChunk;
+    const env2 = items[2] as OpenAIChatCompletionChunk;
+    expect(env1.choices[0].delta.tool_calls![0].index).toBe(0);
+    expect(env1.choices[0].delta.tool_calls![0].id).toBe("call_a");
+    expect(env2.choices[0].delta.tool_calls![0].index).toBe(1);
+    expect(env2.choices[0].delta.tool_calls![0].id).toBe("call_b");
+  });
+
+  it("synthesises a call id when lifed didn't provide one", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "tool_call_pending",
+          call: {
+            callId: "",
+            toolName: "t",
+            inputJson: "{}",
+            requestedCapabilities: [],
+          },
+        },
+        { kind: "finish", reason: "tool_use" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const envelope = items[1] as OpenAIChatCompletionChunk;
+    const id = envelope.choices[0].delta.tool_calls![0].id;
+    expect(id).toBeDefined();
+    expect(id!).toMatch(/^call_/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error path
+// ---------------------------------------------------------------------------
+
+describe("canonicalToOpenaiSse — error event", () => {
+  it('emits `data: {"error": …}\\n\\n` and does NOT emit [DONE]', async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "token", delta: "Partial " },
+        {
+          kind: "error",
+          code: "lifed-ws.transport_error",
+          message: "socket closed unexpectedly",
+        },
+      ]),
+      "claude-3.5-sonnet",
+      "chatcmpl-err",
+    );
+    const wire = await drain(stream);
+    const items = parseSseStream(wire);
+
+    // Expect: announce, content "Partial ", error — NO terminal chunk,
+    // NO [DONE].
+    expect(items).toHaveLength(3);
+    expect(items).not.toContain("[DONE]");
+
+    const err = items[2] as OpenAIErrorChunk;
+    expect(err.error).toBeDefined();
+    expect(err.error.message).toBe("socket closed unexpectedly");
+    expect(err.error.type).toBe("api_error");
+    expect(err.error.code).toBe("lifed-ws.transport_error");
+
+    // Sanity — wire ends with error chunk, not [DONE].
+    expect(wire.includes("[DONE]")).toBe(false);
+  });
+
+  it("maps lifed-ws.auth errors to authentication_error type", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "error",
+          code: "lifed-ws.auth",
+          message: "auth failed",
+        },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const err = items[items.length - 1] as OpenAIErrorChunk;
+    expect(err.error.type).toBe("authentication_error");
+  });
+
+  it("maps lifed-ws.transient_4002 (backpressure) to rate_limit_error", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        {
+          kind: "error",
+          code: "lifed-ws.transient_4002",
+          message: "backpressure",
+        },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    const err = items[items.length - 1] as OpenAIErrorChunk;
+    expect(err.error.type).toBe("rate_limit_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Telemetry events drop silently
+// ---------------------------------------------------------------------------
+
+describe("canonicalToOpenaiSse — telemetry events drop", () => {
+  it("does not emit chunks for warning / haima_billed / vigil_span / nous_score", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([
+        { kind: "warning", code: "stale", message: "minor" },
+        { kind: "haima_billed", microcredits: 1000, rail: "credits" },
+        { kind: "vigil_span", name: "i", durationMs: 12, status: "ok" },
+        { kind: "token", delta: "ok" },
+        { kind: "finish", reason: "stop" },
+      ]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    // Expect 4 items: announce, content, terminal, [DONE].
+    expect(items).toHaveLength(4);
+    expect(items[3]).toBe("[DONE]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Empty stream
+// ---------------------------------------------------------------------------
+
+describe("canonicalToOpenaiSse — empty body", () => {
+  it("emits announce → terminal → [DONE] when only finish is present", async () => {
+    const stream = canonicalToOpenaiSse(
+      iterate([{ kind: "finish", reason: "stop" }]),
+      "m",
+      "id",
+    );
+    const items = parseSseStream(await drain(stream));
+    expect(items).toHaveLength(3);
+    expect(items[2]).toBe("[DONE]");
+    const c0 = items[0] as OpenAIChatCompletionChunk;
+    expect(c0.choices[0].delta).toEqual({ role: "assistant", content: "" });
+    const c1 = items[1] as OpenAIChatCompletionChunk;
+    expect(c1.choices[0].delta).toEqual({});
+    expect(c1.choices[0].finish_reason).toBe("stop");
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/openai-translators.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/openai-translators.test.ts
@@ -1,0 +1,292 @@
+// Unit tests for OpenAI ↔ Anthropic translation helpers.
+//
+// Covers:
+//   1. `openaiMessagesToLatestUserText`:
+//      - empty messages, only-assistant messages → ""
+//      - single user message → returns content
+//      - multi-turn — returns LATEST user text, not first
+//      - array content with `type: "text"` parts → concatenated
+//      - image_url parts → dropped
+//   2. `openaiToolsToAnthropicTools`:
+//      - shape mapping: `{type:"function",function:{name,description,parameters}}`
+//         → `{name,description,input_schema}`
+//      - parameters defaulting to `type: "object"` when missing
+//      - skipping malformed entries (no name, wrong type)
+//      - undefined / empty input → undefined
+//   3. `openaiToolResultToAnthropic`:
+//      - string content → string `content`
+//      - text-array content → text-block array `content`
+//      - image content dropped (text-only blocks survive)
+//      - empty content → no `content` field
+//
+// File under test: ../openai-translators.ts
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  type OpenAIMessage,
+  type OpenAITool,
+  openaiMessagesToLatestUserText,
+  openaiToolResultToAnthropic,
+  openaiToolsToAnthropicTools,
+} from "../openai-translators";
+
+// ---------------------------------------------------------------------------
+// openaiMessagesToLatestUserText
+// ---------------------------------------------------------------------------
+
+describe("openaiMessagesToLatestUserText", () => {
+  it("returns empty string on empty messages[]", () => {
+    expect(openaiMessagesToLatestUserText([])).toBe("");
+  });
+
+  it("returns empty string when no user message is present", () => {
+    const msgs: OpenAIMessage[] = [
+      { role: "system", content: "You are helpful." },
+      { role: "assistant", content: "Hello!" },
+    ];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe("");
+  });
+
+  it("returns the single user message content", () => {
+    const msgs: OpenAIMessage[] = [{ role: "user", content: "Hi there." }];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe("Hi there.");
+  });
+
+  it("returns the LATEST user message text, not the first", () => {
+    const msgs: OpenAIMessage[] = [
+      { role: "user", content: "First turn." },
+      { role: "assistant", content: "Reply." },
+      { role: "user", content: "Second turn." },
+    ];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe("Second turn.");
+  });
+
+  it("flattens array-shaped text content", () => {
+    const msgs: OpenAIMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello, " },
+          { type: "text", text: "world!" },
+        ],
+      },
+    ];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe("Hello, world!");
+  });
+
+  it("drops image_url parts and keeps text", () => {
+    const msgs: OpenAIMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Look at this: " },
+          { type: "image_url", image_url: { url: "https://example/foo.png" } },
+          { type: "text", text: "what is it?" },
+        ],
+      },
+    ];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe(
+      "Look at this: what is it?",
+    );
+  });
+
+  it("returns empty string when latest user content is null", () => {
+    const msgs: OpenAIMessage[] = [{ role: "user", content: null }];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe("");
+  });
+
+  it("walks past trailing tool messages to find the prior user message", () => {
+    // Note: the route REJECTS tool-tail requests at validation time, but
+    // the translator should still walk correctly when given them — the
+    // function's job is "find the latest user text".
+    const msgs: OpenAIMessage[] = [
+      { role: "user", content: "User asked something." },
+      {
+        role: "assistant",
+        content: null,
+      },
+      {
+        role: "tool",
+        tool_call_id: "call_x",
+        content: "tool returned 42",
+      },
+    ];
+    expect(openaiMessagesToLatestUserText(msgs)).toBe("User asked something.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openaiToolsToAnthropicTools
+// ---------------------------------------------------------------------------
+
+describe("openaiToolsToAnthropicTools", () => {
+  it("returns undefined for undefined / empty input", () => {
+    expect(openaiToolsToAnthropicTools(undefined)).toBeUndefined();
+    expect(openaiToolsToAnthropicTools([])).toBeUndefined();
+  });
+
+  it("maps function shape onto input_schema shape", () => {
+    const tools: OpenAITool[] = [
+      {
+        type: "function",
+        function: {
+          name: "update_cabin_params",
+          description: "Update cabin design parameters.",
+          parameters: {
+            type: "object",
+            properties: {
+              updates: {
+                type: "object",
+                additionalProperties: { type: "number" },
+              },
+              explain: { type: "string" },
+            },
+            required: ["updates"],
+          },
+        },
+      },
+    ];
+    const out = openaiToolsToAnthropicTools(tools);
+    expect(out).toBeDefined();
+    expect(out).toHaveLength(1);
+    const t = out![0];
+    expect(t.name).toBe("update_cabin_params");
+    expect(t.description).toBe("Update cabin design parameters.");
+    expect(t.input_schema.type).toBe("object");
+    expect(t.input_schema.properties).toEqual({
+      updates: {
+        type: "object",
+        additionalProperties: { type: "number" },
+      },
+      explain: { type: "string" },
+    });
+    expect(t.input_schema.required).toEqual(["updates"]);
+  });
+
+  it("defaults input_schema.type to 'object' when parameters omitted", () => {
+    const tools: OpenAITool[] = [
+      {
+        type: "function",
+        function: { name: "noop" },
+      },
+    ];
+    const out = openaiToolsToAnthropicTools(tools);
+    expect(out).toBeDefined();
+    expect(out![0].input_schema.type).toBe("object");
+  });
+
+  it("preserves extra JSON Schema fields like additionalProperties", () => {
+    const tools: OpenAITool[] = [
+      {
+        type: "function",
+        function: {
+          name: "strict_call",
+          parameters: {
+            type: "object",
+            properties: { x: { type: "number" } },
+            additionalProperties: false,
+            $defs: { someDef: { type: "string" } },
+          },
+        },
+      },
+    ];
+    const out = openaiToolsToAnthropicTools(tools);
+    expect(out![0].input_schema.additionalProperties).toBe(false);
+    expect(out![0].input_schema.$defs).toEqual({
+      someDef: { type: "string" },
+    });
+  });
+
+  it("skips malformed entries silently (no name, wrong type)", () => {
+    // Build via `unknown` then cast — the function takes `OpenAITool[]`
+    // for the type-safe call site, but runtime defenses should still
+    // hold against malformed entries that bypass typechecking (e.g.
+    // body parsed from untrusted JSON).
+    const tools = [
+      { type: "function", function: { name: "good" } },
+      { type: "function", function: {} }, // missing name
+      { type: "code_interpreter", function: { name: "ignored" } }, // wrong type
+      null,
+      undefined,
+    ] as unknown as OpenAITool[];
+    const out = openaiToolsToAnthropicTools(tools);
+    expect(out).toBeDefined();
+    expect(out).toHaveLength(1);
+    expect(out![0].name).toBe("good");
+  });
+
+  it("omits description when not provided", () => {
+    const tools: OpenAITool[] = [
+      { type: "function", function: { name: "no_desc" } },
+    ];
+    const out = openaiToolsToAnthropicTools(tools);
+    expect(out![0].description).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openaiToolResultToAnthropic
+// ---------------------------------------------------------------------------
+
+describe("openaiToolResultToAnthropic", () => {
+  it("maps string content directly", () => {
+    const out = openaiToolResultToAnthropic({
+      role: "tool",
+      tool_call_id: "call_abc123",
+      content: "42",
+    });
+    expect(out.type).toBe("tool_result");
+    expect(out.tool_use_id).toBe("call_abc123");
+    expect(out.content).toBe("42");
+  });
+
+  it("maps array content with text parts into Anthropic text blocks", () => {
+    const out = openaiToolResultToAnthropic({
+      role: "tool",
+      tool_call_id: "call_x",
+      content: [
+        { type: "text", text: "Result line 1\n" },
+        { type: "text", text: "Result line 2" },
+      ],
+    });
+    expect(out.content).toEqual([
+      { type: "text", text: "Result line 1\n" },
+      { type: "text", text: "Result line 2" },
+    ]);
+  });
+
+  it("drops image_url parts in array content", () => {
+    const out = openaiToolResultToAnthropic({
+      role: "tool",
+      tool_call_id: "call_y",
+      content: [
+        { type: "text", text: "Image generated:" },
+        { type: "image_url", image_url: { url: "https://x/y.png" } },
+      ],
+    });
+    // Only the text block survives — image-result tool outputs aren't
+    // supported in PR-2.
+    expect(out.content).toEqual([{ type: "text", text: "Image generated:" }]);
+  });
+
+  it("omits content field entirely when array has no text parts", () => {
+    const out = openaiToolResultToAnthropic({
+      role: "tool",
+      tool_call_id: "call_z",
+      content: [{ type: "image_url", image_url: { url: "https://x/y.png" } }],
+    });
+    expect(out.content).toBeUndefined();
+  });
+
+  it("preserves the tool_call_id as tool_use_id", () => {
+    const out = openaiToolResultToAnthropic({
+      role: "tool",
+      tool_call_id: "call_VERY_SPECIFIC_ID",
+      content: "ok",
+    });
+    expect(out.tool_use_id).toBe("call_VERY_SPECIFIC_ID");
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/openai-sse.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/openai-sse.ts
@@ -1,0 +1,425 @@
+/**
+ * `CanonicalAgentEvent` → OpenAI Chat Completions SSE byte translator.
+ *
+ * Emits the EXACT byte sequence the official `openai` SDK + Vercel
+ * AI SDK's `openai-compatible` provider expect for streaming
+ * `chat.completions`. Off-the-shelf clients can point at this endpoint
+ * and the stream parses byte-faithfully.
+ *
+ * Wire shape (OpenAI Chat Completions stream):
+ *
+ *   data: {"id":"<req>","object":"chat.completion.chunk","created":<unix>,
+ *          "model":"<model>","choices":[{"index":0,
+ *            "delta":{"role":"assistant","content":""},"finish_reason":null}]}
+ *
+ *   data: {…,"choices":[{"index":0,"delta":{"content":"<text>"},"finish_reason":null}]}
+ *   …
+ *
+ *   data: {…,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+ *
+ *   data: [DONE]
+ *
+ * Notes:
+ *   - Every chunk is `data: <payload>\n\n` (NO `event:` prefix — OpenAI
+ *     SSE does not use named events).
+ *   - The first chunk announces the role (`delta: {role: "assistant",
+ *     content: ""}`) — this is the convention the SDK keys off when
+ *     materializing the assistant message.
+ *   - The stream terminates with the literal sentinel `data: [DONE]\n\n`.
+ *     The OpenAI SDK + Vercel AI SDK + `openai-compatible` provider all
+ *     watch for this exact byte sequence.
+ *   - On error: emit ONE `data: {"error":…}\n\n` chunk and close. Do
+ *     NOT emit `[DONE]` — OpenAI's client treats `[DONE]` as a clean
+ *     close, so a `[DONE]` after an error event would mask the failure.
+ *   - Tool-call deltas chain: the first chunk for a tool call has full
+ *     `{index, id, type:"function", function:{name, arguments:""}}`;
+ *     subsequent chunks for the same tool index carry only
+ *     `{index, function:{arguments:"<json-fragment>"}}` — the SDK
+ *     reassembles the arguments string by concatenation.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ *       (§"Wire shape — OpenAI Chat Completions")
+ */
+
+import "server-only";
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+
+// ---------------------------------------------------------------------------
+// OpenAI chunk types — narrowed to what we emit
+// ---------------------------------------------------------------------------
+
+/**
+ * Reason the assistant finished. OpenAI defines:
+ *   - "stop" — natural end-of-turn (model emitted stop token)
+ *   - "length" — max_tokens hit
+ *   - "tool_calls" — assistant ended on a tool call (the client is
+ *     expected to dispatch and reply with a `role: "tool"` message)
+ *   - "content_filter" — moderation blocked output (we don't emit)
+ *   - "function_call" — legacy; replaced by "tool_calls"
+ */
+export type OpenAIFinishReason =
+  | "stop"
+  | "length"
+  | "tool_calls"
+  | "content_filter"
+  | "function_call";
+
+export interface OpenAIToolCallDelta {
+  index: number;
+  id?: string;
+  type?: "function";
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+}
+
+export interface OpenAIChunkDelta {
+  role?: "assistant";
+  content?: string | null;
+  tool_calls?: OpenAIToolCallDelta[];
+}
+
+export interface OpenAIChunkChoice {
+  index: number;
+  delta: OpenAIChunkDelta;
+  finish_reason: OpenAIFinishReason | null;
+}
+
+export interface OpenAIChatCompletionChunk {
+  id: string;
+  object: "chat.completion.chunk";
+  created: number;
+  model: string;
+  choices: OpenAIChunkChoice[];
+}
+
+export interface OpenAIErrorChunk {
+  error: {
+    message: string;
+    type: string;
+    code?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wire encoders
+// ---------------------------------------------------------------------------
+
+/**
+ * Encode one chunk payload as `data: <json>\n\n`. Exported for unit
+ * tests that want byte-level fixtures.
+ */
+export function encodeOpenAiChunk(
+  payload: OpenAIChatCompletionChunk | OpenAIErrorChunk,
+): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/** Literal `[DONE]` terminator per OpenAI Chat Completions wire spec. */
+export const OPENAI_DONE_SENTINEL = "data: [DONE]\n\n";
+
+// ---------------------------------------------------------------------------
+// Main translator
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate a `CanonicalAgentEvent` async iterable into an OpenAI
+ * Chat Completions SSE byte stream.
+ *
+ * State machine:
+ *
+ *   1. Emit the role-announcement chunk first
+ *      (`delta: {role: "assistant", content: ""}`). OpenAI clients
+ *      key on this to materialize the assistant message slot.
+ *   2. For each TOKEN → emit `delta: {content: "<text>"}`.
+ *   3. For each TOOL_CALL_PENDING → first emit a chunk with full
+ *      tool-call envelope (`index, id, type:"function", function:{name,
+ *      arguments:""}`); if `inputJson` is non-empty / non-`{}`, emit a
+ *      follow-up chunk with `function:{arguments:"<json>"}` for the
+ *      same index. Track per-call index so subsequent calls within the
+ *      same turn don't collide.
+ *   4. On FINISH → emit a terminal chunk with `delta: {}, finish_reason:
+ *      "<reason>"`. The reason mapping favors:
+ *         tool_use → "tool_calls"  (caller dispatched a tool)
+ *         max_tokens → "length"
+ *         anything else → "stop"
+ *      Follow with `data: [DONE]\n\n`.
+ *   5. On ERROR → emit one error-chunk
+ *      (`data: {"error": {message, type, code}}\n\n`) and close;
+ *      do NOT emit `[DONE]`.
+ *
+ * `modelId` echoes back in every chunk's `model` field — should be the
+ * caller's original `model` request param so SDK consumers see the id
+ * they asked for.
+ *
+ * `requestId` is a `chatcmpl_*` id used for every chunk's `id` field
+ * AND surfaced as `Response.headers["openai-request-id"]` (caller's
+ * concern). It MUST be stable across all chunks for one request.
+ */
+export function canonicalToOpenaiSse(
+  events: AsyncIterable<CanonicalAgentEvent>,
+  modelId: string,
+  requestId: string,
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const created = Math.floor(Date.now() / 1000);
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const enqueueChunk = (payload: OpenAIChatCompletionChunk) => {
+        controller.enqueue(encoder.encode(encodeOpenAiChunk(payload)));
+      };
+      const enqueueErr = (payload: OpenAIErrorChunk) => {
+        controller.enqueue(encoder.encode(encodeOpenAiChunk(payload)));
+      };
+      const enqueueDone = () => {
+        controller.enqueue(encoder.encode(OPENAI_DONE_SENTINEL));
+      };
+
+      const makeChunk = (
+        delta: OpenAIChunkDelta,
+        finishReason: OpenAIFinishReason | null,
+      ): OpenAIChatCompletionChunk => ({
+        id: requestId,
+        object: "chat.completion.chunk",
+        created,
+        model: modelId,
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+      });
+
+      // 1. Role-announcement chunk — OpenAI's invariant: the first chunk
+      //    in a stream carries `role: "assistant"`. Subsequent chunks
+      //    omit `role` (the SDK keys to the role from this opener).
+      enqueueChunk(makeChunk({ role: "assistant", content: "" }, null));
+
+      // 2. Walk the canonical event stream.
+      const state: OpenAiStreamState = {
+        toolCalls: new Map<string, ToolCallSlot>(),
+        nextToolIndex: 0,
+        hadToolCall: false,
+      };
+      let finishReason: OpenAIFinishReason = "stop";
+      let errored = false;
+
+      try {
+        for await (const envelope of events) {
+          const result = handleEvent(envelope.event, state, (delta) =>
+            enqueueChunk(makeChunk(delta, null)),
+          );
+          if (result.errored) {
+            enqueueErr({
+              error: {
+                message: result.errorMessage ?? "unknown error",
+                type: result.errorType ?? "api_error",
+                code: result.errorCode,
+              },
+            });
+            errored = true;
+            break;
+          }
+          if (result.finishReason) {
+            finishReason = result.finishReason;
+          }
+          if (result.terminal) {
+            break;
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        enqueueErr({
+          error: { message, type: "api_error" },
+        });
+        controller.close();
+        return;
+      }
+
+      if (errored) {
+        // OpenAI semantics: errored streams close WITHOUT `[DONE]`.
+        controller.close();
+        return;
+      }
+
+      // If the model emitted any tool call without a subsequent FINISH
+      // landing on a different reason, normalize to "tool_calls" — the
+      // standard OpenAI convention when the assistant ended on a tool
+      // call (the client now dispatches + replies).
+      if (state.hadToolCall && finishReason === "stop") {
+        finishReason = "tool_calls";
+      }
+
+      // 3. Terminal chunk — empty delta, finish_reason set.
+      enqueueChunk(makeChunk({}, finishReason));
+
+      // 4. [DONE] sentinel — OpenAI clients rely on this exact literal.
+      enqueueDone();
+      controller.close();
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Implementation detail
+// ---------------------------------------------------------------------------
+
+interface ToolCallSlot {
+  /** OpenAI tool-call index (slot within `delta.tool_calls[]`). */
+  index: number;
+}
+
+interface OpenAiStreamState {
+  /** Per-callId → assigned tool-call index. */
+  toolCalls: Map<string, ToolCallSlot>;
+  /** Monotonic OpenAI tool-call index counter. */
+  nextToolIndex: number;
+  /** Sticky flag — if any tool call landed in this stream. */
+  hadToolCall: boolean;
+}
+
+interface HandleResult {
+  finishReason?: OpenAIFinishReason;
+  errored?: boolean;
+  errorMessage?: string;
+  errorType?: string;
+  errorCode?: string;
+  terminal?: boolean;
+}
+
+function handleEvent(
+  ev: CanonicalAgentEvent["event"],
+  state: OpenAiStreamState,
+  enqueueDelta: (delta: OpenAIChunkDelta) => void,
+): HandleResult {
+  switch (ev.kind) {
+    case "token": {
+      const text = ev.delta;
+      if (!text) return {};
+      // Plain content chunk — no role, no tool_calls.
+      enqueueDelta({ content: text });
+      return {};
+    }
+
+    case "tool_call_pending": {
+      const call = ev.call;
+      const callId = call.callId || synthCallId();
+      const name = call.toolName || "unknown_tool";
+      const slot: ToolCallSlot = {
+        index: state.nextToolIndex++,
+      };
+      state.toolCalls.set(callId, slot);
+      state.hadToolCall = true;
+      // First chunk for this tool call carries the full envelope —
+      // id, type, function.name — and the SDK initialises the
+      // tool-call slot in `delta.tool_calls[index]`.
+      enqueueDelta({
+        tool_calls: [
+          {
+            index: slot.index,
+            id: callId,
+            type: "function",
+            function: {
+              name,
+              // Arguments start empty even when the full JSON is known;
+              // the second chunk carries the payload as a string. The
+              // OpenAI client reassembles via concat, so this works
+              // regardless of whether we emit partial or whole.
+              arguments: "",
+            },
+          },
+        ],
+      });
+      // If lifed already gave us the full input JSON, emit a follow-up
+      // chunk with the arguments payload. If it's empty / `{}`, skip —
+      // the SDK accepts a tool call with empty arguments.
+      if (call.inputJson && call.inputJson !== "{}") {
+        enqueueDelta({
+          tool_calls: [
+            {
+              index: slot.index,
+              function: { arguments: call.inputJson },
+            },
+          ],
+        });
+      }
+      // tool_use is OpenAI's convention to end the assistant turn —
+      // FINISH will land on `finish_reason: "tool_calls"`.
+      return {};
+    }
+
+    case "finish": {
+      return {
+        finishReason: mapFinishReason(ev.reason, state.hadToolCall),
+        terminal: true,
+      };
+    }
+
+    case "error": {
+      const code = ev.code || "";
+      return {
+        errored: true,
+        errorMessage: ev.message || code || "unknown error",
+        errorType: classifyErrorType(code),
+        errorCode: code || undefined,
+        terminal: true,
+      };
+    }
+
+    // Telemetry / non-content events — drop silently on the OpenAI
+    // wire (OpenAI has no analogue for thinking, vigil_span, etc.).
+    case "text_start":
+    case "text_end":
+    case "thinking_start":
+    case "thinking_end":
+    case "tool_result":
+    case "approval_required":
+    case "fs_op":
+    case "nous_score":
+    case "autonomic":
+    case "haima_billed":
+    case "vigil_span":
+    case "warning":
+    case "turn_end":
+    case "open":
+      return {};
+    default: {
+      const _exhaustive: never = ev;
+      void _exhaustive;
+      return {};
+    }
+  }
+}
+
+function mapFinishReason(
+  reason: string | undefined,
+  hadToolCall: boolean,
+): OpenAIFinishReason {
+  switch (reason) {
+    case "stop":
+    case "end_turn":
+      return hadToolCall ? "tool_calls" : "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "tool_calls";
+    default:
+      return hadToolCall ? "tool_calls" : "stop";
+  }
+}
+
+/**
+ * Map a lifed error code prefix to an OpenAI-shape error type. The
+ * type strings mirror OpenAI's documented error envelope —
+ * `invalid_request_error`, `authentication_error`, `rate_limit_error`,
+ * `api_error`, etc.
+ */
+function classifyErrorType(code: string): string {
+  if (code.startsWith("lifed-ws.auth")) return "authentication_error";
+  if (code.startsWith("lifed-ws.ip_blocked")) return "permission_error";
+  if (code.startsWith("lifed-ws.transient_4002")) return "rate_limit_error";
+  if (code.startsWith("lifed-ws.aborted")) return "api_error";
+  return "api_error";
+}
+
+function synthCallId(): string {
+  return `call_${Math.random().toString(36).slice(2, 12)}`;
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/openai-translators.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/openai-translators.ts
@@ -1,0 +1,253 @@
+/**
+ * OpenAI Chat Completions ↔ Anthropic translation helpers.
+ *
+ * Pure functions — no I/O, no state. These bridge the OpenAI request
+ * shape (`role: "system" | "user" | "assistant" | "tool"`, `function`
+ * tool definitions) onto the Anthropic-flavoured envelope the lifed
+ * agent loop accepts.
+ *
+ * Decision D3 (locked in PR-1 of BRO-1208): OpenAI `role: "tool"`
+ * messages translate to Anthropic `tool_result` content blocks. The
+ * canonical lifed runtime keeps server-side conversation history via
+ * the sticky sid (D1), so most of the translation work here is
+ * extracting the latest user turn + reshaping tool definitions; full
+ * history replay is the gateway's responsibility.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ *       (§"Wire shape — OpenAI Chat Completions", §"Tool integration")
+ */
+
+import "server-only";
+import type {
+  AnthropicTextContentBlock,
+  AnthropicTool,
+  AnthropicToolResultContentBlock,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// OpenAI request shape (subset we care about)
+// ---------------------------------------------------------------------------
+
+/**
+ * OpenAI Chat Completions message — subset we need. Real OpenAI shape
+ * also includes `name`, `function_call` (legacy), and per-role variants;
+ * we only need enough to extract user text + translate tool-result
+ * bridging into Anthropic.
+ *
+ * Content per role:
+ *   - `system`: string (or array of `{type: "text", text}` parts)
+ *   - `user`:   string OR array of `{type: "text"|"image_url", ...}` parts
+ *   - `assistant`: string | null, may carry `tool_calls[]`
+ *   - `tool`:   string content, MUST carry `tool_call_id`
+ */
+export interface OpenAIMessageBase {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: string | null | Array<OpenAIContentPart>;
+}
+
+export interface OpenAIContentTextPart {
+  type: "text";
+  text: string;
+}
+
+export interface OpenAIContentImageUrlPart {
+  type: "image_url";
+  image_url: { url: string; detail?: "low" | "high" | "auto" };
+}
+
+export type OpenAIContentPart =
+  | OpenAIContentTextPart
+  | OpenAIContentImageUrlPart;
+
+export interface OpenAIToolCall {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+}
+
+export interface OpenAIAssistantMessage extends OpenAIMessageBase {
+  role: "assistant";
+  tool_calls?: OpenAIToolCall[];
+}
+
+export interface OpenAIToolMessage extends OpenAIMessageBase {
+  role: "tool";
+  tool_call_id: string;
+  /** `content` is required for tool messages — the tool's serialized output. */
+  content: string | Array<OpenAIContentPart>;
+}
+
+export type OpenAIMessage =
+  | OpenAIMessageBase
+  | OpenAIAssistantMessage
+  | OpenAIToolMessage;
+
+/**
+ * OpenAI tool definition — only `function` shape exists in v1 of the
+ * Chat Completions tools field. The `parameters` slot is a JSON Schema
+ * object the model uses to choose / validate arguments.
+ */
+export interface OpenAITool {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters?: {
+      type?: string;
+      properties?: Record<string, unknown>;
+      required?: string[];
+      [k: string]: unknown;
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Translation — request side
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull the latest user-message text from an OpenAI `messages[]` array.
+ *
+ * The lifed `stream()` API takes a single `userMessage` string; the
+ * sticky sid (D1) reuses the existing session if the prefix matches,
+ * so lifed already has the prior turns on its side. We only forward
+ * the *latest user turn* as the per-turn input.
+ *
+ * Behaviour:
+ *   - Walks `messages[]` in reverse until it finds a `role: "user"`
+ *     entry; concatenates its text content (drops image parts, drops
+ *     null/empty content).
+ *   - Returns `""` when no user message is present (the route caller
+ *     surfaces a 400 in that case — see route validation).
+ *
+ * Tool-result messages (`role: "tool"`) are NOT treated as the latest
+ * user turn — they're transcript glue between turns. When the caller
+ * sends a tool-result message followed by an implicit "continue"
+ * request, the route should detect the `role: "tool"` tail and either
+ * (a) forward it as conversation context (D3 handled separately) or
+ * (b) reject the request as ambiguous. PR-2 takes path (b): tool
+ * messages cannot be the final entry, mirroring the Anthropic-side
+ * "last entry must be role:user" validation.
+ */
+export function openaiMessagesToLatestUserText(
+  messages: OpenAIMessage[],
+): string {
+  if (!Array.isArray(messages) || messages.length === 0) return "";
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i];
+    if (m?.role !== "user") continue;
+    return flattenContent(m.content);
+  }
+  return "";
+}
+
+/**
+ * Flatten an OpenAI message `content` field to plain text. Strings pass
+ * through; arrays concat the `text` parts; nullish returns `""`.
+ * Image parts are intentionally dropped — Anthropic image translation
+ * is a separate concern not required for PR-2 (alpine-cabin chat is
+ * text-only).
+ */
+function flattenContent(content: OpenAIMessage["content"] | undefined): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const out: string[] = [];
+  for (const part of content) {
+    if (part && typeof part === "object" && part.type === "text") {
+      out.push(part.text);
+    }
+  }
+  return out.join("");
+}
+
+/**
+ * Translate OpenAI `tools[]` into Anthropic-shape tool definitions.
+ *
+ * OpenAI: `{type: "function", function: {name, description, parameters}}`
+ * Anthropic: `{name, description, input_schema}`
+ *
+ * The `parameters` JSON Schema maps directly onto `input_schema` — both
+ * are JSON Schema Draft-2019 dialects, both with `type: "object"`,
+ * `properties`, `required`. We default the inner `type` to `"object"`
+ * when missing (which is what OpenAI does too — undocumented but
+ * universal in practice).
+ *
+ * Skips invalid entries silently rather than throwing — the route
+ * validator catches bad request shapes upfront; this function trusts
+ * its input.
+ */
+export function openaiToolsToAnthropicTools(
+  tools: OpenAITool[] | undefined,
+): AnthropicTool[] | undefined {
+  if (!tools || !Array.isArray(tools) || tools.length === 0) return undefined;
+  const out: AnthropicTool[] = [];
+  for (const t of tools) {
+    if (!t || t.type !== "function" || !t.function?.name) continue;
+    const params = t.function.parameters ?? {};
+    // Anthropic requires `input_schema.type === "object"`. Default for
+    // safety — OpenAI implicitly assumes object too.
+    const inputSchema: AnthropicTool["input_schema"] = {
+      type: "object",
+      ...(params.properties ? { properties: params.properties } : {}),
+      ...(params.required ? { required: params.required } : {}),
+    };
+    // Copy any additional JSON Schema fields the caller set (e.g.
+    // `additionalProperties`, `$defs`) — they're valid in both dialects.
+    for (const [k, v] of Object.entries(params)) {
+      if (k === "type" || k === "properties" || k === "required") continue;
+      inputSchema[k] = v;
+    }
+    const entry: AnthropicTool = {
+      name: t.function.name,
+      input_schema: inputSchema,
+    };
+    if (t.function.description) entry.description = t.function.description;
+    out.push(entry);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Translate an OpenAI tool-result message (`role: "tool"`) into an
+ * Anthropic `tool_result` content block — Decision D3.
+ *
+ * OpenAI: `{role: "tool", tool_call_id: "call_…", content: "<json or text>"}`
+ * Anthropic: `{type: "tool_result", tool_use_id: "call_…", content: <…>}`
+ *
+ * The `content` field on the Anthropic side accepts either a plain
+ * string or an array of text/image blocks; we mirror what the caller
+ * sent — string stays string, array gets re-shaped to Anthropic blocks
+ * (text only; image-result tool outputs aren't supported in v1).
+ *
+ * This function is invoked when the route needs to surface a
+ * tool-result back into Anthropic-flavoured history (e.g. for non-
+ * sticky-sid fallback paths). PR-2 doesn't yet exercise it on the
+ * latest-user-turn fast path, but the translator is in place so future
+ * PRs (full multi-turn replay) can reuse it.
+ */
+export function openaiToolResultToAnthropic(msg: {
+  role: "tool";
+  tool_call_id: string;
+  content: OpenAIToolMessage["content"];
+}): AnthropicToolResultContentBlock {
+  const out: AnthropicToolResultContentBlock = {
+    type: "tool_result",
+    tool_use_id: msg.tool_call_id,
+  };
+  const content = msg.content;
+  if (typeof content === "string") {
+    out.content = content;
+    return out;
+  }
+  if (Array.isArray(content)) {
+    const blocks: AnthropicTextContentBlock[] = [];
+    for (const part of content) {
+      if (part && typeof part === "object" && part.type === "text") {
+        blocks.push({ type: "text", text: part.text });
+      }
+    }
+    if (blocks.length > 0) out.content = blocks;
+    return out;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Second sub-PR of [BRO-1208](https://linear.app/broomva/issue/BRO-1208). Sibling of merged PR #188 (Anthropic Messages). Adds the `/api/v1/chat/completions` external edge endpoint:

- OpenAI Chat Completions request/SSE shape, byte-faithful per spec
- Routes through `lifed-ws-client.ts` → lifegw → lifed → Anthropic provider
- Reuses PR-1's shared edge-adapter infra (auth, sticky-sid, model registry)
- D3 locked: OpenAI `role: "tool"` messages → Anthropic `tool_result` content blocks
- D2 locked: namespace-preserving registry; `gpt-*` returns 400 `model_not_supported` until a real GPT backend lands

## Test plan

- [ ] CI green: typecheck + bun test
- [ ] Contract tests pass (SSE byte-equivalence vs OpenAI fixtures)
- [ ] After deploy: curl POST /api/v1/chat/completions from https://broomva.github.io origin with a Tier-1 token returns valid OpenAI SSE terminating with `data: [DONE]\n\n`

Closes BRO-1210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)