### PR TITLE
feat(chat): lifegw-backed stream-resume path behind USE_LIFEGW_STREAM_RESUME flag [BRO-1216]

### DIFF
--- a/apps/broomva/app/(chat)/api/chat/[id]/stream/route.ts
+++ b/apps/broomva/app/(chat)/api/chat/[id]/stream/route.ts
@@ -8,8 +8,12 @@ import type { NextRequest } from "next/server";
 import { ChatSDKError } from "@/lib/ai/errors";
 import type { ChatMessage } from "@/lib/ai/types";
 import { getSafeSession } from "@/lib/auth";
+import { mintTier1ForConsumer } from "@/lib/auth/lifegw-jwt";
 import { getChatById, getChatMessageWithPartsById } from "@/lib/db/queries";
 import { ArcanClient, resolveArcanUrl } from "@/lib/arcan";
+import { LifedWsAgentSessionClient } from "@/lib/life-runtime/agent-session/lifed-ws-client";
+import { canonicalToVercelAiSdkSse } from "@/lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse";
+import { getLifegwBaseUrl } from "@/lib/life-runtime/edge-adapter/dispatch-via-lifegw";
 import { getStreamContext } from "../../route";
 
 function appendMessageResponse(message: ChatMessage) {
@@ -54,11 +58,82 @@ export async function GET(
     return new ChatSDKError("forbidden:chat").toResponse();
   }
 
-  // ── Arcan cursor-based replay ───────────────────────────────────
-  // If the user has a Life instance, use Lago's event journal for
-  // stream reconnection instead of Redis resumable streams.
+  // ── Cursor-based replay ─────────────────────────────────────────
+  // If the user has a Life-runtime backend (lifegw or per-user Arcan),
+  // replay events from the cursor on the canonical event journal.
+  //
+  // Backend resolution order (M9-F-A migration, BRO-1216):
+  //   1. lifegw — when USE_LIFEGW_STREAM_RESUME=1 AND LIFED_GATEWAY_URL is set.
+  //      Mints a Tier-1 cap, opens lifed session resumed under the chatId
+  //      as the sticky sid, then opens a per-turn stream with
+  //      userMessage="" + fromSequence=cursor — pure replay-only mode.
+  //   2. Arcan — pre-migration default, kept verbatim. Active when the
+  //      lifegw branch is gated off OR yields an error.
+  //   3. Redis resumable-stream — the fallback for both, unchanged.
   const cursor = request.nextUrl.searchParams.get("cursor");
   if (userId && cursor != null) {
+    const lifegwBaseUrl = getLifegwBaseUrl();
+    const lifegwResumeEnabled =
+      process.env.USE_LIFEGW_STREAM_RESUME === "1" && !!lifegwBaseUrl;
+
+    if (lifegwResumeEnabled) {
+      try {
+        const cap = await mintTier1ForConsumer({
+          consumer: { kind: "user", id: userId },
+          projectSlug: "default",
+        });
+        const lifegwClient = new LifedWsAgentSessionClient({
+          baseUrl: lifegwBaseUrl,
+        });
+        const lifegwSession = await lifegwClient.createSession({
+          capability: { token: cap.token },
+          userId,
+          projectSlug: "default",
+          resumeSid: chatId,
+        });
+        const events = lifegwClient.stream({
+          sessionId: lifegwSession.sid,
+          agentId: `user:${userId}`,
+          projectSlug: "default",
+          userMessage: "",
+          history: [],
+          kernelCtx: {
+            sessionId: lifegwSession.sid,
+            agentId: `user:${userId}`,
+          },
+          capability: {
+            token: cap.token,
+            expiresAt: cap.expiresAt,
+          },
+          fromSequence: BigInt(cursor),
+        });
+
+        const fallbackTextId = crypto.randomUUID();
+        const stream = createUIMessageStream<ChatMessage>({
+          execute: async ({ writer }) => {
+            for await (const chunk of canonicalToVercelAiSdkSse<ChatMessage>(
+              events,
+              { fallbackTextId }
+            )) {
+              writer.write(chunk);
+            }
+          },
+          generateId: () => fallbackTextId,
+        });
+
+        return new Response(
+          stream
+            .pipeThrough(new JsonToSseTransformStream())
+            .pipeThrough(new TextEncoderStream()),
+          { headers: UI_MESSAGE_STREAM_HEADERS }
+        );
+      } catch {
+        // lifegw unreachable / cap mint failed — fall through to Arcan,
+        // then to the Redis path. Same graceful-degradation contract the
+        // existing Arcan branch uses below.
+      }
+    }
+
     const endpoints = await resolveArcanUrl(userId);
     if (endpoints) {
       try {


### PR DESCRIPTION
## Summary
- M9-F-A — first of three M9-F migrations off `lib/arcan/`
- Adds a lifegw-backed branch to `app/(chat)/api/chat/[id]/stream/route.ts` cursor-replay endpoint, behind `USE_LIFEGW_STREAM_RESUME` env flag, **default OFF**
- Graceful degradation: lifegw failure falls through to existing Arcan path, which falls through to Redis resumable-stream
- No production behavior change on merge — flag flip is a separate operator action

## What's in the diff (single file, +78/-3)

`app/(chat)/api/chat/[id]/stream/route.ts`:
- New branch at top of the cursor-replay block. When `USE_LIFEGW_STREAM_RESUME=1` AND `LIFED_GATEWAY_URL` is set:
  1. Mints a Tier-1 cap via `mintTier1ForConsumer({ consumer: { kind: "user", id: userId }, projectSlug: "default" })`
  2. Opens `LifedWsAgentSessionClient.createSession({ resumeSid: chatId, ... })`
  3. Calls `client.stream({ userMessage: "", fromSequence: BigInt(cursor), history: [] })` — pure replay-only mode
  4. Translates canonical events → AI-SDK `UIMessageChunk` via `canonicalToVercelAiSdkSse` (from PR #194)
  5. Pipes through `JsonToSseTransformStream` — wire format identical to existing Arcan path
- Existing Arcan branch + Redis fallback preserved verbatim

## Why behind a flag

Stream resumption affects every reload of an in-progress chat. Silent regression would break UX everywhere. Flag-gated rollout:
1. Merge this PR (default OFF → no behavior change)
2. Operator sets `USE_LIFEGW_STREAM_RESUME=1` + `LIFED_GATEWAY_URL=...` on Vercel preview
3. Smoke: open chat, mid-stream reload, confirm replay continues from cursor with parity to Arcan baseline
4. If green, flip default-ON in prod
5. After ≥48h no regression, file follow-up PR to remove Arcan branch + delete `lib/arcan/`

## P14 dep-chain

**Upstream**:
- `lib/auth/lifegw-jwt.ts` — `mintTier1ForConsumer` (Tier-1 cap minter, from BRO-1208)
- `lib/life-runtime/agent-session/lifed-ws-client.ts` — `LifedWsAgentSessionClient` with `fromSequence` resume support (line 930 sends `from_sequence` WS param)
- `lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse.ts` — canonical event → AI-SDK chunk translator (from PR #194)
- `lib/life-runtime/edge-adapter/dispatch-via-lifegw.ts` — `getLifegwBaseUrl` env reader

**Downstream**:
- BRO-1216 (M9-F) `lib/arcan/` deletion — migrates 1 of 2 Arcan consumers; second is `app/api/auth/migrate-anonymous/route.ts` (needs lifegw identity-migration endpoint analogue first — file separate sub-ticket)
- Bundle-size reduction once `lib/arcan/` deletion follows

## P11 validation gates (pre-commit)

- [x] `bun run test:types` — clean (typegen + tsc --noEmit)
- [x] `bunx biome lint app/(chat)/api/chat/[id]/stream/route.ts` — 0 findings
- [x] `bun run test:unit` — 541 pass / 1 skipped / 0 regressions
- [ ] Vercel preview smoke (operator) — set env flag, mid-stream reload smoke
- [ ] Flip default-ON after smoke confirms parity

## Linear

Partial-progress on BRO-1216 (M9-F). Final close happens when (a) flag flips default-ON in prod, (b) `migrate-anonymous/route.ts` ports off lib/arcan/ (separate sub-PR — depends on lifegw identity-migration endpoint), (c) `lib/arcan/` deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented advanced chat session resumption with cursor-based replay capability, offering enhanced ability to reliably restore and continue previous conversations.

* **Bug Fixes**
  * Improved chat recovery process with strengthened fallback logic, ensuring better continuity and stability when resuming sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/broomva/broomva.tech/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->