### PR TITLE
chore(next-config): drop dead /api/chat outputFileTracingIncludes (post-PR-3)

### DIFF
--- a/apps/broomva/next.config.ts
+++ b/apps/broomva/next.config.ts
@@ -140,10 +140,11 @@ const nextConfig: NextConfig = {
       "./public/images/**",
     ],
   },
-  outputFileTracingIncludes: {
-    "/api/chat": ["./public/agent-knowledge.json"],
-    "/api/chat/[id]/**": ["./public/agent-knowledge.json"],
-  },
+  // outputFileTracingIncludes intentionally empty post-PR-3 (#194). The
+  // /api/chat route no longer reads public/agent-knowledge.json — the
+  // agent context is now built upstream in lifed (broomva/life). Re-add
+  // an entry here only if a route imports a non-source file at runtime
+  // that the Vercel build's tracing analysis would otherwise miss.
   experimental: {
     optimizePackageImports: [
       "react-tweet",


### PR DESCRIPTION
## Summary

Cleanup PR-4 under [BRO-1208](https://linear.app/broomva/issue/BRO-1208). PR #194 routed `/api/chat` through lifegw and stopped reading `public/agent-knowledge.json` from the route — the agent context is now built upstream in lifed. The `outputFileTracingIncludes` entries for `/api/chat` and `/api/chat/[id]/**` are dead weight in the Vercel build.

```bash
$ git show origin/main:apps/broomva/app/\(chat\)/api/chat/route.ts | grep -c agent-knowledge
0
```

## Scope: minimal by design

PR-4 was originally scoped to delete `lib/ai/core-chat-agent.ts`, `lib/arcan/*`, and the 3 `/(chat)/api/chat/` helper files. The dep audit after PR #194 landed showed those modules are still consumed:

- `lib/ai/core-chat-agent.ts` — used by `lib/ai/eval-agent.ts`
- `lib/ai/prompts.ts:buildSystemPrompt` — used by `lib/ai/eval-agent.ts`
- `lib/ai/followup-suggestions.ts:generateFollowupSuggestions` — used by `lib/ai/eval-agent.ts`
- `lib/arcan/{client,execute,resolve}.ts` — used by `app/api/auth/migrate-anonymous/route.ts` + tests
- The 3 `app/(chat)/api/chat/*.ts` helpers — still imported by core-chat-agent.ts

Deleting any of those breaks unrelated surfaces. The right follow-up is a separate eval-agent migration onto lifegw, then those libs can go.

## Test plan

- [ ] CI green (typecheck + validate + build)
- [ ] Vercel build still succeeds (proves the `agent-knowledge.json` tracing was indeed dead)
- [ ] `POST /api/chat` regression unchanged post-deploy (`curl -X POST https://broomva.tech/api/chat -d '{}'` → 400 ChatSDKError, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)