### PR TITLE
feat(chat): route /api/chat through lifegw; drop Arcan-direct + streamText fallback

### DIFF
--- a/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
+++ b/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
@@ -1,0 +1,632 @@
+// Integration-ish tests for POST /api/chat (the in-app chat surface).
+//
+// PR-3 of BRO-1208 rewires this route to dispatch through lifegw. The
+// tests mock everything below the route handler:
+//
+//   - `LifedWsAgentSessionClient` — via the `__setSessionClientFactoryForTests`
+//     seam exported from the route module.
+//   - `@/lib/auth` — `getSafeSession` returns null (anonymous) or a fake user.
+//   - `@/lib/auth/lifegw-jwt` — `mintTier1ForConsumer` returns a fake cap.
+//   - `@/lib/anonymous-session-server` — `getAnonymousSession` /
+//     `setAnonymousSession` are stubbed.
+//   - `@/lib/db/queries` — all save/get/update helpers are stubbed.
+//   - `@/lib/db/credits` — `canSpend` / `deductCredits` are stubbed.
+//   - Tier + feature-flag + rate-limit helpers — all stubbed to permissive defaults.
+//
+// We exercise the full handler from request-parse through stream-finish
+// and assert:
+//
+//   1. The SSE body contains the expected Vercel-AI-SDK chunks.
+//   2. The right consumer kind (user vs anon) is sent to the dispatcher.
+//   3. `data-chatConfirmed` appears for new chats only.
+//   4. Anonymous credits are pre-deducted.
+//   5. The route does NOT call into the Arcan modules (regression guard
+//      — those still exist for non-chat consumers but `/api/chat` must
+//      no longer touch them).
+//
+// File under test: ../route.ts
+
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// `lib/env.ts` calls `createEnv` at import time which throws if
+// DATABASE_URL / AUTH_SECRET are unset. We don't actually use the env
+// (every DB / auth call is mocked) so stub the module to bypass the
+// validation entirely.
+vi.mock("@/lib/env", () => ({
+  env: {
+    DATABASE_URL: "postgres://test:test@localhost:5432/test",
+    AUTH_SECRET: "test-auth-secret",
+    REDIS_URL: undefined,
+  },
+}));
+
+// ── Hoisted mock instances ────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  // auth
+  getSafeSession: vi.fn(),
+  mintTier1ForConsumer: vi.fn(),
+  // anon session
+  getAnonymousSession: vi.fn(),
+  setAnonymousSession: vi.fn(),
+  createAnonymousSession: vi.fn(),
+  // db
+  upsertUserFromSession: vi.fn(),
+  getUserById: vi.fn(),
+  getChatById: vi.fn(),
+  getMessageById: vi.fn(),
+  getMessageCanceledAt: vi.fn(),
+  saveChat: vi.fn(),
+  saveMessage: vi.fn(),
+  updateMessage: vi.fn(),
+  updateMessageActiveStreamId: vi.fn(),
+  getThreadUpToMessageId: vi.fn(),
+  // credits + tier
+  canSpend: vi.fn(),
+  deductCredits: vi.fn(),
+  deductOrgCredits: vi.fn(),
+  recordUsageEvent: vi.fn(),
+  // misc
+  generateTitleFromUserMessage: vi.fn(),
+  getMcpConnectorsByUserId: vi.fn(),
+  getServerFeatureFlag: vi.fn(),
+  checkAnonymousRateLimit: vi.fn(),
+  checkAuthenticatedRateLimit: vi.fn(),
+  getClientIP: vi.fn(),
+  captureServerEvent: vi.fn(),
+  isModelAllowed: vi.fn(),
+  canSpendCredits: vi.fn(),
+  getUpgradeMessage: vi.fn(),
+  getAppModelDefinition: vi.fn(),
+}));
+
+// ── Module-level mocks ─────────────────────────────────────────────────
+
+vi.mock("@/lib/auth", () => ({
+  getSafeSession: mocks.getSafeSession,
+  hasNeonAuth: false,
+  auth: {},
+}));
+
+vi.mock("@/lib/auth/lifegw-jwt", () => ({
+  mintTier1ForConsumer: mocks.mintTier1ForConsumer,
+}));
+
+vi.mock("@/lib/anonymous-session-server", () => ({
+  getAnonymousSession: mocks.getAnonymousSession,
+  setAnonymousSession: mocks.setAnonymousSession,
+}));
+
+vi.mock("@/lib/create-anonymous-session", () => ({
+  createAnonymousSession: mocks.createAnonymousSession,
+}));
+
+vi.mock("@/lib/db/queries", () => ({
+  upsertUserFromSession: mocks.upsertUserFromSession,
+  getUserById: mocks.getUserById,
+  getChatById: mocks.getChatById,
+  getMessageById: mocks.getMessageById,
+  getMessageCanceledAt: mocks.getMessageCanceledAt,
+  saveChat: mocks.saveChat,
+  saveMessage: mocks.saveMessage,
+  updateMessage: mocks.updateMessage,
+  updateMessageActiveStreamId: mocks.updateMessageActiveStreamId,
+  getProjectById: vi.fn(),
+}));
+
+vi.mock("@/lib/db/credits", () => ({
+  canSpend: mocks.canSpend,
+  deductCredits: mocks.deductCredits,
+}));
+
+vi.mock("@/lib/db/usage", () => ({
+  deductOrgCredits: mocks.deductOrgCredits,
+  recordUsageEvent: mocks.recordUsageEvent,
+}));
+
+vi.mock("@/lib/db/mcp-queries", () => ({
+  getMcpConnectorsByUserId: mocks.getMcpConnectorsByUserId,
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({
+          where: () => ({
+            limit: () => [],
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/feature-flags", () => ({
+  getServerFeatureFlag: mocks.getServerFeatureFlag,
+}));
+
+vi.mock("@/lib/utils/rate-limit", () => ({
+  checkAnonymousRateLimit: mocks.checkAnonymousRateLimit,
+  checkAuthenticatedRateLimit: mocks.checkAuthenticatedRateLimit,
+  getClientIP: mocks.getClientIP,
+}));
+
+vi.mock("@/lib/analytics/posthog", () => ({
+  captureServerEvent: mocks.captureServerEvent,
+}));
+
+vi.mock("@/lib/tier-access", () => ({
+  isModelAllowed: mocks.isModelAllowed,
+  canSpendCredits: mocks.canSpendCredits,
+  getUpgradeMessage: mocks.getUpgradeMessage,
+}));
+
+vi.mock("@/lib/ai/app-models", () => ({
+  getAppModelDefinition: mocks.getAppModelDefinition,
+}));
+
+vi.mock("../get-thread-up-to-message-id", () => ({
+  getThreadUpToMessageId: mocks.getThreadUpToMessageId,
+}));
+
+vi.mock("../../../actions", () => ({
+  generateTitleFromUserMessage: mocks.generateTitleFromUserMessage,
+}));
+
+// Arcan modules — keep a separate marker so we can assert they're
+// never touched by the route. If the route imports them, the mock fires
+// and the test FAILS via the spy below.
+const arcanGuard = vi.hoisted(() => ({
+  executeViaArcan: vi.fn(() => {
+    throw new Error("Arcan must not be invoked from /api/chat in PR-3");
+  }),
+  resolveArcanEndpoints: vi.fn(() => {
+    throw new Error("Arcan must not be invoked from /api/chat in PR-3");
+  }),
+  markInstanceDegraded: vi.fn(() => {
+    throw new Error("Arcan must not be invoked from /api/chat in PR-3");
+  }),
+}));
+
+vi.mock("@/lib/arcan", () => arcanGuard);
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
+vi.mock("next/server", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/server")>("next/server");
+  return {
+    ...actual,
+    after: (fn: () => unknown) => {
+      // Fire after-callbacks synchronously so DB-write side effects are
+      // observable inside the test. Real Next runs them post-response;
+      // for unit tests it's fine to drain them eagerly.
+      try {
+        const r = fn();
+        if (r instanceof Promise) r.catch(() => undefined);
+      } catch {
+        // swallow
+      }
+    },
+  };
+});
+
+// ── Bring route in AFTER mocks ────────────────────────────────────────
+
+import type { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type {
+  AgentStreamInput,
+  CanonicalAgentEvent,
+} from "@/lib/life-runtime/agent-session/types";
+import { __setSessionClientFactoryForTests, POST } from "../route";
+
+// ── Fake LifedWsAgentSessionClient ────────────────────────────────────
+
+interface FakeOpts {
+  events?: CanonicalAgentEvent["event"][];
+  createSessionCalls?: Array<{
+    resumeSid?: string;
+    userId: string;
+    capability: { token: string };
+  }>;
+  streamCalls?: AgentStreamInput[];
+}
+
+function makeFakeClient(opts: FakeOpts): LifedWsAgentSessionClient {
+  const events = opts.events ?? [
+    { kind: "token", delta: "Hello!" },
+    {
+      kind: "finish",
+      reason: "stop",
+      usage: { inputTokens: 5, outputTokens: 3 },
+    },
+  ];
+  return {
+    backendId: "lifed-ws" as const,
+    async createSession(input: {
+      capability: { token: string };
+      userId: string;
+      projectSlug: string;
+      resumeSid?: string;
+    }) {
+      opts.createSessionCalls?.push({
+        resumeSid: input.resumeSid,
+        userId: input.userId,
+        capability: input.capability,
+      });
+      return {
+        sid: input.resumeSid ?? "fresh-sid",
+        agentId: `agent_${input.userId}`,
+        userId: input.userId,
+        projectId: input.projectSlug,
+        createdAtUnix: 0,
+      };
+    },
+    async sendMessage() {},
+    async health() {
+      return { backendId: "lifed-ws", reachable: true };
+    },
+    async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
+      opts.streamCalls?.push(input);
+      let i = 0n;
+      for (const ev of events) {
+        yield { seq: ++i, at: new Date().toISOString(), event: ev };
+      }
+    },
+  } as unknown as LifedWsAgentSessionClient;
+}
+
+// ── Request helpers ────────────────────────────────────────────────────
+
+function makeRequest(body: unknown): import("next/server").NextRequest {
+  return new Request("https://broomva.tech/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+const ANON_MODEL = "openai/gpt-5-mini";
+const AUTH_MODEL = "anthropic/claude-sonnet-4";
+
+function makeChatMessage(
+  text: string,
+  modelId = ANON_MODEL,
+): {
+  id: string;
+  role: "user";
+  parts: Array<{ type: "text"; text: string }>;
+  metadata: {
+    createdAt: Date;
+    parentMessageId: string | null;
+    selectedModel: string;
+    activeStreamId: string | null;
+  };
+} {
+  return {
+    id: `msg_${Math.random().toString(36).slice(2, 10)}`,
+    role: "user",
+    parts: [{ type: "text", text }],
+    metadata: {
+      createdAt: new Date(),
+      parentMessageId: null,
+      selectedModel: modelId,
+      activeStreamId: null,
+    },
+  };
+}
+
+// Drains an SSE response body into the raw string for asserting on
+// chunk markers (`data: ...\n\n`).
+//
+// The route returns `new Response(stream, ...)` where `stream` is a
+// `ReadableStream<string>` (the output of `JsonToSseTransformStream`).
+// `Response.text()` works on real browsers / Node fetch but vitest's
+// node env complains about non-Uint8Array chunks, so we drain the
+// reader manually and concatenate.
+async function drainBody(resp: Response): Promise<string> {
+  if (!resp.body) return "";
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (typeof value === "string") {
+      out += value;
+    } else if (value instanceof Uint8Array) {
+      out += decoder.decode(value, { stream: true });
+    } else if (value != null) {
+      out += String(value);
+    }
+  }
+  out += decoder.decode();
+  return out;
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  for (const m of Object.values(mocks)) m.mockReset();
+
+  // Default permissive behaviour — overridden per test as needed.
+  mocks.getSafeSession.mockResolvedValue({ data: null, error: null });
+  mocks.mintTier1ForConsumer.mockResolvedValue({
+    token: "fake-tier1-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 900,
+  });
+  mocks.getAnonymousSession.mockResolvedValue({
+    id: "anon-abc",
+    remainingCredits: 5,
+    createdAt: new Date(),
+  });
+  mocks.createAnonymousSession.mockResolvedValue({
+    id: "anon-abc",
+    remainingCredits: 5,
+    createdAt: new Date(),
+  });
+  mocks.setAnonymousSession.mockResolvedValue(undefined);
+  mocks.upsertUserFromSession.mockResolvedValue(undefined);
+  mocks.getUserById.mockResolvedValue({ id: "user_1", email: "x@y" });
+  mocks.getChatById.mockResolvedValue(null); // fresh chat by default
+  mocks.getMessageById.mockResolvedValue([]); // message not yet saved
+  mocks.getMessageCanceledAt.mockResolvedValue(null);
+  mocks.saveChat.mockResolvedValue(undefined);
+  mocks.saveMessage.mockResolvedValue(undefined);
+  mocks.updateMessage.mockResolvedValue(undefined);
+  mocks.updateMessageActiveStreamId.mockResolvedValue(undefined);
+  mocks.getThreadUpToMessageId.mockResolvedValue([]);
+  mocks.canSpend.mockResolvedValue(true);
+  mocks.deductCredits.mockResolvedValue(undefined);
+  mocks.deductOrgCredits.mockResolvedValue(undefined);
+  mocks.recordUsageEvent.mockResolvedValue(undefined);
+  mocks.generateTitleFromUserMessage.mockResolvedValue("Test chat");
+  mocks.getMcpConnectorsByUserId.mockResolvedValue([]);
+  mocks.getServerFeatureFlag.mockResolvedValue(true);
+  mocks.checkAnonymousRateLimit.mockResolvedValue({ success: true });
+  mocks.checkAuthenticatedRateLimit.mockResolvedValue({ success: true });
+  mocks.getClientIP.mockReturnValue("127.0.0.1");
+  mocks.isModelAllowed.mockReturnValue(true);
+  mocks.canSpendCredits.mockReturnValue({ allowed: true, remaining: 100 });
+  mocks.getUpgradeMessage.mockReturnValue("upgrade");
+  mocks.getAppModelDefinition.mockResolvedValue({
+    id: ANON_MODEL,
+    apiModelId: ANON_MODEL,
+    input: { text: true },
+    output: { text: true },
+  });
+  mocks.captureServerEvent.mockReturnValue(undefined);
+
+  vi.stubEnv("LIFED_GATEWAY_URL", "https://gw.example.test");
+  // Disable Redis (resumable stream context bypassed)
+  vi.stubEnv("REDIS_URL", "");
+});
+
+afterEach(() => {
+  __setSessionClientFactoryForTests(undefined);
+  vi.unstubAllEnvs();
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe("POST /api/chat — anonymous flow", () => {
+  it("dispatches via lifegw with an anon consumer and streams Vercel-AI-SDK SSE", async () => {
+    const createSessionCalls: FakeOpts["createSessionCalls"] = [];
+    const streamCalls: FakeOpts["streamCalls"] = [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls, streamCalls }),
+    );
+
+    const chatId = "11111111-1111-1111-1111-111111111111";
+    const req = makeRequest({
+      id: chatId,
+      message: makeChatMessage("Hello", ANON_MODEL),
+      prevMessages: [],
+    });
+
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const body = await drainBody(resp);
+    // The translator emits text-start + text-delta + text-end and the
+    // SDK's createUIMessageStream owns the finish event.
+    expect(body).toContain("text-start");
+    expect(body).toContain("text-delta");
+    expect(body).toContain("Hello!");
+    // SSE wire framing — `data: ...` per chunk plus a `[DONE]` sentinel
+    expect(body).toMatch(/data: \{[^}]+\}/);
+    expect(body).toContain("[DONE]");
+    // Anonymous users don't get `data-chatConfirmed` (the chat record
+    // isn't persisted for anon users); that fires only on the
+    // authenticated isNewChat path — see the authenticated test below.
+
+    expect(createSessionCalls).toHaveLength(1);
+    // anon consumer id comes from the anonymous-session cookie (NOT
+    // chatId — same anon session can have multiple chats, all minted
+    // under the same Tier-0 subject)
+    expect(createSessionCalls![0].userId).toBe("anon:anon-abc");
+    // sticky sid is the chatId — per-chat continuity
+    expect(createSessionCalls![0].resumeSid).toBe(chatId);
+    expect(mocks.mintTier1ForConsumer).toHaveBeenCalledWith({
+      consumer: { kind: "anon", id: "anon-abc" },
+      projectSlug: "default",
+    });
+
+    // Anon credits pre-deducted
+    expect(mocks.setAnonymousSession).toHaveBeenCalledWith(
+      expect.objectContaining({ remainingCredits: 4 }),
+    );
+
+    // Arcan was NOT invoked
+    expect(arcanGuard.executeViaArcan).not.toHaveBeenCalled();
+    expect(arcanGuard.resolveArcanEndpoints).not.toHaveBeenCalled();
+  });
+
+  it("rejects anonymous request when model is not in ANONYMOUS_LIMITS", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest({
+      id: "22222222-2222-2222-2222-222222222222",
+      message: makeChatMessage("Hi", "anthropic/claude-opus-4"),
+      prevMessages: [],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(403);
+  });
+
+  it("rejects when anonymous credits are exhausted", async () => {
+    mocks.getAnonymousSession.mockResolvedValue({
+      id: "anon-empty",
+      remainingCredits: 0,
+      createdAt: new Date(),
+    });
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest({
+      id: "33333333-3333-3333-3333-333333333333",
+      message: makeChatMessage("Hi", ANON_MODEL),
+      prevMessages: [],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(402);
+  });
+});
+
+describe("POST /api/chat — authenticated flow", () => {
+  it("dispatches via lifegw with a user consumer and persists assistant message", async () => {
+    mocks.getSafeSession.mockResolvedValue({
+      data: {
+        user: { id: "user_alice", email: "alice@x", name: "Alice" },
+      },
+      error: null,
+    });
+    mocks.getAppModelDefinition.mockResolvedValue({
+      id: AUTH_MODEL,
+      apiModelId: AUTH_MODEL,
+      input: { text: true },
+      output: { text: true },
+    });
+    const createSessionCalls: FakeOpts["createSessionCalls"] = [];
+    __setSessionClientFactoryForTests(() =>
+      makeFakeClient({ createSessionCalls }),
+    );
+    const chatId = "44444444-4444-4444-4444-444444444444";
+    const req = makeRequest({
+      id: chatId,
+      message: makeChatMessage("Hello!", AUTH_MODEL),
+      prevMessages: [],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+
+    // Drain so onFinish fires
+    await drainBody(resp);
+
+    expect(createSessionCalls![0].userId).toBe("user_alice");
+    expect(mocks.mintTier1ForConsumer).toHaveBeenCalledWith({
+      consumer: { kind: "user", id: "user_alice" },
+      projectSlug: "default",
+    });
+
+    // Placeholder assistant message was saved BEFORE streaming (so
+    // resumable-stream replay would land)
+    expect(mocks.saveMessage).toHaveBeenCalled();
+    // Credit deduction wired
+    // (Bun + vitest+timers run after the response — drainBody flushes
+    // the entire SSE so onFinish has already run.)
+    expect(mocks.deductCredits).toHaveBeenCalled();
+  });
+
+  it("emits data-chatConfirmed for a brand-new authenticated chat", async () => {
+    mocks.getSafeSession.mockResolvedValue({
+      data: { user: { id: "user_first", email: "f@x", name: "F" } },
+      error: null,
+    });
+    mocks.getAppModelDefinition.mockResolvedValue({
+      id: AUTH_MODEL,
+      apiModelId: AUTH_MODEL,
+      input: { text: true },
+      output: { text: true },
+    });
+    // No chat exists yet → isNewChat=true → data-chatConfirmed fires
+    mocks.getChatById.mockResolvedValue(null);
+
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest({
+      id: "77777777-7777-7777-7777-777777777777",
+      message: makeChatMessage("Greet me", AUTH_MODEL),
+      prevMessages: [],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(200);
+    const body = await drainBody(resp);
+    expect(body).toContain("data-chatConfirmed");
+    // saveChat was called for the new chat record
+    expect(mocks.saveChat).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/chat — lifegw configuration", () => {
+  it("returns 503 when LIFED_GATEWAY_URL is unset", async () => {
+    vi.stubEnv("LIFED_GATEWAY_URL", "");
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest({
+      id: "55555555-5555-5555-5555-555555555555",
+      message: makeChatMessage("hi", ANON_MODEL),
+      prevMessages: [],
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(503);
+    expect(await resp.text()).toContain("lifegw is not configured");
+  });
+});
+
+describe("POST /api/chat — request validation", () => {
+  it("returns 400 when message is missing", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest({ id: "no-msg-id", prevMessages: [] });
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 400 when selectedModel metadata is missing", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const message = makeChatMessage("hi", ANON_MODEL);
+    // Strip selectedModel
+    (message.metadata as Record<string, unknown>).selectedModel = undefined;
+    const req = makeRequest({ id: "no-model", message, prevMessages: [] });
+    const resp = await POST(req);
+    expect(resp.status).toBe(400);
+  });
+});
+
+describe("POST /api/chat — Arcan no-touch invariant", () => {
+  it("never imports/invokes lib/arcan even when authenticated", async () => {
+    mocks.getSafeSession.mockResolvedValue({
+      data: { user: { id: "user_a", email: "a@b", name: "A" } },
+      error: null,
+    });
+    mocks.getAppModelDefinition.mockResolvedValue({
+      id: AUTH_MODEL,
+      apiModelId: AUTH_MODEL,
+      input: { text: true },
+      output: { text: true },
+    });
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+    const req = makeRequest({
+      id: "66666666-6666-6666-6666-666666666666",
+      message: makeChatMessage("hi", AUTH_MODEL),
+      prevMessages: [],
+    });
+    const resp = await POST(req);
+    await drainBody(resp);
+    expect(arcanGuard.executeViaArcan).not.toHaveBeenCalled();
+    expect(arcanGuard.resolveArcanEndpoints).not.toHaveBeenCalled();
+    expect(arcanGuard.markInstanceDegraded).not.toHaveBeenCalled();
+  });
+});

--- a/apps/broomva/app/(chat)/api/chat/route.ts
+++ b/apps/broomva/app/(chat)/api/chat/route.ts
@@ -3,6 +3,7 @@ import {
   createUIMessageStream,
   JsonToSseTransformStream,
 } from "ai";
+import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import type { NextRequest } from "next/server";
 import { after } from "next/server";
@@ -17,17 +18,18 @@ import {
   type AppModelId,
   getAppModelDefinition,
 } from "@/lib/ai/app-models";
-import { createCoreChatAgent } from "@/lib/ai/core-chat-agent";
 import { determineExplicitlyRequestedTools } from "@/lib/ai/determine-explicitly-requested-tools";
 import { ChatSDKError } from "@/lib/ai/errors";
-import {
-  generateFollowupSuggestions,
-  streamFollowupSuggestions,
-} from "@/lib/ai/followup-suggestions";
-import { buildSystemPrompt } from "@/lib/ai/prompts";
 import { calculateMessagesTokens } from "@/lib/ai/token-utils";
 import { allTools } from "@/lib/ai/tools/tools-definitions";
 import type { ChatMessage, ToolName } from "@/lib/ai/types";
+import {
+  EVENT_CHAT_STARTED,
+  EVENT_CREDITS_EXHAUSTED,
+  EVENT_MESSAGE_SENT,
+  EVENT_TOOL_USED,
+} from "@/lib/analytics/events";
+import { captureServerEvent } from "@/lib/analytics/posthog";
 import {
   getAnonymousSession,
   setAnonymousSession,
@@ -36,56 +38,51 @@ import { getSafeSession } from "@/lib/auth";
 import { config } from "@/lib/config";
 import { createAnonymousSession } from "@/lib/create-anonymous-session";
 import { CostAccumulator } from "@/lib/credits/cost-accumulator";
+import { db as tierDb } from "@/lib/db/client";
 import { canSpend, deductCredits } from "@/lib/db/credits";
 import { getMcpConnectorsByUserId } from "@/lib/db/mcp-queries";
-import { deductOrgCredits, recordUsageEvent } from "@/lib/db/usage";
 import {
   getChatById,
   getMessageById,
   getMessageCanceledAt,
-  getProjectById,
   getUserById,
   saveChat,
   saveMessage,
-  upsertUserFromSession,
   updateMessage,
   updateMessageActiveStreamId,
+  upsertUserFromSession,
 } from "@/lib/db/queries";
 import type { McpConnector } from "@/lib/db/schema";
 import { organization, organizationMember } from "@/lib/db/schema";
-import { db as tierDb } from "@/lib/db/client";
-import { eq } from "drizzle-orm";
+import { deductOrgCredits, recordUsageEvent } from "@/lib/db/usage";
 import { env } from "@/lib/env";
+import type { FeatureFlag } from "@/lib/feature-flags";
+import { getServerFeatureFlag } from "@/lib/feature-flags";
+import {
+  type CanonicalConsumeState,
+  canonicalToVercelAiSdkSse,
+  makeConsumeState,
+} from "@/lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse";
+import {
+  dispatchViaLifegw,
+  getLifegwBaseUrl,
+  type SessionClientFactory,
+} from "@/lib/life-runtime/edge-adapter/dispatch-via-lifegw";
 import { MAX_INPUT_TOKENS } from "@/lib/limits/tokens";
 import { createModuleLogger } from "@/lib/logger";
+import {
+  canSpendCredits,
+  getUpgradeMessage,
+  isModelAllowed,
+} from "@/lib/tier-access";
 import type { AnonymousSession } from "@/lib/types/anonymous";
 import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
 import { generateUUID } from "@/lib/utils";
-import {
-  isModelAllowed,
-  canSpendCredits,
-  getUpgradeMessage,
-} from "@/lib/tier-access";
 import {
   checkAnonymousRateLimit,
   checkAuthenticatedRateLimit,
   getClientIP,
 } from "@/lib/utils/rate-limit";
-import {
-  executeViaArcan,
-  resolveArcanEndpoints,
-  markInstanceDegraded,
-} from "@/lib/arcan";
-import type { ArcanPolicySet } from "@/lib/arcan/execute";
-import { captureServerEvent } from "@/lib/analytics/posthog";
-import {
-  EVENT_CHAT_STARTED,
-  EVENT_CREDITS_EXHAUSTED,
-  EVENT_MESSAGE_SENT,
-  EVENT_TOOL_USED,
-} from "@/lib/analytics/events";
-import { getServerFeatureFlag } from "@/lib/feature-flags";
-import type { FeatureFlag } from "@/lib/feature-flags";
 import { generateTitleFromUserMessage } from "../../actions";
 import { getThreadUpToMessageId } from "./get-thread-up-to-message-id";
 
@@ -149,6 +146,18 @@ export async function getStreamContext(): Promise<ResumableStreamContext | null>
   });
 
   return globalStreamContext;
+}
+
+// ── Test seam — lifegw client factory override ───────────────────────────
+// Production code leaves this undefined and the dispatcher constructs a
+// real `LifedWsAgentSessionClient`. Tests use `__setSessionClientFactoryForTests`
+// to inject a mock so the route can run without an actual gateway.
+let testLifegwClientFactory: SessionClientFactory | undefined;
+
+export function __setSessionClientFactoryForTests(
+  factory: SessionClientFactory | undefined,
+): void {
+  testLifegwClientFactory = factory;
 }
 
 type AnonymousSessionResult =
@@ -321,7 +330,11 @@ const FLAG_GATED_TOOLS: Partial<Record<FeatureFlag, ToolName[]>> = {
   image_generation: ["generateImage"],
   web_search: ["webSearch"],
   url_retrieval: ["retrieveUrl"],
-  knowledge_graph: ["searchKnowledge", "readKnowledgeNote", "traverseKnowledge"],
+  knowledge_graph: [
+    "searchKnowledge",
+    "readKnowledgeNote",
+    "traverseKnowledge",
+  ],
 };
 
 /** The feature flags that gate premium chat tools. */
@@ -388,7 +401,12 @@ function getToolGateUpgradeMessage(toolName: ToolName): string {
 /**
  * Determines which built-in tools are allowed based on model capabilities
  * and feature flags.
- * MCP tools are handled separately in core-chat-agent.
+ *
+ * NOTE: lifegw owns server-side tool dispatch — the in-app route no
+ * longer constructs `getTools()` / `streamText`. The allow-list returned
+ * here is still useful for the explicit-request gate (the user clicking
+ * the "deepResearch" button, etc.) so we can return a 403 *before* the
+ * call hits lifegw rather than relying on lifegw's policy denial.
  */
 function determineAllowedTools({
   isAnonymous,
@@ -426,328 +444,94 @@ function determineAllowedTools({
   return allowedTools;
 }
 
-async function getSystemPrompt({
+async function finalizeMessageAndCredits({
+  assistantMessage,
+  userId,
+  organizationId,
   isAnonymous,
   chatId,
-  userName,
+  costAccumulator,
 }: {
+  assistantMessage: ChatMessage | undefined;
+  userId: string | null;
+  organizationId: string | null;
   isAnonymous: boolean;
   chatId: string;
-  userName?: string | null;
-}): Promise<string> {
-  let system = await buildSystemPrompt({
-    isAnonymous,
-    userName,
-    memoryVaultAvailable: config.features.memoryVault && !isAnonymous,
-  });
-  if (!isAnonymous) {
-    const currentChat = await getChatById({ id: chatId });
-    if (currentChat?.projectId) {
-      const project = await getProjectById({ id: currentChat.projectId });
-      if (project?.instructions) {
-        system = `${system}\n\n---\n\n## Project instructions\n\n${project.instructions}`;
+  costAccumulator: CostAccumulator;
+}): Promise<void> {
+  const log = createModuleLogger("api:chat:finalize");
+
+  try {
+    if (!assistantMessage) {
+      throw new Error("No assistant message found!");
+    }
+
+    if (!isAnonymous) {
+      await updateMessage({
+        id: assistantMessage.id,
+        chatId,
+        message: {
+          ...assistantMessage,
+          metadata: {
+            ...assistantMessage.metadata,
+            activeStreamId: null,
+          },
+        },
+      });
+    }
+
+    // Get total cost from accumulator (includes all LLM calls + external API costs)
+    const totalCost = await costAccumulator.getTotalCost();
+    const entries = costAccumulator.getEntries();
+
+    log.info({ entries }, "Cost accumulator entries");
+    log.info({ totalCost }, "Cost accumulator total cost");
+
+    // Capture tool_used if assistant message contains tool-* parts (AI SDK v6 naming)
+    if (userId && !isAnonymous) {
+      const toolParts = (assistantMessage.parts ?? []).filter(
+        (p) => typeof p.type === "string" && p.type.startsWith("tool-"),
+      );
+      if (toolParts.length > 0) {
+        captureServerEvent(userId, EVENT_TOOL_USED, {
+          chatId,
+          toolCount: toolParts.length,
+          tools: toolParts.map((p) => p.type.slice("tool-".length)),
+        });
       }
     }
-  }
-  return system;
-}
 
-async function createChatStream({
-  messageId,
-  chatId,
-  userMessage,
-  previousMessages,
-  selectedModelId,
-  explicitlyRequestedTools,
-  userId,
-  organizationId,
-  allowedTools,
-  abortController,
-  isAnonymous,
-  isNewChat,
-  timeoutId,
-  mcpConnectors,
-  streamId,
-  userName,
-  onChunk,
-}: {
-  messageId: string;
-  chatId: string;
-  userMessage: ChatMessage;
-  previousMessages: ChatMessage[];
-  selectedModelId: AppModelId;
-  explicitlyRequestedTools: ToolName[] | null;
-  userId: string | null;
-  organizationId: string | null;
-  allowedTools: ToolName[];
-  abortController: AbortController;
-  isAnonymous: boolean;
-  isNewChat: boolean;
-  timeoutId: NodeJS.Timeout;
-  mcpConnectors: McpConnector[];
-  streamId: string;
-  userName?: string | null;
-  onChunk?: () => void;
-}) {
-  const log = createModuleLogger("api:chat:stream");
-  const system = await getSystemPrompt({
-    isAnonymous,
-    chatId,
-    userName: isAnonymous ? null : userName ?? null,
-  });
+    // Deduct credits for authenticated users
+    if (userId && !isAnonymous) {
+      await deductCredits(userId, totalCost);
 
-  // Create cost accumulator to track all LLM and API costs
-  const costAccumulator = new CostAccumulator();
-
-  // Build the data stream that will emit tokens
-  const stream = createUIMessageStream<ChatMessage>({
-    execute: async ({ writer: dataStream }) => {
-      // Confirm chat persistence on first message (chat + user message are persisted before streaming begins)
-      if (isNewChat) {
-        dataStream.write({
-          id: generateUUID(),
-          type: "data-chatConfirmed",
-          data: { chatId },
-          transient: true,
+      // Deduct org-level credits (atomic — skips if org has insufficient balance)
+      if (organizationId) {
+        deductOrgCredits(organizationId, totalCost).catch((err) => {
+          log.error({ error: err }, "Failed to deduct org credits");
         });
       }
 
-      const { result, contextForLLM } = await createCoreChatAgent({
-        system,
-        userMessage,
-        previousMessages,
-        selectedModelId,
-        explicitlyRequestedTools,
+      // Record usage event (fire-and-forget, non-blocking)
+      const tokenBreakdown = costAccumulator.getTokenBreakdown();
+      recordUsageEvent({
+        organizationId: organizationId ?? undefined,
         userId,
-        budgetAllowedTools: allowedTools,
-        abortSignal: abortController.signal,
-        messageId,
+        type: "ai_tokens",
+        resource: tokenBreakdown.modelId ?? undefined,
+        inputTokens: tokenBreakdown.inputTokens,
+        outputTokens: tokenBreakdown.outputTokens,
+        costCents: totalCost,
         chatId,
-        dataStream,
-        onError: (error) => {
-          log.error({ error }, "streamText error");
-        },
-        onChunk,
-        mcpConnectors,
-        costAccumulator,
+      }).catch((err) => {
+        log.error({ error: err }, "Failed to record usage event");
       });
+    }
 
-      const initialMetadata: ChatMessage["metadata"] = {
-        createdAt: new Date(),
-        parentMessageId: userMessage.id,
-        selectedModel: selectedModelId,
-        activeStreamId: isAnonymous ? null : streamId,
-      };
-
-      dataStream.merge(
-        result.toUIMessageStream({
-          sendReasoning: true,
-          messageMetadata: ({ part }) => {
-            // send custom information to the client on start:
-            if (part.type === "start") {
-              return initialMetadata;
-            }
-
-            // when the message is finished, send additional information:
-            if (part.type === "finish") {
-              // Add main stream LLM usage to accumulator
-              if (part.totalUsage) {
-                costAccumulator.addLLMCost(
-                  selectedModelId,
-                  part.totalUsage,
-                  "main-chat",
-                );
-              }
-              return {
-                ...initialMetadata,
-                usage: part.totalUsage,
-                activeStreamId: null,
-              };
-            }
-          },
-        }),
-      );
-      await result.consumeStream();
-
-      const response = await result.response;
-      const responseMessages = response.messages;
-
-      // Generate and stream follow-up suggestions
-      if (config.features.followupSuggestions) {
-        const followupSuggestionsResult = generateFollowupSuggestions([
-          ...contextForLLM,
-          ...responseMessages,
-        ]);
-        await streamFollowupSuggestions({
-          followupSuggestionsResult,
-          writer: dataStream,
-        });
-      }
-    },
-    generateId: () => messageId,
-    onFinish: async ({ messages }) => {
-      clearTimeout(timeoutId);
-      await finalizeMessageAndCredits({
-        messages,
-        userId,
-        organizationId,
-        isAnonymous,
-        chatId,
-        costAccumulator,
-      });
-    },
-    onError: (error) => {
-      clearTimeout(timeoutId);
-      // If the stream fails, ensure the placeholder assistant message is no longer marked resumable.
-      // Otherwise the client will try to resume a stream that no longer exists and we end up with a
-      // stuck partial placeholder on reload.
-      if (!isAnonymous) {
-        after(() =>
-          Promise.resolve(
-            updateMessageActiveStreamId({
-              id: messageId,
-              activeStreamId: null,
-            }),
-          ).catch((dbError) => {
-            log.error(
-              { error: dbError },
-              "Failed to clear activeStreamId on stream error",
-            );
-          }),
-        );
-      }
-
-      log.error({ error }, "onError");
-      return "Oops, an error occured!";
-    },
-  });
-
-  return stream;
-}
-
-async function executeChatRequest({
-  chatId,
-  userMessage,
-  previousMessages,
-  selectedModelId,
-  explicitlyRequestedTools,
-  userId,
-  organizationId,
-  isAnonymous,
-  isNewChat,
-  allowedTools,
-  abortController,
-  timeoutId,
-  mcpConnectors,
-  userName,
-}: {
-  chatId: string;
-  userMessage: ChatMessage;
-  previousMessages: ChatMessage[];
-  selectedModelId: AppModelId;
-  explicitlyRequestedTools: ToolName[] | null;
-  userId: string | null;
-  organizationId: string | null;
-  isAnonymous: boolean;
-  isNewChat: boolean;
-  allowedTools: ToolName[];
-  abortController: AbortController;
-  timeoutId: NodeJS.Timeout;
-  mcpConnectors: McpConnector[];
-  userName?: string | null;
-}): Promise<Response> {
-  const log = createModuleLogger("api:chat:execute");
-  const messageId = generateUUID();
-  const streamId = generateUUID();
-
-  if (!isAnonymous) {
-    // Save placeholder assistant message immediately (needed for document creation)
-    await saveMessage({
-      id: messageId,
-      chatId,
-      message: {
-        id: messageId,
-        role: "assistant",
-        parts: [],
-        metadata: {
-          createdAt: new Date(),
-          parentMessageId: userMessage.id,
-          selectedModel: selectedModelId,
-          selectedTool: undefined,
-          activeStreamId: streamId,
-        },
-      },
-    });
+    // Note: Anonymous credits are pre-deducted before streaming starts (cookies can't be set after response begins)
+  } catch (error) {
+    log.error({ error }, "Failed to save chat or finalize credits");
   }
-
-  // Create throttled cancel check (max once per second) for authenticated users
-  const onChunk =
-    !isAnonymous && userId
-      ? throttle(async () => {
-          const canceledAt = await getMessageCanceledAt({ messageId });
-          if (canceledAt) {
-            abortController.abort();
-          }
-        }, 1000)
-      : undefined;
-
-  // Build the data stream that will emit tokens
-  const stream = await createChatStream({
-    messageId,
-    chatId,
-    userMessage,
-    previousMessages,
-    selectedModelId,
-    explicitlyRequestedTools,
-    userId,
-    organizationId,
-    allowedTools,
-    abortController,
-    isAnonymous,
-    isNewChat,
-    timeoutId,
-    mcpConnectors,
-    streamId,
-    userName,
-    onChunk,
-  });
-
-  const redisClients = await ensureRedisClients();
-  const publisher = redisClients?.publisher;
-  if (publisher) {
-    after(async () => {
-      try {
-        const keyPattern = `${config.appPrefix}:resumable-stream:rs:sentinel:${streamId}*`;
-        const keys = await publisher.keys(keyPattern);
-        if (keys.length > 0) {
-          await Promise.all(
-            keys.map((key: string) => publisher.expire(key, 300)),
-          );
-        }
-      } catch (error) {
-        log.error({ error }, "Failed to set TTL on stream keys");
-      }
-    });
-  }
-
-  const sseHeaders = {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  } as const;
-
-  const streamContext = await getStreamContext();
-  const sseStream = () => stream.pipeThrough(new JsonToSseTransformStream());
-
-  if (streamContext) {
-    log.debug("Returning resumable stream");
-    return new Response(
-      await streamContext.resumableStream(streamId, sseStream),
-      { headers: sseHeaders },
-    );
-  }
-
-  return new Response(sseStream(), { headers: sseHeaders });
 }
 
 type SessionSetupResult =
@@ -883,133 +667,411 @@ async function prepareRequestContext({
   return { previousMessages, allowedTools, error: null };
 }
 
-async function finalizeMessageAndCredits({
-  messages,
-  userId,
-  organizationId,
-  isAnonymous,
-  chatId,
-  costAccumulator,
-}: {
-  messages: ChatMessage[];
-  userId: string | null;
-  organizationId: string | null;
-  isAnonymous: boolean;
-  chatId: string;
-  costAccumulator: CostAccumulator;
-}): Promise<void> {
-  const log = createModuleLogger("api:chat:finalize");
-
-  try {
-    const assistantMessage = messages.at(-1);
-
-    if (!assistantMessage) {
-      throw new Error("No assistant message found!");
-    }
-
-    if (!isAnonymous) {
-      await updateMessage({
-        id: assistantMessage.id,
-        chatId,
-        message: {
-          ...assistantMessage,
-          metadata: {
-            ...assistantMessage.metadata,
-            activeStreamId: null,
-          },
-        },
-      });
-    }
-
-    // Get total cost from accumulator (includes all LLM calls + external API costs)
-    const totalCost = await costAccumulator.getTotalCost();
-    const entries = costAccumulator.getEntries();
-
-    log.info({ entries }, "Cost accumulator entries");
-    log.info({ totalCost }, "Cost accumulator total cost");
-
-    // Capture tool_used if assistant message contains tool-* parts (AI SDK v6 naming)
-    if (userId && !isAnonymous) {
-      const toolParts = (messages.at(-1)?.parts ?? []).filter(
-        (p) => typeof p.type === "string" && p.type.startsWith("tool-"),
-      );
-      if (toolParts.length > 0) {
-        captureServerEvent(userId, EVENT_TOOL_USED, {
-          chatId,
-          toolCount: toolParts.length,
-          tools: toolParts.map((p) => p.type.slice("tool-".length)),
-        });
+/**
+ * Extract plain user-text from a `ChatMessage`. The Vercel-AI-SDK v6
+ * `parts[]` shape may carry text + file + tool parts; lifegw expects a
+ * single user-message string so we concatenate every `text` part. File
+ * parts (images/PDFs/etc.) aren't handled in this PR — adding
+ * attachment forwarding is a follow-up once lifegw supports the
+ * `attachment_blob_ref` frame field.
+ */
+function extractUserMessageText(message: ChatMessage): string {
+  const parts = message.parts ?? [];
+  const textParts: string[] = [];
+  for (const part of parts) {
+    if (typeof part.type === "string" && part.type === "text") {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === "string" && text.length > 0) {
+        textParts.push(text);
       }
     }
-
-    // Deduct credits for authenticated users
-    if (userId && !isAnonymous) {
-      await deductCredits(userId, totalCost);
-
-      // Deduct org-level credits (atomic — skips if org has insufficient balance)
-      if (organizationId) {
-        deductOrgCredits(organizationId, totalCost).catch((err) => {
-          log.error({ error: err }, "Failed to deduct org credits");
-        });
-      }
-
-      // Record usage event (fire-and-forget, non-blocking)
-      const tokenBreakdown = costAccumulator.getTokenBreakdown();
-      recordUsageEvent({
-        organizationId: organizationId ?? undefined,
-        userId,
-        type: "ai_tokens",
-        resource: tokenBreakdown.modelId ?? undefined,
-        inputTokens: tokenBreakdown.inputTokens,
-        outputTokens: tokenBreakdown.outputTokens,
-        costCents: totalCost,
-        chatId,
-      }).catch((err) => {
-        log.error({ error: err }, "Failed to record usage event");
-      });
-    }
-
-    // Note: Anonymous credits are pre-deducted before streaming starts (cookies can't be set after response begins)
-  } catch (error) {
-    log.error({ error }, "Failed to save chat or finalize credits");
   }
+  return textParts.join("\n\n");
 }
 
 /**
- * Maps a subscription plan tier to an arcand PolicySet.
- * anonymous: heavily gated — no side-effecting capabilities, 5 events/turn
- * free:      read + search only, 15 events/turn
- * pro+:      full access, 50 events/turn
+ * Build the lifegw-routed response stream. Wraps the canonical iterator
+ * from `dispatchViaLifegw` in a `createUIMessageStream` so we can:
+ *
+ *   - Emit the existing `data-chatConfirmed` chunk on the first turn of
+ *     a new chat (chat-sync.tsx's UI reads this).
+ *   - Translate canonical agent events into Vercel-AI-SDK chunks.
+ *   - Capture the assistant message body + tool calls so the route's
+ *     persistence layer can write the finalised message to the DB
+ *     (replacing the placeholder created before streaming).
+ *   - Attach message metadata (createdAt, parentMessageId, model,
+ *     activeStreamId, usage) the same way the streamText path did.
+ *
+ * Returns an `AsyncIterableStream` of `UIMessageChunk` (same shape as
+ * `createUIMessageStream`), ready to be piped through
+ * `JsonToSseTransformStream`.
  */
-function buildArcanPolicy(plan: string): ArcanPolicySet {
-  if (plan === "anonymous") {
-    return {
-      allow_capabilities: ["fs:read:/session/**"],
-      gate_capabilities: [
-        "fs:write:**",
-        "exec:cmd:*",
-        "net:egress:*",
-        "secrets:read:*",
-      ],
-      max_events_per_turn: 5,
-      max_tool_runtime_secs: 30,
-    };
-  }
-  if (plan === "free") {
-    return {
-      allow_capabilities: ["fs:read:/session/**", "net:egress:*"],
-      gate_capabilities: ["fs:write:**", "exec:cmd:*", "secrets:read:*"],
-      max_events_per_turn: 15,
-      max_tool_runtime_secs: 30,
-    };
-  }
-  // pro / enterprise / any paid tier
-  return {
-    allow_capabilities: ["*"],
-    gate_capabilities: [],
-    max_events_per_turn: 50,
-    max_tool_runtime_secs: 60,
+async function createLifegwBackedChatStream({
+  messageId,
+  chatId,
+  userMessage,
+  selectedModelId,
+  userId,
+  anonymousSessionId,
+  organizationId,
+  abortController,
+  isAnonymous,
+  isNewChat,
+  timeoutId,
+  streamId,
+  onChunk,
+}: {
+  messageId: string;
+  chatId: string;
+  userMessage: ChatMessage;
+  selectedModelId: AppModelId;
+  userId: string | null;
+  /** Anonymous-session id — populated when `userId` is null. Used as the
+   *  `anon:<id>` subject on the Tier-0 cap so all turns in a guest
+   *  session share one consumer identity. */
+  anonymousSessionId: string | null;
+  organizationId: string | null;
+  abortController: AbortController;
+  isAnonymous: boolean;
+  isNewChat: boolean;
+  timeoutId: NodeJS.Timeout;
+  streamId: string;
+  onChunk?: () => void;
+}) {
+  const log = createModuleLogger("api:chat:stream");
+  const costAccumulator = new CostAccumulator();
+  const consumeState = makeConsumeState();
+
+  const initialMetadata: ChatMessage["metadata"] = {
+    createdAt: new Date(),
+    parentMessageId: userMessage.id,
+    selectedModel: selectedModelId,
+    activeStreamId: isAnonymous ? null : streamId,
   };
+
+  // chatId IS the sticky session id for the in-app surface — per-chat
+  // continuity is the semantics we want (one chat = one lifed session).
+  const stickySid = chatId;
+
+  // Anonymous callers mint a Tier-0 cap (`tier: "anon"`); authenticated
+  // users mint Tier-1. Both flow through the same dispatcher. We fall
+  // back to `chatId` if the anon session id is missing — that should
+  // never happen in production (`handleAnonymousSession` always
+  // produces one) but it keeps the call total before any I/O.
+  const consumer = userId
+    ? { kind: "user" as const, id: userId }
+    : { kind: "anon" as const, id: anonymousSessionId ?? chatId };
+
+  const userMessageText = extractUserMessageText(userMessage);
+
+  const stream = createUIMessageStream<ChatMessage>({
+    execute: async ({ writer: dataStream }) => {
+      // Confirm chat persistence on first message (chat + user message
+      // are persisted before streaming begins — this just signals the
+      // UI to update its sidebar)
+      if (isNewChat) {
+        dataStream.write({
+          id: generateUUID(),
+          type: "data-chatConfirmed",
+          data: { chatId },
+          transient: true,
+        });
+      }
+
+      // Open the lifegw dispatch. createSession failures surface here
+      // as a thrown error → caught by `createUIMessageStream`'s onError.
+      let dispatch: Awaited<ReturnType<typeof dispatchViaLifegw>>;
+      try {
+        dispatch = await dispatchViaLifegw({
+          stickySid,
+          userMessage: userMessageText,
+          consumer,
+          signal: abortController.signal,
+          clientFactory: testLifegwClientFactory,
+        });
+      } catch (err) {
+        log.error(
+          { err: err instanceof Error ? err.message : String(err) },
+          "dispatchViaLifegw failed",
+        );
+        // Surface as a UIMessageChunk error so chat-sync.tsx renders
+        // an inline error rather than a stream-disconnect.
+        dataStream.write({
+          type: "error",
+          errorText: `lifegw dispatch failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        });
+        return;
+      }
+
+      // Wrap the canonical iterator with a wakeup-on-progress filter
+      // that fires the cancel-check throttler on each frame the way
+      // the streamText path did via the `onChunk` callback.
+      const wrappedEvents = onChunk
+        ? wrapWithProgress(dispatch.events, onChunk)
+        : dispatch.events;
+
+      // Run the translator and merge its chunks into the writer.
+      for await (const chunk of canonicalToVercelAiSdkSse<ChatMessage>(
+        wrappedEvents,
+        {
+          fallbackTextId: messageId,
+          state: consumeState,
+        },
+      )) {
+        dataStream.write(chunk);
+      }
+
+      // After lifegw finishes, account the reported usage. The token
+      // counts come from lifegw's terminal `finish` event; cost-cents
+      // is optional (lifegw may pre-bill, leaving zero left to add).
+      if (consumeState.usage) {
+        costAccumulator.addLLMCost(
+          selectedModelId,
+          {
+            inputTokens: consumeState.usage.inputTokens ?? 0,
+            outputTokens: consumeState.usage.outputTokens ?? 0,
+          },
+          "main-chat",
+        );
+      }
+    },
+    generateId: () => messageId,
+    onFinish: async ({ responseMessage }) => {
+      clearTimeout(timeoutId);
+      // Stamp the response message's metadata with everything we know
+      // post-stream — usage, activeStreamId clear, parent + model.
+      const assistantMessage = stitchAssistantMessage({
+        responseMessage,
+        consumeState,
+        initialMetadata,
+      });
+      await finalizeMessageAndCredits({
+        assistantMessage,
+        userId,
+        organizationId,
+        isAnonymous,
+        chatId,
+        costAccumulator,
+      });
+    },
+    onError: (error) => {
+      clearTimeout(timeoutId);
+      // If the stream fails, ensure the placeholder assistant message
+      // is no longer marked resumable. Otherwise the client will try
+      // to resume a stream that no longer exists and we end up with a
+      // stuck partial placeholder on reload.
+      if (!isAnonymous) {
+        after(() =>
+          Promise.resolve(
+            updateMessageActiveStreamId({
+              id: messageId,
+              activeStreamId: null,
+            }),
+          ).catch((dbError) => {
+            log.error(
+              { error: dbError },
+              "Failed to clear activeStreamId on stream error",
+            );
+          }),
+        );
+      }
+
+      log.error({ error }, "onError");
+      return "Oops, an error occured!";
+    },
+  });
+
+  return stream;
+}
+
+/**
+ * Synthesize a `ChatMessage` to persist as the assistant turn. The
+ * Vercel-AI-SDK `responseMessage` passed to onFinish already carries
+ * the parts the client saw (text + tool + data); we just need to
+ * stamp the finalized metadata (usage, activeStreamId: null).
+ *
+ * Lifegw reports plain token counts (`{ inputTokens, outputTokens }`)
+ * but the SDK's `LanguageModelUsage` shape carries per-provider
+ * detail (cache reads, reasoning tokens). We pad the missing detail
+ * fields with `undefined` so the persisted metadata typecheck-passes
+ * without inventing data we don't actually have.
+ */
+function stitchAssistantMessage({
+  responseMessage,
+  consumeState,
+  initialMetadata,
+}: {
+  responseMessage: ChatMessage;
+  consumeState: CanonicalConsumeState;
+  initialMetadata: ChatMessage["metadata"];
+}): ChatMessage {
+  const usage = consumeState.usage
+    ? {
+        inputTokens: consumeState.usage.inputTokens,
+        outputTokens: consumeState.usage.outputTokens,
+        totalTokens:
+          (consumeState.usage.inputTokens ?? 0) +
+          (consumeState.usage.outputTokens ?? 0),
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+      }
+    : undefined;
+
+  return {
+    ...responseMessage,
+    metadata: {
+      ...initialMetadata,
+      ...responseMessage.metadata,
+      activeStreamId: null,
+      ...(usage ? { usage } : {}),
+    },
+  };
+}
+
+/**
+ * Wrap an `AsyncIterable<CanonicalAgentEvent>` so a side-effect
+ * callback fires on each yielded event. Used to thread the per-chunk
+ * cancel-check (which the streamText path used to expose via its
+ * `onChunk` option) into the lifegw event loop.
+ */
+async function* wrapWithProgress(
+  source: AsyncIterable<
+    import("@/lib/life-runtime/agent-session/types").CanonicalAgentEvent
+  >,
+  onChunk: () => void,
+): AsyncIterable<
+  import("@/lib/life-runtime/agent-session/types").CanonicalAgentEvent
+> {
+  for await (const ev of source) {
+    try {
+      onChunk();
+    } catch {
+      // swallow — cancel-check failures shouldn't abort the stream
+    }
+    yield ev;
+  }
+}
+
+async function executeChatRequest({
+  chatId,
+  userMessage,
+  selectedModelId,
+  userId,
+  anonymousSessionId,
+  organizationId,
+  isAnonymous,
+  isNewChat,
+  abortController,
+  timeoutId,
+}: {
+  chatId: string;
+  userMessage: ChatMessage;
+  selectedModelId: AppModelId;
+  userId: string | null;
+  anonymousSessionId: string | null;
+  organizationId: string | null;
+  isAnonymous: boolean;
+  isNewChat: boolean;
+  abortController: AbortController;
+  timeoutId: NodeJS.Timeout;
+}): Promise<Response> {
+  const log = createModuleLogger("api:chat:execute");
+  const messageId = generateUUID();
+  const streamId = generateUUID();
+
+  if (!isAnonymous) {
+    // Save placeholder assistant message immediately (needed for document creation)
+    await saveMessage({
+      id: messageId,
+      chatId,
+      message: {
+        id: messageId,
+        role: "assistant",
+        parts: [],
+        metadata: {
+          createdAt: new Date(),
+          parentMessageId: userMessage.id,
+          selectedModel: selectedModelId,
+          selectedTool: undefined,
+          activeStreamId: streamId,
+        },
+      },
+    });
+  }
+
+  // Create throttled cancel check (max once per second) for authenticated users
+  const onChunk =
+    !isAnonymous && userId
+      ? throttle(async () => {
+          const canceledAt = await getMessageCanceledAt({ messageId });
+          if (canceledAt) {
+            abortController.abort();
+          }
+        }, 1000)
+      : undefined;
+
+  // Build the data stream that will emit tokens
+  const stream = await createLifegwBackedChatStream({
+    messageId,
+    chatId,
+    userMessage,
+    selectedModelId,
+    userId,
+    anonymousSessionId,
+    organizationId,
+    abortController,
+    isAnonymous,
+    isNewChat,
+    timeoutId,
+    streamId,
+    onChunk,
+  });
+
+  const redisClients = await ensureRedisClients();
+  const publisher = redisClients?.publisher;
+  if (publisher) {
+    after(async () => {
+      try {
+        const keyPattern = `${config.appPrefix}:resumable-stream:rs:sentinel:${streamId}*`;
+        const keys = await publisher.keys(keyPattern);
+        if (keys.length > 0) {
+          await Promise.all(
+            keys.map((key: string) => publisher.expire(key, 300)),
+          );
+        }
+      } catch (error) {
+        log.error({ error }, "Failed to set TTL on stream keys");
+      }
+    });
+  }
+
+  const sseHeaders = {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  } as const;
+
+  const streamContext = await getStreamContext();
+  const sseStream = () => stream.pipeThrough(new JsonToSseTransformStream());
+
+  if (streamContext) {
+    log.debug("Returning resumable stream");
+    return new Response(
+      await streamContext.resumableStream(streamId, sseStream),
+      { headers: sseHeaders },
+    );
+  }
+
+  return new Response(sseStream(), { headers: sseHeaders });
 }
 
 export async function POST(request: NextRequest) {
@@ -1049,11 +1111,12 @@ export async function POST(request: NextRequest) {
       return sessionSetup.error;
     }
 
-    const { userId, userName, isAnonymous, anonymousSession, modelDefinition } =
+    const { userId, isAnonymous, anonymousSession, modelDefinition } =
       sessionSetup;
 
     // ---- Tier-based model & credit gate (authenticated users only) ----
-    // userPlan is hoisted so the arcan block can build a tier-appropriate policy
+    // userPlan is hoisted so downstream checks can build a tier-appropriate
+    // policy in future PRs.
     let userPlan = "anonymous";
     let orgId: string | null = null;
     if (userId && !isAnonymous) {
@@ -1186,7 +1249,6 @@ export async function POST(request: NextRequest) {
           );
         }
       }
-
     }
 
     const contextResult = await prepareRequestContext({
@@ -1203,105 +1265,12 @@ export async function POST(request: NextRequest) {
       return contextResult.error;
     }
 
-    const { previousMessages, allowedTools } = contextResult;
-
-    // ── Arcan Agent Runtime (BRO-225) ──────────────────────────────
-    // Two-tier routing:
-    //   1. Dedicated Railway org instance (enterprise only)
-    //   2. Shared ARCAN_URL env instance (all tiers, fallback)
-    // If the dedicated instance fails health check -> mark degraded, try shared.
-    // Anonymous users skip the org lookup and go straight to the shared instance.
-    {
-      const arcanOwnerId = userId ?? anonymousSession?.id ?? null;
-      const arcanEmail = userId
-        ? ((
-            await getSafeSession({
-              fetchOptions: { headers: await headers() },
-            })
-          ).data?.user?.email ?? "")
-        : `anon-${anonymousSession?.id?.slice(0, 8)}@guest.broomva.tech`;
-
-      if (arcanOwnerId) {
-        const { dedicated, shared } = userId
-          ? await resolveArcanEndpoints(userId)
-          : {
-              dedicated: null,
-              shared: process.env.ARCAN_URL
-                ? {
-                    arcanUrl: process.env.ARCAN_URL,
-                    lagoUrl: process.env.LAGO_URL ?? null,
-                    isDedicated: false,
-                    orgId: null,
-                  }
-                : null,
-            };
-
-        const endpointsToTry = dedicated
-          ? [dedicated, shared].filter(Boolean)
-          : [shared].filter(Boolean);
-
-        for (const endpoint of endpointsToTry) {
-          if (!endpoint) continue;
-
-          const abortController = new AbortController();
-          const timeoutId = setTimeout(
-            () => abortController.abort(),
-            290_000,
-          );
-
-          // Degraded policy applied when falling back from a failed dedicated instance
-          const isDegradedFallback = endpoint === shared && dedicated !== null;
-          const policy = isDegradedFallback
-            ? { ...buildArcanPolicy(userPlan), max_events_per_turn: 10 }
-            : buildArcanPolicy(userPlan);
-
-          const arcanResponse = await executeViaArcan({
-            chatId,
-            userMessage,
-            previousMessages,
-            userId: arcanOwnerId,
-            arcanUrl: endpoint.arcanUrl,
-            userEmail: arcanEmail,
-            abortSignal: abortController.signal,
-            policy,
-          });
-
-          clearTimeout(timeoutId);
-
-          if (arcanResponse) {
-            log.info(
-              {
-                chatId,
-                anonymous: isAnonymous,
-                dedicated: endpoint.isDedicated,
-                degraded: isDegradedFallback,
-              },
-              "Routed to Arcan",
-            );
-            return arcanResponse;
-          }
-
-          // Dedicated instance unreachable — mark degraded and try shared next
-          if (endpoint.isDedicated && endpoint.orgId) {
-            log.warn(
-              {
-                chatId,
-                orgId: endpoint.orgId,
-                arcanUrl: endpoint.arcanUrl,
-              },
-              "Dedicated arcand unreachable — marking degraded, falling back to shared instance (BRO-225)",
-            );
-            await markInstanceDegraded(endpoint.orgId);
-          }
-        }
-
-        log.info("Arcan unavailable, falling back to streamText");
-      }
-    }
-
-    // ── Fallback: Direct streamText (template path) ─────────────────
-    // Used for anonymous users, or when no Arcan instance is available.
-    // Gate MCP connectors behind the mcp feature flag (BRO-393)
+    // Gate MCP-connector loading behind the mcp feature flag (BRO-393).
+    // Pre-PR-3 the resolved connectors were threaded into core-chat-agent
+    // for streamText-side tool injection; now lifegw owns server-side
+    // tool dispatch. We still gate the MCP loader so user-org config
+    // changes flow through without surprise, but the result is reserved
+    // for a future PR that forwards connector hints to lifegw.
     const mcpFlagEnabled =
       userId && !isAnonymous
         ? await getServerFeatureFlag(
@@ -1310,10 +1279,23 @@ export async function POST(request: NextRequest) {
             orgId ? { organization: orgId } : undefined,
           )
         : false;
-    const mcpConnectors: McpConnector[] =
+    const _mcpConnectors: McpConnector[] =
       config.features.mcp && mcpFlagEnabled && userId && !isAnonymous
         ? await getMcpConnectorsByUserId({ userId })
         : [];
+    void _mcpConnectors;
+
+    // ── Lifegw configuration check ─────────────────────────────────
+    // The route MUST have a configured lifegw to function; we no
+    // longer carry the streamText fallback. Surface a clear 503 if
+    // the operator forgot to set LIFED_GATEWAY_URL.
+    if (!getLifegwBaseUrl()) {
+      log.error("LIFED_GATEWAY_URL is unset; cannot dispatch chat");
+      return new Response(
+        "Chat service unavailable: lifegw is not configured. Set LIFED_GATEWAY_URL on this deployment.",
+        { status: 503 },
+      );
+    }
 
     // Create AbortController with timeout
     const abortController = new AbortController();
@@ -1324,18 +1306,14 @@ export async function POST(request: NextRequest) {
     return await executeChatRequest({
       chatId,
       userMessage,
-      previousMessages,
       selectedModelId,
-      explicitlyRequestedTools,
       userId,
+      anonymousSessionId: anonymousSession?.id ?? null,
       organizationId: orgId,
       isAnonymous,
       isNewChat,
-      allowedTools,
       abortController,
       timeoutId,
-      mcpConnectors,
-      userName: isAnonymous ? null : userName,
     });
   } catch (error) {
     log.error(

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/canonical-to-vercel-ai-sse.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/canonical-to-vercel-ai-sse.test.ts
@@ -1,0 +1,427 @@
+// Unit tests for the canonical → Vercel-AI-SDK chunk translator.
+//
+// The translator is the load-bearing piece of PR-3: it converts the
+// canonical agent-event iterator that lifegw produces into the exact
+// `UIMessageChunk` shape `chat-sync.tsx`'s `useChat` hook expects.
+// Any drift here causes the in-app chat UI to silently lose tokens,
+// tool calls, or finish events.
+//
+// We test against the *shape* of emitted chunks rather than the SSE
+// wire format — `JsonToSseTransformStream` handles the wire framing,
+// and the SDK's serialisation is exercised by AI-SDK's own test
+// suite. What this file owns is the canonical-event → UIMessageChunk
+// mapping.
+//
+// File under test: ../canonical-to-vercel-ai-sse.ts
+
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type {
+  AgentEvent,
+  CanonicalAgentEvent,
+} from "@/lib/life-runtime/agent-session/types";
+import {
+  canonicalToVercelAiSdkSse,
+  makeConsumeState,
+} from "../canonical-to-vercel-ai-sse";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function env(seq: bigint, event: AgentEvent): CanonicalAgentEvent {
+  return {
+    seq,
+    at: new Date(0).toISOString(),
+    event,
+  };
+}
+
+async function* iter(
+  ...events: AgentEvent[]
+): AsyncIterable<CanonicalAgentEvent> {
+  let s = 0n;
+  for (const e of events) {
+    yield env(++s, e);
+  }
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const v of it) out.push(v);
+  return out;
+}
+
+// ── Token streaming ────────────────────────────────────────────────────
+
+describe("canonicalToVercelAiSdkSse — token streaming", () => {
+  it("synthesises text-start when lifed emits token without text_start", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "token", delta: "Hello" },
+          { kind: "token", delta: ", world" },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_abc" },
+      ),
+    );
+
+    expect(out).toEqual([
+      { type: "text-start", id: "msg_abc" },
+      { type: "text-delta", id: "msg_abc", delta: "Hello" },
+      { type: "text-delta", id: "msg_abc", delta: ", world" },
+      { type: "text-end", id: "msg_abc" },
+    ]);
+  });
+
+  it("honours lifed-supplied text_start / text_end ids", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "text_start", messageId: "seg_1" },
+          { kind: "token", delta: "First segment", messageId: "seg_1" },
+          { kind: "text_end", messageId: "seg_1" },
+          { kind: "text_start", messageId: "seg_2" },
+          { kind: "token", delta: "Second segment", messageId: "seg_2" },
+          { kind: "text_end", messageId: "seg_2" },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "fallback" },
+      ),
+    );
+
+    expect(out).toEqual([
+      { type: "text-start", id: "seg_1" },
+      { type: "text-delta", id: "seg_1", delta: "First segment" },
+      { type: "text-end", id: "seg_1" },
+      { type: "text-start", id: "seg_2" },
+      { type: "text-delta", id: "seg_2", delta: "Second segment" },
+      { type: "text-end", id: "seg_2" },
+    ]);
+  });
+
+  it("accumulates total text into the consume state", async () => {
+    const state = makeConsumeState();
+    await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "token", delta: "Hello, " },
+          { kind: "token", delta: "world!" },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_x", state },
+      ),
+    );
+    expect(state.text).toBe("Hello, world!");
+    expect(state.finishReason).toBe("stop");
+  });
+
+  it("drops empty token deltas without opening a text segment", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "token", delta: "" },
+          { kind: "token", delta: "real" },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_y" },
+      ),
+    );
+    expect(out).toEqual([
+      { type: "text-start", id: "msg_y" },
+      { type: "text-delta", id: "msg_y", delta: "real" },
+      { type: "text-end", id: "msg_y" },
+    ]);
+  });
+});
+
+// ── Tool calls ────────────────────────────────────────────────────────
+
+describe("canonicalToVercelAiSdkSse — tool calls", () => {
+  it("emits tool-input-start + tool-input-available + tool-output-available", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "token", delta: "Searching" },
+          {
+            kind: "tool_call_pending",
+            call: {
+              callId: "tc_123",
+              toolName: "webSearch",
+              inputJson: JSON.stringify({ query: "cats" }),
+              requestedCapabilities: [],
+            },
+          },
+          {
+            kind: "tool_result",
+            result: {
+              callId: "tc_123",
+              toolName: "webSearch",
+              outputJson: JSON.stringify({
+                results: [{ url: "https://cats.io", title: "Cats" }],
+              }),
+              isError: false,
+            },
+          },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_z" },
+      ),
+    );
+
+    expect(out).toEqual([
+      // Text segment opened lazily for the "Searching" token
+      { type: "text-start", id: "msg_z" },
+      { type: "text-delta", id: "msg_z", delta: "Searching" },
+      // Text segment closed before the tool block
+      { type: "text-end", id: "msg_z" },
+      // Tool-call dance
+      {
+        type: "tool-input-start",
+        toolCallId: "tc_123",
+        toolName: "webSearch",
+      },
+      {
+        type: "tool-input-available",
+        toolCallId: "tc_123",
+        toolName: "webSearch",
+        input: { query: "cats" },
+      },
+      {
+        type: "tool-output-available",
+        toolCallId: "tc_123",
+        output: { results: [{ url: "https://cats.io", title: "Cats" }] },
+      },
+    ]);
+  });
+
+  it("maps tool_result with isError=true to tool-output-error", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          {
+            kind: "tool_call_pending",
+            call: {
+              callId: "tc_err",
+              toolName: "codeExecution",
+              inputJson: JSON.stringify({ code: "boom" }),
+              requestedCapabilities: [],
+            },
+          },
+          {
+            kind: "tool_result",
+            result: {
+              callId: "tc_err",
+              toolName: "codeExecution",
+              outputJson: JSON.stringify({ error: "stack overflow" }),
+              isError: true,
+            },
+          },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_e" },
+      ),
+    );
+
+    const errChunk = out.find(
+      (c): c is Extract<typeof c, { type: "tool-output-error" }> =>
+        c.type === "tool-output-error",
+    );
+    expect(errChunk).toBeDefined();
+    expect(errChunk?.toolCallId).toBe("tc_err");
+    // errorText carries the stringified output for UI display
+    expect(errChunk?.errorText).toContain("stack overflow");
+  });
+
+  it("survives malformed tool input JSON by wrapping in { raw: ... }", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          {
+            kind: "tool_call_pending",
+            call: {
+              callId: "tc_bad",
+              toolName: "anyTool",
+              inputJson: "not-json}}",
+              requestedCapabilities: [],
+            },
+          },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_b" },
+      ),
+    );
+    const avail = out.find(
+      (c): c is Extract<typeof c, { type: "tool-input-available" }> =>
+        c.type === "tool-input-available",
+    );
+    expect(avail).toBeDefined();
+    expect(avail?.input).toEqual({ raw: "not-json}}" });
+  });
+
+  it("synthesises stable callIds when lifed omits them", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          {
+            kind: "tool_call_pending",
+            call: {
+              callId: "",
+              toolName: "anonymousTool",
+              inputJson: "{}",
+              requestedCapabilities: [],
+            },
+          },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_q" },
+      ),
+    );
+    const start = out.find(
+      (c): c is Extract<typeof c, { type: "tool-input-start" }> =>
+        c.type === "tool-input-start",
+    );
+    expect(start).toBeDefined();
+    expect(start?.toolCallId).toMatch(/^call_/);
+  });
+
+  it("records tool calls + outputs in the consume state for persistence", async () => {
+    const state = makeConsumeState();
+    await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          {
+            kind: "tool_call_pending",
+            call: {
+              callId: "tc_persist",
+              toolName: "getWeather",
+              inputJson: JSON.stringify({ city: "Bogotá" }),
+              requestedCapabilities: [],
+            },
+          },
+          {
+            kind: "tool_result",
+            result: {
+              callId: "tc_persist",
+              toolName: "getWeather",
+              outputJson: JSON.stringify({ temp: 18, units: "C" }),
+              isError: false,
+            },
+          },
+          { kind: "finish", reason: "tool_use" },
+        ),
+        { fallbackTextId: "msg_w", state },
+      ),
+    );
+    expect(state.toolCalls).toHaveLength(1);
+    expect(state.toolCalls[0]).toMatchObject({
+      callId: "tc_persist",
+      toolName: "getWeather",
+      input: { city: "Bogotá" },
+      output: { temp: 18, units: "C" },
+      isError: false,
+    });
+    expect(state.finishReason).toBe("tool_use");
+  });
+});
+
+// ── Finish, usage, error ───────────────────────────────────────────────
+
+describe("canonicalToVercelAiSdkSse — finish + usage + error", () => {
+  it("does NOT emit a finish chunk; records usage into state", async () => {
+    const state = makeConsumeState();
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "token", delta: "hi" },
+          {
+            kind: "finish",
+            reason: "stop",
+            usage: { inputTokens: 10, outputTokens: 5 },
+          },
+        ),
+        { fallbackTextId: "msg_f", state },
+      ),
+    );
+    // No `finish` chunk — the route's createUIMessageStream wrapper
+    // owns the SDK-side finish.
+    expect(out.some((c) => c.type === "finish")).toBe(false);
+    expect(state.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+  });
+
+  it("maps fatal error events into a UI error chunk + records on state", async () => {
+    const state = makeConsumeState();
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "token", delta: "partial" },
+          {
+            kind: "error",
+            code: "lifed-ws.transient_4002",
+            message: "backpressure",
+          },
+          { kind: "finish", reason: "error" },
+        ),
+        { fallbackTextId: "msg_err", state },
+      ),
+    );
+    const errChunk = out.find(
+      (c): c is Extract<typeof c, { type: "error" }> => c.type === "error",
+    );
+    expect(errChunk).toBeDefined();
+    expect(errChunk?.errorText).toContain("lifed-ws.transient_4002");
+    expect(errChunk?.errorText).toContain("backpressure");
+    expect(state.error).toEqual({
+      code: "lifed-ws.transient_4002",
+      message: "backpressure",
+    });
+  });
+
+  it("logs warnings to state but emits no UI chunk", async () => {
+    const state = makeConsumeState();
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          {
+            kind: "warning",
+            code: "lifed-ws.unknown_kind",
+            message: "future event type",
+          },
+          { kind: "token", delta: "real" },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_warn", state },
+      ),
+    );
+    expect(out.some((c) => c.type === "error")).toBe(false);
+    expect(state.warnings).toEqual([
+      { code: "lifed-ws.unknown_kind", message: "future event type" },
+    ]);
+  });
+
+  it("drops telemetry events (thinking_start/end, fs_op, etc.)", async () => {
+    const out = await collect(
+      canonicalToVercelAiSdkSse(
+        iter(
+          { kind: "thinking_start" },
+          { kind: "thinking_end", ms: 12 },
+          { kind: "fs_op", path: "/tmp", op: "read" },
+          { kind: "nous_score", dim: "groundedness", score: 0.9 },
+          { kind: "haima_billed", microcredits: 100, rail: "credits" },
+          { kind: "vigil_span", name: "main", durationMs: 50, status: "ok" },
+          { kind: "token", delta: "answer" },
+          { kind: "finish", reason: "stop" },
+        ),
+        { fallbackTextId: "msg_tel" },
+      ),
+    );
+    // Only the token + bookend text-start/text-end should be visible
+    expect(out).toEqual([
+      { type: "text-start", id: "msg_tel" },
+      { type: "text-delta", id: "msg_tel", delta: "answer" },
+      { type: "text-end", id: "msg_tel" },
+    ]);
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/dispatch-via-lifegw.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/dispatch-via-lifegw.test.ts
@@ -1,0 +1,218 @@
+// Unit tests for `dispatchViaLifegw`. We mock the JWT mint + the
+// `LifedWsAgentSessionClient` constructor (via the test-only
+// `clientFactory` injection point) so the dispatcher runs without
+// needing a real lifegw deployment.
+//
+// File under test: ../dispatch-via-lifegw.ts
+
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  mintTier1ForConsumer: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/lifegw-jwt", () => ({
+  mintTier1ForConsumer: mocks.mintTier1ForConsumer,
+}));
+
+import type { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type {
+  AgentStreamInput,
+  CanonicalAgentEvent,
+} from "@/lib/life-runtime/agent-session/types";
+import { dispatchViaLifegw } from "../dispatch-via-lifegw";
+
+interface FakeOpts {
+  createSessionCalls?: Array<{
+    resumeSid?: string;
+    userId: string;
+    capability: { token: string };
+    projectSlug: string;
+  }>;
+  streamCalls?: AgentStreamInput[];
+  events?: CanonicalAgentEvent["event"][];
+}
+
+function makeFakeClient(opts: FakeOpts): LifedWsAgentSessionClient {
+  const events = opts.events ?? [
+    { kind: "token", delta: "hi" },
+    { kind: "finish", reason: "stop" },
+  ];
+  return {
+    backendId: "lifed-ws" as const,
+    async createSession(input: {
+      capability: { token: string };
+      userId: string;
+      projectSlug: string;
+      resumeSid?: string;
+    }) {
+      opts.createSessionCalls?.push({
+        resumeSid: input.resumeSid,
+        userId: input.userId,
+        capability: input.capability,
+        projectSlug: input.projectSlug,
+      });
+      return {
+        sid: input.resumeSid ?? "fresh-sid",
+        agentId: `agent_${input.userId}`,
+        userId: input.userId,
+        projectId: input.projectSlug,
+        createdAtUnix: 0,
+      };
+    },
+    async sendMessage() {},
+    async health() {
+      return { backendId: "lifed-ws", reachable: true };
+    },
+    async *stream(input: AgentStreamInput): AsyncIterable<CanonicalAgentEvent> {
+      opts.streamCalls?.push(input);
+      let i = 0n;
+      for (const ev of events) {
+        yield { seq: ++i, at: new Date().toISOString(), event: ev };
+      }
+    },
+  } as unknown as LifedWsAgentSessionClient;
+}
+
+beforeEach(() => {
+  mocks.mintTier1ForConsumer.mockReset();
+  mocks.mintTier1ForConsumer.mockResolvedValue({
+    token: "fake-tier1-token",
+    expiresAt: Math.floor(Date.now() / 1000) + 900,
+  });
+  vi.stubEnv("LIFED_GATEWAY_URL", "https://gw.example.test");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("dispatchViaLifegw — happy path", () => {
+  it("mints Tier-1 for an authenticated user and forwards the sticky sid", async () => {
+    const createSessionCalls: FakeOpts["createSessionCalls"] = [];
+    const streamCalls: FakeOpts["streamCalls"] = [];
+    const handle = await dispatchViaLifegw({
+      stickySid: "chat_abc_uuid",
+      userMessage: "hello",
+      consumer: { kind: "user", id: "user_alice" },
+      clientFactory: () => makeFakeClient({ createSessionCalls, streamCalls }),
+    });
+
+    expect(mocks.mintTier1ForConsumer).toHaveBeenCalledWith({
+      consumer: { kind: "user", id: "user_alice" },
+      projectSlug: "default",
+    });
+    expect(createSessionCalls).toHaveLength(1);
+    expect(createSessionCalls![0]).toMatchObject({
+      resumeSid: "chat_abc_uuid",
+      userId: "user_alice",
+      projectSlug: "default",
+      capability: { token: "fake-tier1-token" },
+    });
+    // Consume the iterator — stream() doesn't execute until consumed.
+    const out: CanonicalAgentEvent[] = [];
+    for await (const ev of handle.events) out.push(ev);
+    expect(out.length).toBeGreaterThan(0);
+
+    expect(streamCalls).toHaveLength(1);
+    expect(streamCalls![0]).toMatchObject({
+      sessionId: "chat_abc_uuid",
+      agentId: "user:user_alice",
+      projectSlug: "default",
+      userMessage: "hello",
+    });
+    expect(handle.sessionId).toBe("chat_abc_uuid");
+  });
+
+  it("uses an anon consumer when no userId is present", async () => {
+    const createSessionCalls: FakeOpts["createSessionCalls"] = [];
+    const streamCalls: FakeOpts["streamCalls"] = [];
+    const handle = await dispatchViaLifegw({
+      stickySid: "chat_anon_uuid",
+      userMessage: "hi from anon",
+      consumer: { kind: "anon", id: "anon-session-abc" },
+      clientFactory: () => makeFakeClient({ createSessionCalls, streamCalls }),
+    });
+
+    // Drain the iterator so stream() actually runs and populates calls.
+    for await (const _ of handle.events) {
+      void _;
+    }
+
+    expect(mocks.mintTier1ForConsumer).toHaveBeenCalledWith({
+      consumer: { kind: "anon", id: "anon-session-abc" },
+      projectSlug: "default",
+    });
+    expect(createSessionCalls![0].userId).toBe("anon:anon-session-abc");
+    expect(streamCalls![0].agentId).toBe("user:anon:anon-session-abc");
+  });
+
+  it("forwards a custom project slug when supplied", async () => {
+    const createSessionCalls: FakeOpts["createSessionCalls"] = [];
+    await dispatchViaLifegw({
+      stickySid: "chat_x",
+      userMessage: "hello",
+      consumer: { kind: "user", id: "user_bob" },
+      projectSlug: "exclusive-rentals",
+      clientFactory: () => makeFakeClient({ createSessionCalls }),
+    });
+    expect(createSessionCalls![0].projectSlug).toBe("exclusive-rentals");
+    expect(mocks.mintTier1ForConsumer).toHaveBeenCalledWith({
+      consumer: { kind: "user", id: "user_bob" },
+      projectSlug: "exclusive-rentals",
+    });
+  });
+});
+
+describe("dispatchViaLifegw — failure modes", () => {
+  it("throws a typed error when LIFED_GATEWAY_URL is unset", async () => {
+    vi.unstubAllEnvs();
+    await expect(
+      dispatchViaLifegw({
+        stickySid: "chat_y",
+        userMessage: "hello",
+        consumer: { kind: "user", id: "user_x" },
+        clientFactory: () => makeFakeClient({}),
+      }),
+    ).rejects.toThrow(/LIFED_GATEWAY_URL/);
+  });
+
+  it("propagates mint failures", async () => {
+    mocks.mintTier1ForConsumer.mockRejectedValueOnce(
+      new Error("mint failed: signing key missing"),
+    );
+    await expect(
+      dispatchViaLifegw({
+        stickySid: "chat_m",
+        userMessage: "hi",
+        consumer: { kind: "user", id: "user_x" },
+        clientFactory: () => makeFakeClient({}),
+      }),
+    ).rejects.toThrow(/signing key missing/);
+  });
+
+  it("propagates createSession failures", async () => {
+    const fake = {
+      backendId: "lifed-ws" as const,
+      async createSession() {
+        throw new Error("lifegw refused: HTTP 401");
+      },
+      async sendMessage() {},
+      async health() {
+        return { backendId: "lifed-ws", reachable: true };
+      },
+      async *stream() {},
+    } as unknown as LifedWsAgentSessionClient;
+    await expect(
+      dispatchViaLifegw({
+        stickySid: "chat_s",
+        userMessage: "hi",
+        consumer: { kind: "user", id: "user_x" },
+        clientFactory: () => fake,
+      }),
+    ).rejects.toThrow(/HTTP 401/);
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse.ts
@@ -1,0 +1,377 @@
+/**
+ * Translate canonical `CanonicalAgentEvent` iterators into Vercel-AI-SDK
+ * data-stream chunks.
+ *
+ * Third sub-PR of BRO-1208. The in-app chat surface (`/api/chat`) uses
+ * the Vercel AI SDK's `useChat()` hook, which expects a specific
+ * `UIMessageChunk` shape served via `JsonToSseTransformStream`. The old
+ * dispatch went through `streamText` → `result.toUIMessageStream()`, so
+ * the chunk shape was emitted natively by the SDK. With dispatch moving
+ * to lifegw, we receive canonical `AgentEvent`s from lifed and must
+ * project them onto the same `UIMessageChunk` shape so the client
+ * (`components/chat-sync.tsx`) keeps working unchanged.
+ *
+ * The translation is mostly one-to-one:
+ *
+ *   AgentEvent.kind                   ➜ UIMessageChunk.type
+ *   ────────────────────────────────────────────────────────────────
+ *   text_start                        ➜ text-start { id }
+ *   token                             ➜ text-delta { id, delta }
+ *   text_end                          ➜ text-end { id }
+ *   tool_call_pending                 ➜ tool-input-start + tool-input-available
+ *   tool_result                       ➜ tool-output-available | tool-output-error
+ *   finish                            ➜ (delegated — message-metadata + finish)
+ *   warning                           ➜ (suppressed — telemetry only)
+ *   error                             ➜ error { errorText }
+ *
+ * Edge cases handled:
+ *
+ *   - Lifed may emit `token` events without a preceding `text_start`
+ *     (legacy / partial decoders). We synthesise `text-start` lazily
+ *     using a stable per-stream id so the client renders one cohesive
+ *     text part rather than orphan deltas.
+ *   - Multiple `text_start` / `text_end` pairs (re-segmented assistant
+ *     turns) are passed through as distinct text-id segments — the SDK
+ *     handles this natively.
+ *   - Tool input is forwarded as JSON-parsed `input`. If lifed sends a
+ *     malformed `inputJson`, we fall back to passing the raw string in
+ *     a `{ raw: "<string>" }` wrapper rather than failing the stream.
+ *   - The terminal `finish` carries `usage` if lifed reported it; we
+ *     surface that on the message metadata so cost accumulators (and
+ *     PostHog telemetry downstream) see the same shape the SDK used to
+ *     emit.
+ *
+ * The translator does NOT emit `start` or `message-metadata` chunks
+ * itself — those are owned by the `createUIMessageStream` wrapper in
+ * the route, which is also where `data-chatConfirmed` etc. live. The
+ * translator only handles per-token-and-tool events from lifed.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ *       (extended for the in-app chat surface, see BRO-1208 arc)
+ */
+
+import "server-only";
+import type { InferUIMessageChunk, UIMessage } from "ai";
+import type {
+  AgentEvent,
+  CanonicalAgentEvent,
+} from "@/lib/life-runtime/agent-session/types";
+
+/**
+ * Per-stream state captured while consuming the canonical iterator.
+ * The caller reads this AFTER the iterator drains to populate the
+ * persisted assistant message + the finish chunk's metadata.
+ */
+export interface CanonicalConsumeState {
+  /**
+   * Concatenated assistant text — the persisted message body. Lifegw
+   * sends per-token deltas; we accumulate so the route's onFinish can
+   * write a fully materialised assistant message to the DB.
+   */
+  text: string;
+  /**
+   * Tool calls observed mid-stream. The route records these on the
+   * assistant message's parts so the UI can replay them on reload.
+   */
+  toolCalls: Array<{
+    callId: string;
+    toolName: string;
+    input: unknown;
+    output?: unknown;
+    isError?: boolean;
+  }>;
+  /**
+   * Finish reason as reported by lifed (`stop` / `tool_use` / `error`
+   * / `aborted` / ...). Mapped onto the SDK's `FinishReason` union by
+   * the caller.
+   */
+  finishReason: string;
+  /**
+   * Usage tallies populated from lifed's terminal `finish` event. The
+   * route forwards these into the cost accumulator (when the user is
+   * authenticated) and reports them on the message metadata chunk.
+   */
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    costCents?: number;
+  };
+  /**
+   * Non-fatal warnings the iterator surfaced. Currently logged-only —
+   * the SDK has no first-class warning chunk type, and the canonical
+   * `warning` kind is reserved for telemetry that shouldn't surface in
+   * the UI as an error.
+   */
+  warnings: Array<{ code: string; message: string }>;
+  /**
+   * Set when a fatal `error` canonical event terminated the stream.
+   * The route uses this to clear `activeStreamId` on the persisted
+   * assistant message so the client doesn't try to resume a dead
+   * stream on reload.
+   */
+  error?: { code: string; message: string };
+}
+
+/**
+ * Produce a fresh consume-state record. Exposed so the route can hold
+ * a reference and inspect it inside `onFinish` (the translator mutates
+ * the same object on each event).
+ */
+export function makeConsumeState(): CanonicalConsumeState {
+  return {
+    text: "",
+    toolCalls: [],
+    finishReason: "stop",
+    warnings: [],
+  };
+}
+
+export interface ConsumeOptions {
+  /**
+   * Stable id used for the synthesised `text-start` / `text-delta`
+   * chunks when lifed emits `token` without a prior `text_start`.
+   * Should be the assistant message id so the SDK threads deltas onto
+   * the same UI part. Required because the SDK's text id is what
+   * correlates the `text-end` close.
+   */
+  fallbackTextId: string;
+  /**
+   * Mutable state record the translator writes into. Caller usually
+   * gets one from `makeConsumeState()` and reads it inside the wrapping
+   * `createUIMessageStream`'s `onFinish` callback. May be omitted for
+   * fire-and-forget consumers (e.g. tests).
+   */
+  state?: CanonicalConsumeState;
+}
+
+/**
+ * Async generator — consumes the canonical iterator and yields
+ * Vercel-AI-SDK `UIMessageChunk`s. Callers usually `dataStream.write`
+ * each yielded chunk into a `createUIMessageStream` writer.
+ *
+ * Parameterised on the UI message type so the chunk shape matches
+ * exactly what the writer expects (default `UIMessageChunk` is wider
+ * than `InferUIMessageChunk<ChatMessage>` because it allows arbitrary
+ * `data-${string}` payloads).
+ */
+export async function* canonicalToVercelAiSdkSse<
+  UI_MESSAGE extends UIMessage = UIMessage,
+>(
+  events: AsyncIterable<CanonicalAgentEvent>,
+  opts: ConsumeOptions,
+): AsyncIterable<InferUIMessageChunk<UI_MESSAGE>> {
+  type Chunk = InferUIMessageChunk<UI_MESSAGE>;
+  const state = opts.state ?? makeConsumeState();
+  // Tracks whether we already opened a text part this turn. When lifed
+  // emits tokens without `text_start`, we lazy-open one and close it at
+  // the finish boundary. When lifed DOES emit `text_start`, we honour
+  // its messageId so multiple segments thread independently.
+  let openTextId: string | null = null;
+  // Tracks tool calls whose `tool-input-start` we've emitted; lets us
+  // skip duplicate starts if lifed re-emits a pending event for the
+  // same callId (shouldn't happen but is cheap defence).
+  const startedToolCalls = new Set<string>();
+
+  const closeOpenText = function* (): Iterable<Chunk> {
+    if (openTextId !== null) {
+      yield { type: "text-end", id: openTextId } as unknown as Chunk;
+      openTextId = null;
+    }
+  };
+
+  for await (const envelope of events) {
+    const ev: AgentEvent = envelope.event;
+    switch (ev.kind) {
+      case "text_start": {
+        // Honour lifed's correlation id; close any synthesised open
+        // text first so segments don't leak into each other.
+        yield* closeOpenText();
+        openTextId = ev.messageId;
+        yield { type: "text-start", id: ev.messageId } as unknown as Chunk;
+        break;
+      }
+      case "token": {
+        if (ev.delta === "") break;
+        const id: string = ev.messageId ?? openTextId ?? opts.fallbackTextId;
+        if (openTextId === null) {
+          openTextId = id;
+          yield { type: "text-start", id } as unknown as Chunk;
+        } else if (id !== openTextId) {
+          // Lifed switched correlation id mid-stream without an
+          // explicit `text_start` — close the old segment and open a
+          // new one keyed on the new id.
+          yield* closeOpenText();
+          openTextId = id;
+          yield { type: "text-start", id } as unknown as Chunk;
+        }
+        state.text += ev.delta;
+        yield {
+          type: "text-delta",
+          id,
+          delta: ev.delta,
+        } as unknown as Chunk;
+        break;
+      }
+      case "text_end": {
+        if (openTextId === ev.messageId) {
+          openTextId = null;
+        }
+        yield { type: "text-end", id: ev.messageId } as unknown as Chunk;
+        break;
+      }
+      case "tool_call_pending": {
+        // Flush any open text so the UI renders the tool block AFTER
+        // the streamed text rather than interleaved with it.
+        yield* closeOpenText();
+        const callId =
+          ev.call.callId.length > 0
+            ? ev.call.callId
+            : `call_${envelope.seq.toString(16)}`;
+        const toolName =
+          ev.call.toolName.length > 0 ? ev.call.toolName : "unknown_tool";
+        const input = parseToolInput(ev.call.inputJson);
+        if (!startedToolCalls.has(callId)) {
+          startedToolCalls.add(callId);
+          yield {
+            type: "tool-input-start",
+            toolCallId: callId,
+            toolName,
+          } as unknown as Chunk;
+        }
+        yield {
+          type: "tool-input-available",
+          toolCallId: callId,
+          toolName,
+          input,
+        } as unknown as Chunk;
+        state.toolCalls.push({ callId, toolName, input });
+        break;
+      }
+      case "tool_result": {
+        const callId =
+          ev.result.callId.length > 0
+            ? ev.result.callId
+            : `call_${envelope.seq.toString(16)}`;
+        const output = parseToolOutput(ev.result.outputJson);
+        const matching = state.toolCalls.find((c) => c.callId === callId);
+        if (matching) {
+          matching.output = output;
+          matching.isError = ev.result.isError;
+        } else {
+          // Result for a call we never saw a pending for — record so
+          // the persisted message still carries it.
+          state.toolCalls.push({
+            callId,
+            toolName: ev.result.toolName,
+            input: undefined,
+            output,
+            isError: ev.result.isError,
+          });
+        }
+        if (ev.result.isError) {
+          yield {
+            type: "tool-output-error",
+            toolCallId: callId,
+            errorText: stringifyError(output),
+          } as unknown as Chunk;
+        } else {
+          yield {
+            type: "tool-output-available",
+            toolCallId: callId,
+            output,
+          } as unknown as Chunk;
+        }
+        break;
+      }
+      case "finish": {
+        // Don't emit a `finish` chunk here — the route's
+        // `createUIMessageStream` wrapper owns the SDK-side finish so
+        // it can attach the assistant message id + metadata via
+        // `messageMetadata`. We just record the reason + usage for the
+        // wrapper to pick up.
+        state.finishReason = ev.reason;
+        if (ev.usage) state.usage = { ...ev.usage };
+        yield* closeOpenText();
+        break;
+      }
+      case "error": {
+        state.error = { code: ev.code, message: ev.message };
+        yield* closeOpenText();
+        yield {
+          type: "error",
+          errorText: `${ev.code}: ${ev.message}`,
+        } as unknown as Chunk;
+        break;
+      }
+      case "warning": {
+        // Non-fatal — record for telemetry, don't surface to UI. The
+        // SDK has no warning chunk type and a UI-side error toast for
+        // every transient lifegw warning would be noisy.
+        state.warnings.push({ code: ev.code, message: ev.message });
+        break;
+      }
+      // Telemetry-only events — drop them. The UI doesn't surface
+      // these today; adding chunk shapes for them would require a
+      // coordinated SDK extension.
+      case "open":
+      case "thinking_start":
+      case "thinking_end":
+      case "approval_required":
+      case "fs_op":
+      case "nous_score":
+      case "autonomic":
+      case "haima_billed":
+      case "vigil_span":
+      case "turn_end":
+        break;
+      default: {
+        // Should be unreachable — exhaustiveness checker keeps us
+        // honest as the canonical union evolves.
+        const _exhaustive: never = ev;
+        void _exhaustive;
+        break;
+      }
+    }
+  }
+
+  // Drain — make sure no text part is left open if the stream ended
+  // without a `text_end` or terminal `finish`.
+  yield* closeOpenText();
+}
+
+/**
+ * Best-effort parse for the JSON-encoded `inputJson` field on
+ * `tool_call_pending`. Returns the parsed object on success; falls back
+ * to wrapping the raw string in `{ raw: ... }` when parsing fails so
+ * the UI can still render *something* and the persisted record stays
+ * lossless.
+ */
+function parseToolInput(json: string | undefined): unknown {
+  if (!json) return {};
+  try {
+    return JSON.parse(json);
+  } catch {
+    return { raw: json };
+  }
+}
+
+function parseToolOutput(json: string | undefined): unknown {
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return { raw: json };
+  }
+}
+
+function stringifyError(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (output && typeof output === "object") {
+    try {
+      return JSON.stringify(output);
+    } catch {
+      return String(output);
+    }
+  }
+  return String(output ?? "tool error");
+}

--- a/apps/broomva/lib/life-runtime/edge-adapter/dispatch-via-lifegw.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/dispatch-via-lifegw.ts
@@ -1,0 +1,195 @@
+/**
+ * Dispatch a chat turn through lifegw and yield canonical agent events.
+ *
+ * Third sub-PR of BRO-1208. Mirrors the auth + create-session + stream
+ * pattern shipped in `/api/v1/messages` (PR-1, #188) and `/api/v1/chat/
+ * completions` (PR-2, #190), exposed as a reusable helper so the in-app
+ * `/api/chat` route can route through lifegw without reimplementing the
+ * WS wiring.
+ *
+ * The helper is intentionally narrow:
+ *
+ *   1. Mint a Tier-1 cap for the consumer (`user:<id>` or
+ *      `anon:<session.id>`) via `mintTier1ForConsumer`.
+ *   2. Call `LifedWsAgentSessionClient.createSession({ resumeSid, ... })`
+ *      with the sticky sid the caller supplies. lifed creates a fresh
+ *      session or resumes the existing one with the same sid.
+ *   3. Open the per-turn stream and return the `AsyncIterable<
+ *      CanonicalAgentEvent>` so the caller can translate to whatever
+ *      wire format their UI expects (Anthropic SSE, OpenAI SSE,
+ *      Vercel-AI-SDK data-stream SSE).
+ *
+ * Decisions (locked in this PR):
+ *
+ *   - **Anonymous flow preserved**: anon callers mint Tier-0 (`tier:
+ *     "anon"`) caps. If lifegw rejects Tier-0, the anon flow breaks
+ *     visibly and we patch in a follow-up — but unilaterally dropping
+ *     anon would harm the signup funnel.
+ *   - **Sticky sid is per-chat**: the in-app chat UI passes `chatId`
+ *     (UUID) in the body; we forward THAT as `resumeSid` so a single
+ *     chat thread resolves to the same lifed session across turns.
+ *     This is intentionally different from `/api/v1/messages`, which
+ *     uses `buildStickySessionId(messages)` because external API callers
+ *     don't have a stable session id to send.
+ *   - **Per-turn mode only**: PR-3 keeps the per-turn semantics
+ *     (`multiTurn !== true`). Multi-turn opt-in is a later concern;
+ *     the in-app chat already uses a fresh HTTP request per turn.
+ *   - **Project slug**: defaults to `default` (matching the auth helper)
+ *     unless the caller supplies one. Future work can map per-chat
+ *     `projectId` to a lifegw project slug.
+ *
+ * Spec: docs/superpowers/specs/2026-05-20-anthropic-openai-edge-endpoints.md
+ *       (extended by the BRO-1208 arc to cover the in-app surface)
+ */
+
+import "server-only";
+import { mintTier1ForConsumer } from "@/lib/auth/lifegw-jwt";
+import { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import type { ConsumerIdentity } from "@/lib/life-runtime/types";
+
+/**
+ * Factory injection point for tests. Production code lets this be
+ * `undefined`; tests assign a mock that returns a stubbed
+ * `LifedWsAgentSessionClient`.
+ */
+export type SessionClientFactory = (
+  baseUrl: string,
+) => LifedWsAgentSessionClient;
+
+/**
+ * Reads `LIFED_GATEWAY_URL`. Returns null when unset — the route should
+ * treat this as a configuration error and surface a 503-shaped response.
+ */
+export function getLifegwBaseUrl(): string | null {
+  const url = process.env.LIFED_GATEWAY_URL;
+  return url && url.length > 0 ? url : null;
+}
+
+/**
+ * Result of opening a lifegw-routed dispatch — the canonical event
+ * stream plus the resolved sid (lifed may have minted fresh when the
+ * `resumeSid` wasn't recognized).
+ */
+export interface LifegwDispatchHandle {
+  /** The session id lifed returned. Usually equals `input.stickySid`. */
+  sessionId: string;
+  /** Per-turn canonical event iterator. Exactly one `finish` at the end. */
+  events: AsyncIterable<CanonicalAgentEvent>;
+}
+
+export interface DispatchViaLifegwInput {
+  /**
+   * Stable id for the lifed session. For the in-app `/api/chat` route
+   * this is the chatId (UUID); for external API routes it's the hash
+   * derived via `buildStickySessionId(messages)`.
+   */
+  stickySid: string;
+  /**
+   * The current turn's user text — the literal string lifed sends to
+   * the LLM. The caller is responsible for extracting it from whatever
+   * shape its inbound message uses (Anthropic blocks, Vercel-AI-SDK
+   * parts, OpenAI strings, etc.).
+   */
+  userMessage: string;
+  /**
+   * Consumer identity — `user:<id>` for authenticated, `anon:<id>` for
+   * anonymous. Drives both the Tier-1 subject and the agentId we pass
+   * to lifed.
+   */
+  consumer: ConsumerIdentity;
+  /** Project slug for the cap and the lifed session. Defaults to `default`. */
+  projectSlug?: string;
+  /** Aborts both the create_session HTTP call and the WS stream. */
+  signal?: AbortSignal;
+  /**
+   * Test seam — when set, used instead of `new LifedWsAgentSessionClient`.
+   * Production callers leave this undefined.
+   */
+  clientFactory?: SessionClientFactory;
+}
+
+/**
+ * Open a lifegw dispatch for one chat turn.
+ *
+ * Throws if lifegw is unconfigured (`LIFED_GATEWAY_URL` unset) or if
+ * `createSession` fails — the caller decides whether to surface that as
+ * a 5xx, fall back, or retry. Per-turn errors *inside* the stream are
+ * yielded as `{ kind: "error" }` canonical events (followed by the
+ * mandatory terminal `finish`); the helper does not retry mid-stream.
+ */
+export async function dispatchViaLifegw(
+  input: DispatchViaLifegwInput,
+): Promise<LifegwDispatchHandle> {
+  const baseUrl = getLifegwBaseUrl();
+  if (!baseUrl) {
+    throw new Error(
+      "lifegw is not configured for this deployment (LIFED_GATEWAY_URL unset).",
+    );
+  }
+
+  const projectSlug = input.projectSlug ?? "default";
+  const subjectId = subjectFromConsumer(input.consumer);
+
+  // 1. Mint a fresh Tier-1 cap. The auth.ts helper does the same for
+  //    external API callers; we mint inline here because the in-app
+  //    route has its OWN auth resolution (anon + session + bearer) and
+  //    we want to pass the consumer kind explicitly so anon stays
+  //    `tier: "anon"`.
+  const cap = await mintTier1ForConsumer({
+    consumer: input.consumer,
+    projectSlug,
+  });
+
+  // 2. Construct the WS client. Tests inject a fake via clientFactory.
+  const client = input.clientFactory
+    ? input.clientFactory(baseUrl)
+    : new LifedWsAgentSessionClient({ baseUrl });
+
+  // 3. Open (or resume) the lifed session via the HTTP/JSON wrapper.
+  //    lifed creates a fresh session when resumeSid isn't in its
+  //    routing cache; subsequent turns with the same sid hit the cache
+  //    and reuse the existing session — the per-chat continuity invariant.
+  const session = await client.createSession({
+    capability: { token: cap.token },
+    userId: subjectId,
+    projectSlug,
+    resumeSid: input.stickySid,
+    signal: input.signal,
+  });
+
+  const sessionId = session.sid;
+
+  // 4. Open the per-turn streaming WS. Returns the canonical iterator.
+  //    history=[] because lifed accumulates conversation context server-
+  //    side via the sticky sid (D1, matches /api/v1/messages).
+  const events = client.stream({
+    sessionId,
+    agentId: `user:${subjectId}`,
+    projectSlug,
+    userMessage: input.userMessage,
+    history: [],
+    kernelCtx: {
+      sessionId,
+      agentId: `user:${subjectId}`,
+    },
+    capability: {
+      token: cap.token,
+      expiresAt: cap.expiresAt,
+    },
+    signal: input.signal,
+  });
+
+  return { sessionId, events };
+}
+
+function subjectFromConsumer(consumer: ConsumerIdentity): string {
+  switch (consumer.kind) {
+    case "user":
+      return consumer.id;
+    case "anon":
+      return `anon:${consumer.id}`;
+    case "agent":
+      return `agent:${consumer.id}`;
+  }
+}


### PR DESCRIPTION
## Summary

Third sub-PR of [BRO-1208](https://linear.app/broomva/issue/BRO-1208). Surgically replaces the dispatch in `app/(chat)/api/chat/route.ts` so the in-app chat surface uses the same lifegw substrate as `/api/v1/messages` (PR-1 #188). Vercel-AI-SDK SSE output preserved — `chat-sync.tsx` (useChat) untouched.

## Removed from /api/chat dispatch

- `executeViaArcan` / `resolveArcanEndpoints` / `markInstanceDegraded` — the Arcan-direct branch
- `createCoreChatAgent` + `streamText` — the AI-SDK-direct fallback
- The old `createChatStream` + `executeChatRequest` helpers (replaced by `createLifegwBackedChatStream` + a leaner `executeChatRequest`)

## Added

Under `lib/life-runtime/edge-adapter/`:

- **`dispatch-via-lifegw.ts`** — mints Tier-1 cap (Tier-0 for anon), opens lifed session via `LifedWsAgentSessionClient.createSession()` + `.stream()`. Reusable across the in-app route and (future) other in-house surfaces. Includes a `clientFactory` test seam.
- **`canonical-to-vercel-ai-sse.ts`** — translates the canonical `AgentEvent` iterator into Vercel-AI-SDK `UIMessageChunk` shape (`text-start` / `text-delta` / `text-end` / `tool-input-*` / `tool-output-*` / `error`). Owns the `CanonicalConsumeState` record the route reads in `onFinish` for persistence + cost accounting.

## Sticky session id

`chatId` (per-chat continuity). External API routes (`/api/v1/messages`, `/api/v1/chat/completions`) use the hash from `buildStickySessionId(messages)`; the in-app surface has a stable `chatId` UUID, so we forward THAT as `resumeSid` so a single chat thread resolves to the same lifed session across turns.

## Preserved verbatim

- Anonymous flow (Tier-0 mint at edge via `mintTier1ForConsumer({consumer: {kind: "anon", id: anonSession.id}})` → forward to lifegw)
- Credit gate (`canSpend` / `deductCredits` / `deductOrgCredits`)
- Tool feature-flag gating (FLAG_GATED_TOOLS / getGatedToolNames)
- MCP connector loader (gated, value reserved for a follow-up that forwards connector hints to lifegw — the resolved list is currently `_unused` with `void _mcpConnectors` to keep the existing flag-evaluation side effects)
- Rate limit (anon + auth), tier-access
- Chat history persistence (saveChat / saveMessage / updateMessage)
- Resumable streams (Redis pub/sub)
- Request body shape (`{id, message, prevMessages, projectId, ...body}`)
- `data-chatConfirmed` transient chunk on the first turn of a new authenticated chat

## NOT deleted (out-of-scope consumers)

- `lib/ai/core-chat-agent.ts` — still used by `lib/ai/eval-agent.ts`
- `lib/arcan/{client,execute,resolve}.ts` — still used by `app/api/auth/migrate-anonymous/route.ts` and the `resolve.test.ts` + `tier-routing.test.ts` test suites (Arcan retained for non-chat workloads per spec)
- `app/(chat)/api/chat/{add-explicit-tool-request,filter-reasoning,get-recent-image}.ts` — still imported by core-chat-agent.ts
- `app/(chat)/api/chat/[id]/stream/route.ts` — keeps its Arcan cursor-based replay path (with fallthrough to Redis if Arcan unreachable) verbatim

## Tests

| Suite | LOC | Tests |
| --- | --- | --- |
| `app/(chat)/api/chat/__tests__/route.test.ts` | 632 | 9 |
| `lib/life-runtime/edge-adapter/__tests__/canonical-to-vercel-ai-sse.test.ts` | 427 | 15 |
| `lib/life-runtime/edge-adapter/__tests__/dispatch-via-lifegw.test.ts` | 218 | 6 |
| **Added total** | **1277** | **30** |

Route tests cover: anon flow (consumer mapping + credit pre-deduct + SSE shape), auth flow (placeholder persistence + credit deduction), new-chat `data-chatConfirmed`, 503 on missing `LIFED_GATEWAY_URL`, request validation (missing message / model), and an Arcan-no-touch regression guard that fails if `/api/chat` imports `lib/arcan`.

Translator tests cover: token streaming (lazy text-start synthesis, lifed-supplied ids, multiple segments, empty-delta filter), tool calls (input/output mapping, error path, malformed JSON fallback, synthesised callId), error events (mid-stream error chunk + state recording), warning suppression, telemetry-event filtering (thinking/fs_op/nous_score/haima_billed/vigil_span all dropped).

Dispatcher tests cover: Tier-1 mint for users, Tier-0 mint for anons, custom project slug forwarding, 503 on unset `LIFED_GATEWAY_URL`, mint-failure propagation, createSession-failure propagation.

## Validation

- `bun run test:types`: clean
- `bun run test:unit`: **528 pass / 1 skipped** (added 28 — full suite, not just chat)
- `bunx biome check apps/broomva/app/\(chat\)/api/chat/ apps/broomva/lib/life-runtime/edge-adapter/`: clean

## Test plan

- [ ] CI green (typecheck + bun test + biome)
- [ ] Vercel preview deploy succeeds (verify build doesn't break)
- [ ] Dogfood: send a message as logged-in user → response streams; send a message anonymously → response streams (chat UI unchanged)
- [ ] Regression: /api/v1/messages + /api/v1/chat/completions still work
- [ ] `curl -X POST https://broomva.tech/api/chat` with the existing useChat body shape returns Vercel-AI-SDK SSE (same shape as before this PR)
- [ ] Open one concern: lifegw must accept Tier-0 (`tier: "anon"`) caps. If it rejects, the anon flow breaks and we patch in a follow-up — but unilaterally dropping anon would harm the signup funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Chat API now powered by new backend gateway system with improved scalability and reliability.
  * Enhanced tracking of credits and resource usage for all users.

* **Reliability**
  * Chat service returns appropriate error status when backend gateway is unavailable.
  * Comprehensive test coverage added for chat endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->