### PR TITLE
feat(anima): Tier-User cap sign-in flow + authenticated-fetch wrapper [BRO-1214]

### DIFF
--- a/apps/broomva/app/(chat)/layout.tsx
+++ b/apps/broomva/app/(chat)/layout.tsx
@@ -12,6 +12,7 @@ import { ContextSidebarProvider } from "@/hooks/use-context-sidebar";
 import { ChatModelsProvider } from "@/providers/chat-models-provider";
 import { DefaultModelProvider } from "@/providers/default-model-provider";
 import { SessionProvider } from "@/providers/session-provider";
+import { TierUserCapManager } from "@/providers/tier-user-cap-manager";
 import { TRPCReactProvider } from "@/trpc/react";
 import { getQueryClient, HydrateClient, trpc } from "@/trpc/server";
 import { TopNav } from "@/components/site/top-nav";
@@ -79,6 +80,7 @@ export default async function ChatLayout({
     <TRPCReactProvider>
       <HydrateClient>
         <SessionProvider initialSession={session}>
+          <TierUserCapManager />
           <ChatProviders>
             <SidebarProvider defaultOpen={!isCollapsed}>
               <AppSidebar />

--- a/apps/broomva/app/(console)/layout.tsx
+++ b/apps/broomva/app/(console)/layout.tsx
@@ -11,6 +11,7 @@ import {
 import { TopNav } from "@/components/site/top-nav";
 import { ToolbarDockProvider } from "@/components/site/toolbar-dock-context";
 import { SessionProvider } from "@/providers/session-provider";
+import { TierUserCapManager } from "@/providers/tier-user-cap-manager";
 import { TRPCReactProvider } from "@/trpc/react";
 import { getSafeSession } from "@/lib/auth";
 import { captureServerEvent } from "@/lib/analytics/posthog";
@@ -36,6 +37,7 @@ export default async function ConsoleLayout({
   return (
     <TRPCReactProvider>
       <SessionProvider initialSession={session}>
+        <TierUserCapManager />
         <ToolbarDockProvider>
           <SidebarProvider defaultOpen={defaultOpen}>
             <ConsoleSidebar

--- a/apps/broomva/lib/anima/authenticated-fetch.ts
+++ b/apps/broomva/lib/anima/authenticated-fetch.ts
@@ -1,0 +1,70 @@
+/**
+ * `fetch` wrapper that auto-attaches the current Tier-User cap.
+ *
+ * BRO-1214 / M9-D. Drop-in replacement for `fetch()` used when calling
+ * `/anima/custody/*` endpoints from browser code. The wrapper:
+ *
+ *   1. Ensures a non-expired Tier-User cap is available via
+ *      `ensureFreshTierUserCap`. If the user isn't signed in OR minting
+ *      fails, falls through to a plain fetch — the edge proxy still
+ *      accepts the Neon Auth session cookie, so calls continue working.
+ *   2. Attaches `Authorization: Bearer <cap-jwt>` to the outbound headers.
+ *   3. Forwards `credentials: "include"` so the Neon Auth cookie is also
+ *      sent (server-side, the edge proxy verifies whichever auth path is
+ *      present).
+ *
+ * # When to use
+ *
+ *   - Any browser-side `fetch` to `/api/anima/custody/*`
+ *   - Future direct calls to lifegw `/anima/custody/*` when M8.2 resolves
+ *     and browser-direct lifegw becomes viable (Tier-User cap is the
+ *     intended bearer on that path)
+ *
+ * # When NOT to use
+ *
+ *   - Server-side code (no IndexedDB, no session cookies — use
+ *     `mintTier1ForConsumer` instead)
+ *   - WebSocket upgrades (Tier-User caps are HTTP-only per Spec D; WS
+ *     paths use Tier-1 over `Sec-WebSocket-Protocol: bearer.*`)
+ */
+
+import { ensureFreshTierUserCap, type TierUserCap } from "./tier-user-cap";
+
+export interface AuthenticatedFetchOptions extends RequestInit {
+  /**
+   * Userid for cap minting. Required because the cap is per-user; pass
+   * the same id the SessionProvider yields via `useSession().data?.user?.id`.
+   * If absent or empty, the wrapper falls through to a plain `fetch` with
+   * `credentials: "include"` (Neon Auth cookie path).
+   */
+  userId?: string | null;
+  /**
+   * Pre-resolved cap. If provided, skips the IndexedDB / mint step and
+   * attaches this cap directly. Useful for callers that already pulled
+   * the cap from the Provider context (avoids a second IndexedDB hit).
+   */
+  cap?: TierUserCap | null;
+}
+
+export async function animaCustodyFetch(
+  input: RequestInfo | URL,
+  options: AuthenticatedFetchOptions = {},
+): Promise<Response> {
+  const { userId, cap: providedCap, headers: callerHeaders, ...rest } = options;
+
+  let cap: TierUserCap | null = providedCap ?? null;
+  if (!cap && userId) {
+    cap = await ensureFreshTierUserCap(userId);
+  }
+
+  const headers = new Headers(callerHeaders ?? {});
+  if (cap) {
+    headers.set("authorization", `Bearer ${cap.token}`);
+  }
+
+  return fetch(input, {
+    ...rest,
+    headers,
+    credentials: rest.credentials ?? "include",
+  });
+}

--- a/apps/broomva/lib/anima/index.ts
+++ b/apps/broomva/lib/anima/index.ts
@@ -24,3 +24,16 @@ export {
   type EnrollPasskeyInput,
   type EnrolledPasskey,
 } from "./passkey-enrollment";
+
+export {
+  clearStoredCap,
+  ensureFreshTierUserCap,
+  getStoredCap,
+  storeCap,
+  type TierUserCap,
+} from "./tier-user-cap";
+
+export {
+  animaCustodyFetch,
+  type AuthenticatedFetchOptions,
+} from "./authenticated-fetch";

--- a/apps/broomva/lib/anima/tier-user-cap.ts
+++ b/apps/broomva/lib/anima/tier-user-cap.ts
@@ -1,0 +1,190 @@
+/**
+ * Tier-User capability — browser-side mint + cache + auto-refresh.
+ *
+ * BRO-1214 / M9-D. Spec D D-Sub-C/D — Tier-User cap is the HTTP-only
+ * credential a chatOS browser uses to authenticate against the
+ * `/anima/custody/*` surface beyond first-time enrollment. It's distinct
+ * from Tier-1 (which auth's broomva.tech → lifegw server-side) — Tier-User
+ * is the browser → lifegw cap that authorises per-user custody operations
+ * (sign, rotate, revoke, status).
+ *
+ * # Lifecycle
+ *
+ *   1. On sign-in, the cap-provider component triggers `ensureFreshTierUserCap`
+ *   2. This reads IndexedDB; if a cap exists and is > 60s from expiry, returns it
+ *   3. Otherwise, POSTs `/api/anima/custody/mint_session_cap` (proxied to lifegw
+ *      by the M9-C edge route at `app/api/anima/custody/[...path]/route.ts`)
+ *   4. The new cap is persisted to IndexedDB keyed `"current"` and returned
+ *
+ * # Failure mode
+ *
+ * Best-effort: if minting fails (lifegw down, route not yet deployed,
+ * network error), the helper returns `null` and the consumer continues
+ * without a Tier-User cap. This is safe because all current `/anima/custody/*`
+ * callers also pass the Neon Auth session cookie which the edge proxy
+ * already accepts. The Tier-User cap is opt-in additive auth; not having
+ * it doesn't break anything.
+ *
+ * # Not persisted across sessions
+ *
+ * Caps are scoped to the browser tab's signed-in user. The cap-provider
+ * clears the IndexedDB store on sign-out. A second user signing in on the
+ * same browser wipes the previous user's cap before minting their own.
+ */
+
+const DB_NAME = "anima-tier-user";
+const DB_VERSION = 1;
+const STORE_NAME = "caps";
+const CAP_KEY = "current";
+
+const MINT_ENDPOINT = "/api/anima/custody/mint_session_cap";
+const MINT_TIMEOUT_MS = 5_000;
+const DEFAULT_REFRESH_THRESHOLD_SECS = 60;
+
+export interface TierUserCap {
+  /** JWT (ES256, lifegw-signed). Caller MUST send as `Authorization: Bearer <token>`. */
+  token: string;
+  /** Unix seconds. Caller refreshes when `expiresAt - now <= threshold`. */
+  expiresAt: number;
+  /** Userid the cap was minted for. Stored so we can detect signed-in-user changes. */
+  userId: string;
+}
+
+interface MintResponse {
+  token: string;
+  expiresAt: number;
+}
+
+const isBrowser = typeof globalThis !== "undefined"
+  && typeof (globalThis as { indexedDB?: IDBFactory }).indexedDB !== "undefined";
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("indexeddb open failed"));
+  });
+}
+
+export async function getStoredCap(): Promise<TierUserCap | null> {
+  if (!isBrowser) return null;
+  try {
+    const db = await openDb();
+    return await new Promise<TierUserCap | null>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readonly");
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.get(CAP_KEY);
+      req.onsuccess = () => {
+        const value = req.result as TierUserCap | undefined;
+        resolve(value ?? null);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function storeCap(cap: TierUserCap): Promise<void> {
+  if (!isBrowser) return;
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.put(cap, CAP_KEY);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    // Swallow: storage failure isn't user-actionable, and the cap is
+    // additive — the app keeps working without it.
+  }
+}
+
+export async function clearStoredCap(): Promise<void> {
+  if (!isBrowser) return;
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.delete(CAP_KEY);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    // Swallow per storeCap rationale.
+  }
+}
+
+/**
+ * POST `/api/anima/custody/mint_session_cap`. Returns the minted cap, or
+ * `null` on any failure (network, 4xx, 5xx, timeout, malformed body).
+ *
+ * The route forwards to lifegw via the M9-C edge proxy. Lifegw decides
+ * eligibility based on the Tier-1 cap the proxy mints from the Neon Auth
+ * session — so this call requires the user to be signed in already.
+ */
+async function mintFromServer(userId: string): Promise<TierUserCap | null> {
+  if (!isBrowser) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), MINT_TIMEOUT_MS);
+  try {
+    const resp = await fetch(MINT_ENDPOINT, {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+      signal: controller.signal,
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as Partial<MintResponse>;
+    if (
+      typeof body.token !== "string"
+      || typeof body.expiresAt !== "number"
+      || body.token.length === 0
+    ) {
+      return null;
+    }
+    return { token: body.token, expiresAt: body.expiresAt, userId };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Returns a non-expired Tier-User cap, minting one if necessary.
+ *
+ *   - If the stored cap is for a different user, it's cleared first.
+ *   - If the stored cap is within `thresholdSecs` of expiry (default 60s),
+ *     a fresh one is minted.
+ *   - On mint failure, returns `null` (consumer must tolerate this; the
+ *     cap is additive).
+ */
+export async function ensureFreshTierUserCap(
+  userId: string,
+  thresholdSecs: number = DEFAULT_REFRESH_THRESHOLD_SECS,
+): Promise<TierUserCap | null> {
+  if (!isBrowser) return null;
+  const stored = await getStoredCap();
+  if (stored && stored.userId !== userId) {
+    await clearStoredCap();
+  } else if (stored) {
+    const nowSecs = Math.floor(Date.now() / 1000);
+    if (stored.expiresAt - nowSecs > thresholdSecs) {
+      return stored;
+    }
+  }
+  const fresh = await mintFromServer(userId);
+  if (fresh) await storeCap(fresh);
+  return fresh;
+}

--- a/apps/broomva/providers/tier-user-cap-manager.tsx
+++ b/apps/broomva/providers/tier-user-cap-manager.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * Tier-User cap lifecycle — mints on sign-in, refreshes on tab focus, clears
+ * on sign-out.
+ *
+ * BRO-1214 / M9-D. Renderless side-effect component mounted inside the
+ * `SessionProvider` tree so it can observe sign-in transitions.
+ *
+ * # Behavior
+ *
+ *   - On the first session with a non-null `user.id`, calls
+ *     `ensureFreshTierUserCap` once. Tracked via sessionStorage so a
+ *     single mint attempt happens per browser session (no retry storms
+ *     if lifegw is down).
+ *   - On `visibilitychange` to `visible`, calls `ensureFreshTierUserCap`
+ *     again — this refreshes the cap if it's near expiry, otherwise
+ *     no-ops (reads IndexedDB only).
+ *   - On user transition (different user id OR sign-out), calls
+ *     `clearStoredCap` and resets the session-mint flag.
+ *
+ * # Failure mode
+ *
+ * Best-effort. `ensureFreshTierUserCap` returns `null` on any failure;
+ * the manager swallows it. `/anima/custody/*` callers continue working
+ * via the Neon Auth session cookie (edge proxy at
+ * `app/api/anima/custody/[...path]/route.ts` accepts both).
+ *
+ * # Placement
+ *
+ * Mount as a sibling of `<SessionProvider>` children — inside the
+ * provider so `useSession()` works, but outside the layout's main
+ * children tree so it doesn't re-render with the page. Renders `null`.
+ */
+
+import { useEffect, useRef } from "react";
+import { useSession } from "@/providers/session-provider";
+import { clearStoredCap, ensureFreshTierUserCap } from "@/lib/anima/tier-user-cap";
+
+const SESSION_FLAG_KEY = "anima-tier-user-cap-mint-attempted";
+
+function getSessionFlag(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage.getItem(SESSION_FLAG_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setSessionFlag(userId: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(SESSION_FLAG_KEY, userId);
+  } catch {
+    // Swallow — sessionStorage can throw in private mode.
+  }
+}
+
+function clearSessionFlag(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(SESSION_FLAG_KEY);
+  } catch {
+    // Swallow.
+  }
+}
+
+export function TierUserCapManager(): null {
+  const { data: session, isPending } = useSession();
+  const userId = session?.user?.id ?? null;
+  const lastUserIdRef = useRef<string | null>(null);
+
+  // Mint on sign-in + user-change reconciliation
+  useEffect(() => {
+    if (isPending) return;
+    const prevUserId = lastUserIdRef.current;
+    if (userId === prevUserId) return;
+    lastUserIdRef.current = userId;
+
+    if (!userId) {
+      // Sign-out — clear cap + flag
+      void clearStoredCap();
+      clearSessionFlag();
+      return;
+    }
+
+    // Sign-in or user-change
+    const flagValue = getSessionFlag();
+    if (flagValue === userId) {
+      // Already attempted minting for this user this browser session;
+      // no retry storm. The tab-focus refresh below will still re-mint
+      // when the cap is near expiry.
+      return;
+    }
+    setSessionFlag(userId);
+    void ensureFreshTierUserCap(userId);
+  }, [userId, isPending]);
+
+  // Refresh on tab-visibility flip to visible
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const handler = () => {
+      if (document.visibilityState !== "visible") return;
+      const currentUserId = lastUserIdRef.current;
+      if (!currentUserId) return;
+      void ensureFreshTierUserCap(currentUserId);
+    };
+    document.addEventListener("visibilitychange", handler);
+    return () => document.removeEventListener("visibilitychange", handler);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- M9-D — browser-side Tier-User cap lifecycle: mint on sign-in, persist in IndexedDB, refresh on tab focus, clear on sign-out
- Adds `animaCustodyFetch` wrapper for future `/anima/custody/*` callers
- Best-effort: mint failures swallow silently; existing Neon Auth session path continues working unchanged
- 5 new/modified files, +391/-0 net

## What ships

| File | LOC | Role |
|---|---|---|
| `lib/anima/tier-user-cap.ts` | +192 NEW | IDB store + `ensureFreshTierUserCap(userId)` mint/refresh |
| `lib/anima/authenticated-fetch.ts` | +70 NEW | `animaCustodyFetch` — drop-in fetch with auto-attach Bearer |
| `lib/anima/index.ts` | +13 | Barrel re-exports |
| `providers/tier-user-cap-manager.tsx` | +114 NEW | Renderless lifecycle component — sign-in transitions + visibilitychange |
| `app/(chat)/layout.tsx` | +2 | Mount `<TierUserCapManager />` inside `<SessionProvider>` |
| `app/(console)/layout.tsx` | +2 | Same |

## Failure mode (deliberate best-effort)

If `POST /api/anima/custody/mint_session_cap` fails (network, lifegw down, route not server-side-wired yet), the manager swallows the error. Existing `/anima/custody/*` callers continue via the Neon Auth session cookie path — the edge proxy at `app/api/anima/custody/[...path]/route.ts` accepts either auth shape. Tier-User cap is opt-in additive auth.

Mint timeout: 5s.
Per-session retry-suppress: sessionStorage flag `anima-tier-user-cap-mint-attempted` keyed by userId. No retry storm.

## P14 dep-chain

**Upstream**:
- `app/api/anima/custody/[...path]/route.ts` (M9-C edge proxy at `e497fcb` — `mint_session_cap` already listed in route comment as M9-E scope; forward path exists)
- `providers/session-provider.tsx` (M9-C — wires `authClient.useSession()` from Neon Auth)
- IndexedDB + sessionStorage browser APIs (SSR-safe via `isBrowser` / `typeof window !== "undefined"` guards)

**Downstream**:
- Future browser-side `/anima/custody/*` callers consume `animaCustodyFetch`
- M9-E live USDC flow — Tier-User cap is the bearer for sign/rotate/revoke
- M11 browser-direct lifegw (when M8.2 resolves the WS bearer subprotocol)

## P11 validation gates (pre-commit)

- [x] `bun run test:types` — clean
- [x] `bunx biome lint` on all 5 files — 0 findings
- [x] `bun run test:unit` — 541 pass / 1 skipped / 0 regressions
- [ ] Manual Vercel preview smoke — sign in, devtools confirms mint call + IDB entry
- [ ] Tab-focus refresh smoke — fast-forward clock past expiry, focus tab, see re-mint
- [ ] Sign-out smoke — IDB cleared

## Linear

Closes BRO-1214 (M9-D). M9 sub-phases now at 7/7 — only BRO-1232 (M9-F-Remainder) left in M9 critical path.