### PR TITLE
feat(chat): per-frame deadline on lifegw stream — silent hang → structured error [BRO-1234]

### DIFF
--- a/apps/broomva/app/(chat)/api/chat/route.ts
+++ b/apps/broomva/app/(chat)/api/chat/route.ts
@@ -68,6 +68,10 @@ import {
   getLifegwBaseUrl,
   type SessionClientFactory,
 } from "@/lib/life-runtime/edge-adapter/dispatch-via-lifegw";
+import {
+  getFrameDeadlineMs,
+  wrapWithFrameDeadline,
+} from "@/lib/life-runtime/edge-adapter/wrap-with-frame-deadline";
 import { MAX_INPUT_TOKENS } from "@/lib/limits/tokens";
 import { createModuleLogger } from "@/lib/logger";
 import {
@@ -812,9 +816,21 @@ async function createLifegwBackedChatStream({
         ? wrapWithProgress(dispatch.events, onChunk)
         : dispatch.events;
 
+      // Per-frame deadline (BRO-1234). If lifegw goes silent the
+      // wrapper synthesises an `error` + `finish` canonical event
+      // pair so the user sees a structured failure within
+      // `frameDeadlineMs` instead of a silent 504 at Vercel's 290s
+      // function timeout. The translator turns the synthetic `error`
+      // into a UIMessageChunk error that chat-sync.tsx renders inline.
+      const frameDeadlineMs = getFrameDeadlineMs();
+      const eventsWithDeadline =
+        frameDeadlineMs !== null
+          ? wrapWithFrameDeadline(wrappedEvents, frameDeadlineMs, log)
+          : wrappedEvents;
+
       // Run the translator and merge its chunks into the writer.
       for await (const chunk of canonicalToVercelAiSdkSse<ChatMessage>(
-        wrappedEvents,
+        eventsWithDeadline,
         {
           fallbackTextId: messageId,
           state: consumeState,

--- a/apps/broomva/lib/life-runtime/edge-adapter/__tests__/wrap-with-frame-deadline.test.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/__tests__/wrap-with-frame-deadline.test.ts
@@ -1,0 +1,269 @@
+// Unit tests for `wrap-with-frame-deadline.ts`. Uses vitest fake
+// timers to drive the per-frame deadline deterministically.
+//
+// BRO-1234 first PR — see module header for full context.
+
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+import {
+  DEFAULT_FRAME_DEADLINE_MS,
+  type FrameDeadlineLogger,
+  getFrameDeadlineMs,
+  wrapWithFrameDeadline,
+} from "../wrap-with-frame-deadline";
+
+function makeFakeLogger() {
+  // Returned mocks satisfy the FrameDeadlineLogger shape; inference
+  // preserves the Mock types so `.toHaveBeenCalledWith(...)` works.
+  const log = {
+    info: vi.fn<(data: object, msg: string) => void>(),
+    warn: vi.fn<(data: object, msg: string) => void>(),
+  } satisfies FrameDeadlineLogger;
+  return log;
+}
+
+function env(ev: CanonicalAgentEvent["event"], seq = 1n): CanonicalAgentEvent {
+  return { seq, event: ev } as CanonicalAgentEvent;
+}
+
+/**
+ * Async iterable that yields the supplied frames and then completes
+ * naturally. No artificial delays — used to verify the wrapper is a
+ * pass-through when the source produces inside the deadline.
+ */
+async function* eager(
+  frames: CanonicalAgentEvent[],
+): AsyncIterable<CanonicalAgentEvent> {
+  for (const f of frames) yield f;
+}
+
+/**
+ * Async iterable that never yields anything. Each `next()` returns a
+ * pending promise that resolves only when `release()` is called on the
+ * returned handle. Used to simulate lifegw silence.
+ */
+function controllable(): {
+  iter: AsyncIterable<CanonicalAgentEvent>;
+  push: (ev: CanonicalAgentEvent | "end") => void;
+} {
+  const queue: Array<CanonicalAgentEvent | "end"> = [];
+  let resolveNext: ((v: void) => void) | null = null;
+  const wake = () => {
+    const r = resolveNext;
+    resolveNext = null;
+    r?.();
+  };
+  const iter: AsyncIterable<CanonicalAgentEvent> = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next(): Promise<IteratorResult<CanonicalAgentEvent>> {
+          while (queue.length === 0) {
+            await new Promise<void>((resolve) => {
+              resolveNext = resolve;
+            });
+          }
+          const head = queue.shift()!;
+          if (head === "end") return { value: undefined, done: true };
+          return { value: head, done: false };
+        },
+      };
+    },
+  };
+  return {
+    iter,
+    push: (ev) => {
+      queue.push(ev);
+      wake();
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("getFrameDeadlineMs", () => {
+  it("returns default when env is unset", () => {
+    vi.stubEnv("LIFEGW_FRAME_DEADLINE_MS", "");
+    expect(getFrameDeadlineMs()).toBe(DEFAULT_FRAME_DEADLINE_MS);
+  });
+
+  it("returns default when env is non-numeric", () => {
+    vi.stubEnv("LIFEGW_FRAME_DEADLINE_MS", "abc");
+    expect(getFrameDeadlineMs()).toBe(DEFAULT_FRAME_DEADLINE_MS);
+  });
+
+  it("returns null (opt-out) when env is zero", () => {
+    vi.stubEnv("LIFEGW_FRAME_DEADLINE_MS", "0");
+    expect(getFrameDeadlineMs()).toBeNull();
+  });
+
+  it("returns null (opt-out) when env is negative", () => {
+    vi.stubEnv("LIFEGW_FRAME_DEADLINE_MS", "-5");
+    expect(getFrameDeadlineMs()).toBeNull();
+  });
+
+  it("returns the parsed value when env is a positive integer", () => {
+    vi.stubEnv("LIFEGW_FRAME_DEADLINE_MS", "5000");
+    expect(getFrameDeadlineMs()).toBe(5000);
+  });
+});
+
+describe("wrapWithFrameDeadline — pass-through", () => {
+  it("yields all frames unchanged when source completes inside deadline", async () => {
+    const log = makeFakeLogger();
+    const frames: CanonicalAgentEvent[] = [
+      env({ kind: "token", delta: "hi", messageId: "m" } as never, 1n),
+      env({ kind: "token", delta: " there", messageId: "m" } as never, 2n),
+      env({ kind: "finish", reason: "stop" } as never, 3n),
+    ];
+
+    const out: CanonicalAgentEvent[] = [];
+    for await (const ev of wrapWithFrameDeadline(eager(frames), 30_000, log)) {
+      out.push(ev);
+    }
+
+    expect(out).toEqual(frames);
+    // First-frame log fires exactly once on the first yielded frame.
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "token" }),
+      "lifegw first frame received",
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns cleanly on an empty source without emitting anything", async () => {
+    const log = makeFakeLogger();
+    const out: CanonicalAgentEvent[] = [];
+    for await (const ev of wrapWithFrameDeadline(eager([]), 30_000, log)) {
+      out.push(ev);
+    }
+    expect(out).toEqual([]);
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("wrapWithFrameDeadline — deadline fires", () => {
+  it("synthesises lifed.stream.no-first-frame + finish when source is silent", async () => {
+    const log = makeFakeLogger();
+    const { iter } = controllable(); // never push, never end
+
+    const out: CanonicalAgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of wrapWithFrameDeadline(iter, 30_000, log)) {
+        out.push(ev);
+      }
+    })();
+
+    // Advance fake-timer clock past the deadline; the wrapper's
+    // setTimeout fires, Promise.race resolves "deadline", error+finish
+    // are yielded, the loop returns.
+    await vi.advanceTimersByTimeAsync(30_001);
+    await drain;
+
+    expect(out).toHaveLength(2);
+    expect(out[0].event).toMatchObject({
+      kind: "error",
+      code: "lifed.stream.no-first-frame",
+      message: expect.stringContaining("30000ms"),
+    });
+    expect(out[1].event).toMatchObject({ kind: "finish", reason: "error" });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ deadlineMs: 30_000, frameCount: 0 }),
+      "lifegw frame deadline exceeded before first frame",
+    );
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it("synthesises lifed.stream.frame-deadline after one frame then silence", async () => {
+    const log = makeFakeLogger();
+    const { iter, push } = controllable();
+
+    const out: CanonicalAgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of wrapWithFrameDeadline(iter, 30_000, log)) {
+        out.push(ev);
+      }
+    })();
+
+    // Push the first frame inside the deadline.
+    push(env({ kind: "token", delta: "hi", messageId: "m" } as never, 1n));
+    // Yield to the microtask queue so the wrapper's iter.next() resolves.
+    await vi.advanceTimersByTimeAsync(0);
+    // Source now goes silent — advance past the deadline.
+    await vi.advanceTimersByTimeAsync(30_001);
+    await drain;
+
+    expect(out).toHaveLength(3);
+    expect(out[0].event).toMatchObject({ kind: "token", delta: "hi" });
+    expect(out[1].event).toMatchObject({
+      kind: "error",
+      code: "lifed.stream.frame-deadline",
+      message: expect.stringContaining("after frame 1"),
+    });
+    expect(out[2].event).toMatchObject({ kind: "finish", reason: "error" });
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ deadlineMs: 30_000, frameCount: 1 }),
+      "lifegw frame deadline exceeded between frames",
+    );
+  });
+
+  it("does NOT fire deadline if source completes exactly at boundary", async () => {
+    const log = makeFakeLogger();
+    const { iter, push } = controllable();
+
+    const out: CanonicalAgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of wrapWithFrameDeadline(iter, 30_000, log)) {
+        out.push(ev);
+      }
+    })();
+
+    push(env({ kind: "token", delta: "hi", messageId: "m" } as never, 1n));
+    await vi.advanceTimersByTimeAsync(0);
+    push(env({ kind: "finish", reason: "stop" } as never, 2n));
+    await vi.advanceTimersByTimeAsync(0);
+    push("end");
+    await vi.advanceTimersByTimeAsync(0);
+    await drain;
+
+    expect(out).toHaveLength(2);
+    expect(out[1].event).toMatchObject({ kind: "finish", reason: "stop" });
+    // No synthesised error.
+    expect(out.some((e) => (e.event as { kind?: string }).kind === "error")).toBe(false);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("wrapWithFrameDeadline — synthesised frame seq numbers", () => {
+  it("uses high BigInt seqs so synthesised frames are distinguishable from real ones", async () => {
+    const log = makeFakeLogger();
+    const { iter } = controllable();
+    const out: CanonicalAgentEvent[] = [];
+    const drain = (async () => {
+      for await (const ev of wrapWithFrameDeadline(iter, 1_000, log)) {
+        out.push(ev);
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(1_001);
+    await drain;
+
+    expect(out).toHaveLength(2);
+    // Both synthesised frames have seqs >= 9e15, well past any
+    // realistic upstream sequence.
+    expect(out[0].seq).toBeGreaterThanOrEqual(BigInt("9000000000000000"));
+    expect(out[1].seq).toBeGreaterThan(out[0].seq);
+  });
+});

--- a/apps/broomva/lib/life-runtime/edge-adapter/wrap-with-frame-deadline.ts
+++ b/apps/broomva/lib/life-runtime/edge-adapter/wrap-with-frame-deadline.ts
@@ -1,0 +1,160 @@
+/**
+ * Wrap a `CanonicalAgentEvent` async iterable with a per-frame deadline.
+ *
+ * If `deadlineMs` elapses between frames (or before the first frame),
+ * yield a synthetic `{kind:"error", code, message}` envelope followed
+ * by a `{kind:"finish", reason:"error"}` envelope, then exit. The
+ * downstream `canonicalToVercelAiSdkSse` translator already turns
+ * `error` events into `UIMessageChunk` errors, so the route surfaces a
+ * visible error within `deadlineMs` instead of waiting on the Vercel
+ * function's 290-second AbortController timeout (which today manifests
+ * as a silent 504 to the client).
+ *
+ * The wrapper is observability + UX: it converts a silent gateway-side
+ * hang into a structured, visible failure mode that future iterations
+ * can grep on in Vercel + Railway logs. It does NOT fix the underlying
+ * hang — that lives in the lifed → arcan → Vercel-AI-Gateway path and
+ * needs its own instrumentation PR (see BRO-1234 §"Suggested second
+ * PR (broomva/life)").
+ *
+ * Spec: BRO-1234 first PR — handoff at
+ * `~/broomva/docs/handoffs/2026-05-22-bro-1208-streaming-hang-handoff.md`
+ * §"Suggested first PR".
+ */
+
+import "server-only";
+import type { CanonicalAgentEvent } from "@/lib/life-runtime/agent-session/types";
+
+/**
+ * Default per-frame deadline. 30s is the canonical figure from the
+ * BRO-1234 handoff — long enough to absorb a slow first inference from
+ * the gateway (cold-start, throttled, very long prompt), short enough
+ * that the user sees an error well inside Vercel's 290s function
+ * timeout.
+ */
+export const DEFAULT_FRAME_DEADLINE_MS = 30_000;
+
+/**
+ * Resolve the per-frame deadline from env or default.
+ *
+ * `LIFEGW_FRAME_DEADLINE_MS` env override:
+ *   - unset / empty → `DEFAULT_FRAME_DEADLINE_MS`
+ *   - non-numeric → `DEFAULT_FRAME_DEADLINE_MS` (fail safe)
+ *   - `<= 0` → `null` (opt-out; wrapper is a no-op)
+ *   - positive integer → that value in milliseconds
+ *
+ * The opt-out exists for benchmarking + load tests where artificial
+ * per-frame deadlines obscure real latency distributions. Production
+ * deployments should leave this unset.
+ */
+export function getFrameDeadlineMs(): number | null {
+  const raw = process.env.LIFEGW_FRAME_DEADLINE_MS;
+  if (raw === undefined || raw === "") return DEFAULT_FRAME_DEADLINE_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_FRAME_DEADLINE_MS;
+  if (parsed <= 0) return null;
+  return parsed;
+}
+
+/**
+ * Minimal logger surface this wrapper needs. Compatible with
+ * `createModuleLogger("...")` from `@/lib/logger` — pass that
+ * directly. Kept narrow so the wrapper is easy to test with a stub.
+ */
+export interface FrameDeadlineLogger {
+  info: (data: object, msg: string) => void;
+  warn: (data: object, msg: string) => void;
+}
+
+/**
+ * Synthesised-frame seq numbers start past 2^53 so they're trivially
+ * distinguishable from any real lifegw sequence in trace output. The
+ * translator keys text chunks by their `messageId`, not by `seq`, so
+ * this choice doesn't break id correlation downstream.
+ */
+const SYNTH_SEQ_BASE = BigInt("9000000000000000");
+
+/**
+ * Wrap the canonical event iterator with a per-frame deadline.
+ *
+ * Each call to `iter.next()` races against `setTimeout(deadlineMs)`.
+ * If the timer wins, the wrapper synthesises a terminal error+finish
+ * pair and returns. The original iterator is left for GC — we
+ * deliberately do NOT call `iter.return()` because the upstream WS
+ * may still be draining and a forced cancellation can race with the
+ * auth-close-code path in lifed-ws-client. The synthetic finish is
+ * enough for the downstream `createUIMessageStream` wrapper to exit
+ * cleanly, and the abandoned iterator is GC'd once the response
+ * Promise resolves.
+ */
+export async function* wrapWithFrameDeadline(
+  source: AsyncIterable<CanonicalAgentEvent>,
+  deadlineMs: number,
+  log: FrameDeadlineLogger,
+): AsyncIterable<CanonicalAgentEvent> {
+  const iter = source[Symbol.asyncIterator]();
+  const tStart = Date.now();
+  let frameCount = 0;
+
+  while (true) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const next = iter.next();
+    const deadline = new Promise<"deadline">((resolve) => {
+      timer = setTimeout(() => resolve("deadline"), deadlineMs);
+    });
+
+    let result: IteratorResult<CanonicalAgentEvent> | "deadline";
+    try {
+      result = await Promise.race([next, deadline]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+
+    if (result === "deadline") {
+      const elapsedMs = Date.now() - tStart;
+      log.warn(
+        {
+          deadlineMs,
+          frameCount,
+          elapsedMs,
+        },
+        frameCount === 0
+          ? "lifegw frame deadline exceeded before first frame"
+          : "lifegw frame deadline exceeded between frames",
+      );
+      yield {
+        seq: SYNTH_SEQ_BASE,
+        event: {
+          kind: "error",
+          code:
+            frameCount === 0
+              ? "lifed.stream.no-first-frame"
+              : "lifed.stream.frame-deadline",
+          message:
+            frameCount === 0
+              ? `No first frame from lifegw within ${deadlineMs}ms`
+              : `No frame from lifegw within ${deadlineMs}ms after frame ${frameCount}`,
+        },
+      } as CanonicalAgentEvent;
+      yield {
+        seq: SYNTH_SEQ_BASE + 1n,
+        event: { kind: "finish", reason: "error" },
+      } as CanonicalAgentEvent;
+      return;
+    }
+
+    if (result.done) return;
+
+    frameCount += 1;
+    if (frameCount === 1) {
+      log.info(
+        {
+          msToFirstFrame: Date.now() - tStart,
+          kind: result.value.event.kind,
+        },
+        "lifegw first frame received",
+      );
+    }
+    yield result.value;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `wrapWithFrameDeadline` — a per-frame deadline wrapper around the canonical agent-event iterator that `/api/chat` consumes from lifegw. When lifegw goes silent (no `agent_event` frame within `LIFEGW_FRAME_DEADLINE_MS`, default **30s**), the wrapper synthesises an `error` + `finish` canonical envelope pair. The existing translator turns the synthetic `error` into a `UIMessageChunk` error that `chat-sync.tsx` already renders inline.

Linear: **BRO-1234** — `lifed stream-consume hangs after register_anima_session — no agent_event frames reach /api/chat`

## Why

**Today**: anon dogfood through prod `/api/chat` returns **504 Vercel runtime + 0 SSE bytes** after lifegw silently stalls past `register_anima_session`. Reproduced 4× today (May 22, 2026) via Railway log capture + curl probe — `create_session` saga completes in <200ms, then nothing. The Vercel function exceeds its 290s AbortController and emits a 504 to the client. End-user-facing: chat UI submits, no response, no error.

Without instrumentation at the iterator boundary, the diagnostic loop is 60–120s per probe with no signal. With the deadline, the same silent hang surfaces as a structured `lifed.stream.no-first-frame` canonical error in <30s + a server-side `log.warn` line that future arcs can grep on.

This PR is **observability + UX correctness**, not a fix for the underlying lifed → arcan → Vercel-AI-Gateway hang. The lifed-side fix lands as a follow-up PR in `broomva/life` (see BRO-1234 §\"Suggested second PR (broomva/life)\").

## Files

| File | LOC | Role |
|---|---|---|
| `apps/broomva/lib/life-runtime/edge-adapter/wrap-with-frame-deadline.ts` | +138 NEW | The wrapper + env parser + logger interface |
| `apps/broomva/lib/life-runtime/edge-adapter/__tests__/wrap-with-frame-deadline.test.ts` | +220 NEW | 11 tests — pass-through, deadline-fires (first frame / between frames), env parsing (5 cases), synth-seq distinguishability |
| `apps/broomva/app/(chat)/api/chat/route.ts` | +13/-1 | Import + compose wrapper into the canonical-iterator chain after `wrapWithProgress` |

Net: **+371 / -1**.

## Env

`LIFEGW_FRAME_DEADLINE_MS` — override the 30s default.
- Unset / empty → **30000** (default)
- Non-numeric → **30000** (fail safe)
- `<= 0` → **null** (opt-out — wrapper becomes no-op, for benchmarking)
- Positive int → that value in ms

## P14 dep-chain

**Upstream:**
- `dispatchViaLifegw` → `LifedWsAgentSessionClient.stream()` → upstream WS to lifegw — **unchanged**
- `wrapWithProgress` (existing) — composed BEFORE the deadline wrapper, so cancel-checks still fire on real frames
- `canonicalToVercelAiSdkSse` (existing translator) — already handles synthetic `error` + `finish` envelopes via its `case \"error\"` branch (line 297-304), so the synthesised pair routes through the same downstream path as a real lifegw error

**Downstream:**
- `chat-sync.tsx` (existing client UI) — renders `UIMessageChunk` of type `error` as an inline error toast; **no client-side change needed**
- Vercel function 290s `AbortController` — still present as the outer guard, but should never fire for the silent-lifegw case once this PR is live
- Future BRO-1234 second PR (broomva/life) — adds `tracing::info!` at entry/exit of `VercelAiGatewayArcan::dispatch_message` so when the deadline fires the cause-side log is also present

## P11 validation

**Pre-merge (this PR):**
- [x] 11 new unit tests pass (vitest fake-timers, deterministic deadline firing)
- [x] All 66 pre-existing edge-adapter tests still pass
- [x] `bun run test:types` green (after fixing one `Mock` type inference issue in the test)
- [x] `bunx biome check` clean on all 3 changed files
- [x] `wrapWithFrameDeadline` composes cleanly with the existing `wrapWithProgress` chain — no API surface change to dispatchers or translators

**Post-merge dogfood (per lessons doc rule #1 + rule #8):**
- [ ] Vercel deploy SHA matches merge commit SHA (auto-deploy from `main`, verify via `gh api repos/broomva/broomva.tech/deployments`)
- [ ] Anon `/api/chat` probe returns response body containing `lifed.stream.no-first-frame` within ~30s, NOT 504 at 290s
- [ ] Vercel function logs show `lifegw frame deadline exceeded before first frame` warn line

## Companion / next PRs

1. **broomva/life** — add `tracing::info!` instrumentation to `VercelAiGatewayArcan::dispatch_message` (entry, before HTTP send, after response status, per SSE chunk). Currently 2 log calls in 785 LOC — the success path is silent. With the deadline error code from this PR + the lifed-side logs, one probe will collapse the 3-way root-cause hypothesis space (substrate-never-fires / response-parse-bug / gateway-throttled) to one.
2. **broomva/life** — once root cause known, ship the actual fix.

## Handoff

Continues the BRO-1208 + BRO-1228 autonomous arc per `~/broomva/docs/handoffs/2026-05-22-bro-1208-streaming-hang-handoff.md` §\"Suggested first PR\". Applies lesson #1 (dogfood mandated post-deploy), lesson #2 (verify deploy SHA before claiming done), lesson #7 (distinguishing-probe primitive — the wrapper's structured error code IS the diagnostic primitive for this hang category).

🤖 Generated with [Claude Code](https://claude.com/claude-code)