### PR TITLE
fix(account): unblock Vercel prod deploy — Next.js 16 cacheComponents + dynamic({ssr:false}) (BRO-1229)

### DIFF
--- a/apps/broomva/app/account/layout.tsx
+++ b/apps/broomva/app/account/layout.tsx
@@ -12,7 +12,10 @@ import { redirect } from "next/navigation";
 import { AccountNav } from "@/components/account/account-nav";
 import { getSafeSession } from "@/lib/auth";
 
-export const dynamic = "force-dynamic";
+// BRO-1229 — `export const dynamic = "force-dynamic"` is incompatible
+// with `nextConfig.cacheComponents` (Next.js 16). The `await headers()`
+// call below automatically opts this layout into dynamic rendering, so
+// the explicit declaration is redundant *and* now blocks the build.
 
 export default async function AccountLayout({
   children,

--- a/apps/broomva/app/account/page.tsx
+++ b/apps/broomva/app/account/page.tsx
@@ -21,7 +21,9 @@ import {
 } from "@/components/ui/card";
 import { fetchPasskeyStatus } from "@/lib/anima/passkey-status";
 
-export const dynamic = "force-dynamic";
+// BRO-1229 — removed `export const dynamic = "force-dynamic"`;
+// incompatible with `nextConfig.cacheComponents` (Next.js 16). The
+// `await headers()` call already makes this page dynamic-by-default.
 
 export default async function AccountIndexPage() {
   const headerStore = await headers();

--- a/apps/broomva/app/account/security/passkey/page.tsx
+++ b/apps/broomva/app/account/security/passkey/page.tsx
@@ -1,13 +1,11 @@
 /**
  * /account/security/passkey — passkey enrollment + status surface.
  *
- * BRO-1213 / M9-C.
- *
- * # Bundle-size discipline (D4)
- *
- * The interactive enrollment card is loaded via `next/dynamic({ ssr: false })`
- * so WebAuthn ceremony code stays out of the shared client shell. The
- * server-rendered shell shows a skeleton while the client chunk hydrates.
+ * BRO-1213 / M9-C; BRO-1229 — moved the `dynamic({ ssr: false })` call
+ * into the client-side `<PasskeyCardLazy>` wrapper because Next.js 16
+ * only allows that option from Client Component contexts. The lazy
+ * chunk boundary is preserved (WebAuthn ceremony code stays out of the
+ * shared client shell); only the file that owns `nextDynamic` moved.
  *
  * # State 1 + 2 handling
  *
@@ -19,30 +17,15 @@
  */
 
 import { headers } from "next/headers";
-import nextDynamic from "next/dynamic";
-import { Skeleton } from "@/components/ui/skeleton";
+import { PasskeyCardLazy } from "@/components/account/passkey-card-lazy";
 import { getSafeSession } from "@/lib/auth";
 import { fetchPasskeyStatus } from "@/lib/anima/passkey-status";
 
-const PasskeyEnrollmentCard = nextDynamic(
-  () =>
-    import("@/components/account/passkey-enrollment-card").then(
-      (m) => m.PasskeyEnrollmentCard,
-    ),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="space-y-3">
-        <Skeleton className="h-8 w-2/3" />
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-10 w-40" />
-      </div>
-    ),
-  },
-);
-
-export const dynamic = "force-dynamic";
+// BRO-1229 — removed `export const dynamic = "force-dynamic"`;
+// incompatible with `nextConfig.cacheComponents` (Next.js 16). The
+// `await headers()` call below already makes this page dynamic-by-
+// default, so the explicit opt-in is redundant *and* now blocks the
+// build.
 
 export default async function PasskeyPage() {
   const headerStore = await headers();
@@ -72,7 +55,7 @@ export default async function PasskeyPage() {
         </p>
       </div>
 
-      <PasskeyEnrollmentCard
+      <PasskeyCardLazy
         initialStatus={initialStatus}
         userEmail={session.user.email ?? "you@broomva.tech"}
         userId={session.user.id}

--- a/apps/broomva/components/account/passkey-card-lazy.tsx
+++ b/apps/broomva/components/account/passkey-card-lazy.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * Client-side lazy wrapper around `<PasskeyEnrollmentCard />`.
+ *
+ * BRO-1229 — moved out of `app/account/security/passkey/page.tsx` (a
+ * Server Component). Next.js 16 removed support for
+ * `dynamic({ ssr: false })` when called from a Server Component
+ * context — the option is now Client-Component-only. By marking this
+ * file `"use client"` we re-enable the `ssr: false` path AND keep the
+ * lazy chunk boundary so the WebAuthn ceremony code stays out of the
+ * shared client shell.
+ *
+ * Behaviour matches the previous inline shape exactly: same dynamic
+ * import target, same `ssr: false`, same skeleton-shaped loading state.
+ * The page (`page.tsx`) imports this directly as a regular component —
+ * no `nextDynamic` at the page boundary anymore.
+ */
+
+import nextDynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { PasskeyStatus } from "@/lib/anima/passkey-status";
+
+const PasskeyEnrollmentCard = nextDynamic(
+  () =>
+    import("@/components/account/passkey-enrollment-card").then(
+      (m) => m.PasskeyEnrollmentCard,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-10 w-40" />
+      </div>
+    ),
+  },
+);
+
+export interface PasskeyCardLazyProps {
+  initialStatus: PasskeyStatus;
+  userEmail: string;
+  userId: string;
+}
+
+/**
+ * Server-prop-safe wrapper — props are POJO-serializable so they cross
+ * the Server → Client boundary cleanly.
+ */
+export function PasskeyCardLazy(props: PasskeyCardLazyProps) {
+  return <PasskeyEnrollmentCard {...props} />;
+}


### PR DESCRIPTION
## Unblocks production

broomva.tech Vercel production deploys have been FAILING for ~22h (since BRO-1213 passkey UI merge at \`a058535\`). Multiple feature PRs blocked from going live, including BRO-1224 (the just-merged transparent Tier-1 refresh) — its new \`/api/auth/lifegw-token\` endpoint isn't live in production yet because Vercel can't ship it.

## Two stacked Next.js 16 incompatibilities

### 1. \`nextDynamic({ ssr: false })\` in Server Components

\`apps/broomva/app/account/security/passkey/page.tsx:27\` (server-side async page) was calling \`nextDynamic(..., { ssr: false, loading: ... })\`. Next.js 16 dropped support for \`ssr: false\` in Server Component contexts.

**Fix**: extracted the dynamic-import + skeleton into a new client-component file \`apps/broomva/components/account/passkey-card-lazy.tsx\` (\`\"use client\"\`). Page imports it as a regular component. Behavior preserved (same lazy chunk + skeleton).

### 2. \`export const dynamic = \"force-dynamic\"\` + cacheComponents

\`next.config.ts\` has \`cacheComponents: true\`. Next.js 16 treats \`export const dynamic = \"force-dynamic\"\` as incompatible:
\`\`\`
Route segment config \"dynamic\" is not compatible with nextConfig.cacheComponents. Please remove it.
\`\`\`

Three files affected: \`account/layout.tsx:15\`, \`account/page.tsx:24\`, \`account/security/passkey/page.tsx:24\`.

**Fix**: removed all three. Each page already calls \`await headers()\` which auto-opts into dynamic rendering under cacheComponents.

## Verification

- \`next build\` locally passes the account/* error site (remaining failures are unrelated env-config in other routes that Vercel has set)
- \`tsc --noEmit -p tsconfig.json\` clean

## Acceptance

- [ ] Vercel production deploy of \`main\` succeeds after this merges
- [ ] \`/account/security/passkey\` still renders with skeleton fallback
- [ ] \`https://broomva.tech/api/auth/lifegw-token\` returns 405 GET (BRO-1224 live)

## Linear

[BRO-1229](https://linear.app/broomva/issue/BRO-1229)

🤖 Generated with [Claude Code](https://claude.com/claude-code)