### PR TITLE
feat(control): wire RCS control loop on broomva.tech (full governance + loop)

### DIFF
--- a/.control/arcs.yaml
+++ b/.control/arcs.yaml
@@ -1,0 +1,98 @@
+# =============================================================================
+# bstack — Closure-Contract Arcs (the (X, U, h, Π, T) 5-tuple, generalized)
+# =============================================================================
+#
+# A closure-contract *arc* lifts the same 5-tuple already used at the 4 hard-
+# coded RCS layers (see assets/templates/rcs-parameters.toml.template) to the
+# N user-declared domain arcs the workspace actually runs every day. Each arc
+# names one feedback loop the workspace promises to close:
+#
+#     (plant_surfaces, sensor, actuator, termination, tau_a)
+#
+# read as:
+#
+#     "for these plant surfaces, observe via this sensor, act via this
+#      actuator, terminate when this condition holds, within tau_a seconds."
+#
+# The agent's reasoning is the universal Π (controller). When
+# actuator.kind == "agent_reasoning" the controller binding is implicit —
+# the agent loop closes the arc by reading the sensor, deciding, and acting.
+# Script / mcp_tool / http actuators bind specific mechanisms while keeping
+# the agent in the supervisory role.
+#
+# Read by:
+#   - scripts/compute-arc-status.sh   (per-arc verdict reader; mirrors
+#                                      compute-budget-status.sh shape)
+#   - scripts/doctor.sh §20            (arcs-declared health)
+#   - schemas/arcs.v1.json             (declarative shape; bstack doctor
+#                                      runs json-schema validation in §10)
+#
+# Editing rules:
+#   - Bump schema_version below when adding/removing fields.
+#   - Run `bash scripts/compute-arc-status.sh --human` after edits to verify
+#     each arc still resolves to a verdict.
+#   - tau_a is in seconds (per-arc switching cost denominator). Keep it
+#     proportional to the natural cadence of the loop: PR CI is ~1800s,
+#     bookkeeping promotion-quality is ~86400s, etc.
+#   - Workspace files override this template: copy to .control/arcs.yaml,
+#     edit, and compute-arc-status.sh will prefer the workspace file.
+
+schema_version: 1
+
+arcs:
+  # ---------------------------------------------------------------------------
+  # Arc 1 — code-pr-greenflow
+  # ---------------------------------------------------------------------------
+  # Closes the loop: "every PR I open ends up merged with all checks green."
+  # Plant: GitHub PR checks. Sensor: `gh pr checks --json`. Actuator: agent
+  # reasoning (which calls heal-recipes from .control/policy.yaml ci_heal:
+  # block). Termination: predicate over checks_green AND merged. Window:
+  # 30 minutes (PR CI ceiling — beyond this the human steps in).
+  - id: code-pr-greenflow
+    description: PR CI greenflow — open, watch, heal, merge.
+    plant_surfaces:
+      - gh://${repo}/pulls
+      - fs://.github/workflows/
+    sensor:
+      kind: json_path
+      source: gh pr checks --json conclusion,name --jq '[.[] | select(.conclusion != null)]'
+      expr: all(.conclusion == "SUCCESS")
+    actuator:
+      kind: agent_reasoning
+      tools:
+        - gh
+        - skills/p9/scripts/p9.py
+        - skills/bookkeeping/scripts/bookkeeping.py
+    termination:
+      kind: predicate
+      expr: checks_green AND merged
+    tau_a: 1800
+    shield_ref: gates.hard.G-PR-MERGE
+
+  # ---------------------------------------------------------------------------
+  # Arc 2 — bookkeeping-promotion-quality
+  # ---------------------------------------------------------------------------
+  # Closes the loop: "every Layer-2 raw extract that ends up an entity page
+  # in research/entities/ scored ≥7/9 on the Nous gate." Plant: research/
+  # notes/ + research/entities/. Sensor: a hypothetical eval script that
+  # exits 0 when the most recent promotion run scored ≥ threshold.
+  # Actuator: agent reasoning (the agent re-runs bookkeeping replay if the
+  # score dips). Termination: score_threshold. Window: 1 day (matches the
+  # bookkeeping cadence and the L3 governance budget).
+  - id: bookkeeping-promotion-quality
+    description: Bookkeeping promotion quality — every entity page meets the Nous gate.
+    plant_surfaces:
+      - fs://research/entities/
+      - fs://research/notes/
+    sensor:
+      kind: exit_code
+      source: skills/bookkeeping/scripts/eval-promotion-quality.sh
+    actuator:
+      kind: agent_reasoning
+      tools:
+        - skills/bookkeeping/scripts/bookkeeping.py
+    termination:
+      kind: score_threshold
+      expr: score >= 7
+    tau_a: 86400
+    shield_ref: gates.governed.G-PROMOTION-NOUS

--- a/.control/audit/.gitkeep
+++ b/.control/audit/.gitkeep
@@ -1,0 +1,2 @@
+# RCS audit logs are machine-local runtime telemetry — not committed.
+# This .gitkeep keeps the dir present so the loop has somewhere to write.

--- a/.control/policy.yaml
+++ b/.control/policy.yaml
@@ -1,0 +1,208 @@
+# Agentic Control Kernel — bstack workspace policy
+# Installed by `bstack bootstrap` when .control/policy.yaml is absent.
+# Customize for your workspace; bstack doctor will validate required blocks.
+
+version: "1.0"
+profile: governed  # baseline | governed | autonomous
+
+setpoints:
+  - id: S1
+    name: "gate_pass_rate"
+    target: 0.85
+    alert_below: 0.70
+    severity: blocking
+
+  - id: S2
+    name: "audit_pass_rate"
+    target: 1.0
+    alert_below: 0.95
+    severity: blocking
+
+gates:
+  governed:
+    - id: G1
+      rule: "No force-push to protected branches"
+      severity: blocking
+
+    - id: G2
+      rule: "No `git reset --hard` without backup branch"
+      severity: blocking
+
+    - id: G3
+      rule: "No `rm -rf` on protected paths"
+      severity: blocking
+
+    - id: G4
+      rule: "No staging .env, credentials, secrets"
+      severity: blocking
+
+    - id: G5
+      rule: "Verify tests pass before push"
+      severity: warn
+
+    - id: G6
+      rule: "Run smoke before commit"
+      severity: warn
+
+# === P9 CI Watcher + Productive-Wait Primitive ===
+# Required by skills/p9 (bstack P9 primitive — name matches number). Fails closed if absent.
+
+ci_watch:
+  enabled: true
+  max_concurrent_prs: 1
+  isolation_tier_map:
+    research: none
+    docs: none
+    code_independent: worktree
+    code_dependent: stacked_branch
+    governance: blocked
+
+ci_heal:
+  enabled: true
+  max_attempts: 5
+  stability_floor: 0.3
+  classified_failure_types: [lint, format, test_flaky, codegen_drift, import_missing]
+  escalation_channel:
+    linear_team: BRO
+    linear_label: ci-heal-escalation
+    notify_hook: skills/p9/scripts/p9-escalate-notify.sh
+
+# === P9 Auto-merge actuator ===
+# Closes the MERGE_READY → merged gap. Default-disabled; opt-in branch class.
+
+auto_merge:
+  enabled: false
+  require_no_requested_changes: true
+  require_branch_up_to_date: true
+  merge_method: squash
+  delete_branch: true
+  rules:
+    # Governance paths ALWAYS block (matcher pre-pass enforces this regardless
+    # of rule order; listing them first protects against future reshuffles)
+    - path_touched: CLAUDE.md
+      action: require_human
+    - path_touched: AGENTS.md
+      action: require_human
+    - path_touched: METALAYER.md
+      action: require_human
+    - path_touched: .control/policy.yaml
+      action: require_human
+    # === Indirect-prompt-injection defense — editor-config paths (2026-05-15) ===
+    # Spec: specs/2026-05-15-indirect-prompt-injection-defense.md §4 Tier 1.
+    # Rationale: every documented incident in 2024-2026 that turned indirect prompt
+    # injection into RCE pivoted through a silent write to one of these paths:
+    #   - .vscode/tasks.json + .vscode/settings.json  (CVE-2025-53773 Copilot YOLO-Mode;
+    #                                                   blockchain-C2 gist 2026-05-06)
+    #   - .cursor/mcp.json                            (CurXecute CVE-2025-54135; MCPoison
+    #                                                   CVE-2025-54136)
+    #   - .claude/settings.json                       (Claudy Day Claude.ai exfil)
+    #   - .gitignore (removal)                        (blockchain-C2 gist stage 5)
+    - path_touched: .vscode/*
+      action: require_human
+    - path_touched: .cursor/*
+      action: require_human
+    - path_touched: .idea/*
+      action: require_human
+    - path_touched: .continue/*
+      action: require_human
+    - path_touched: .aider/*
+      action: require_human
+    - path_touched: .claude/settings.json
+      action: require_human
+    - path_touched: .gitignore
+      action: require_human
+    # Auto-merge classes (uncomment to enable per branch pattern)
+    # - branch_pattern: "docs/*"
+    #   action: auto
+    # - branch_pattern: "research/*"
+    #   action: auto
+  default_action: notify
+
+# === Indirect-prompt-injection defense — PreToolUse write gate (2026-05-15) ===
+# Spec: specs/2026-05-15-indirect-prompt-injection-defense.md §4 Tier 1.
+# Consumed by ~/broomva/scripts/check-file-write-safety.py (workspace-side, ships
+# as PR #2 against broomva/workspace). This block defines the schema; the runtime
+# is a separate concern. Schema lands first so the runtime can pin to a stable
+# contract.
+#
+# Three sub-blocks:
+#   write_gate.content_patterns: regex refusal on dangerous content substrings.
+#   write_gate.magic_bytes_check: refuses files whose extension claims one type but
+#                                 whose magic bytes are script/executable.
+#   write_gate.gitignore_modification: refuses .gitignore edits that REMOVE patterns
+#                                       (additions are normal; removals enable silent
+#                                       commits of malicious files).
+#
+# Default state: enabled. Override per-workspace by setting
+#   write_gate.enabled: false  in .control/policy.yaml — but the bstack-doctor
+# command will warn loudly when this is off.
+
+write_gate:
+  enabled: true
+  content_patterns:
+    # Each pattern is a Python `re` regex matched against the file content being
+    # written or edited. severity=blocking refuses the write with exit code 8
+    # (analogue to the marketing-shape detector in broomva/social-intelligence
+    # PR #2 — same refuse-to-send substrate pattern). severity=warn logs but
+    # allows.
+    - pattern: "runOn:\\s*folderOpen"
+      severity: blocking
+      rationale: "VS Code autoexec primitive. Universal trigger across Jamf Threat Labs Dec 2025 North Korea campaign, Tenable/ThreatLocker advisories, mihai-r-lupu blockchain-C2 gist 2026-05-06. https://github.com/microsoft/vscode/issues/309406"
+    - pattern: "task\\.allowAutomaticTasks:\\s*true"
+      severity: blocking
+      rationale: "VS Code autoexec-bypass key — blockchain-C2 gist used this exact setting to skip the 'Do you want to allow automatic tasks?' confirmation"
+    - pattern: "chat\\.tools\\.autoApprove:\\s*true"
+      severity: blocking
+      rationale: "GitHub Copilot YOLO-Mode (CVE-2025-53773, CVSS 7.8) — prompt injection writes this exact key to .vscode/settings.json then shell-exec auto-approves"
+    - pattern: "--dangerously-skip-permissions"
+      severity: blocking
+      rationale: "Claude Code unsafe-flag bypass — used by Nx s1ngularity (CISA-advisory) postinstall scripts to weaponize AI CLIs as recon"
+    - pattern: "api\\.trongrid\\.io|fullnode\\.mainnet\\.aptoslabs|bsc-dataseed\\.binance|bsc-rpc\\.publicnode"
+      severity: blocking
+      rationale: "Public-blockchain RPCs in non-blockchain code = dead-drop C2 signal (blockchain-C2 gist used TRON for XOR key + Aptos + BSC fallback)"
+    - pattern: "child_process\\.spawn\\([^)]*detached:\\s*true"
+      severity: warn
+      rationale: "Detached spawn in JS/TS = persistence primitive (blockchain-C2 gist Layer 4 used this to keep payload alive after parent exits)"
+  magic_bytes_check:
+    enabled: true
+    # Maps a forbidden file-extension family to a list of magic-byte / start-of-content
+    # signatures that MUST NOT appear at the file head. Catches the font-file-with-JS
+    # disguise from the blockchain-C2 gist (stage 4).
+    #
+    # Signatures are matched against the first 256 bytes of content (utf-8 decoded for
+    # text-style sigs; raw bytes for binary sigs). String signatures match literally.
+    rules:
+      - extension_match: [".woff2", ".woff", ".ttf", ".otf", ".eot"]
+        forbid_signatures_starting_with:
+          - "function"
+          - "(function"
+          - "const "
+          - "var "
+          - "let "
+          - "import "
+          - "module.exports"
+          - "#!/"
+        rationale: "Font file with script content = blockchain-C2 stage 4 (fa-solid-400.woff2 disguise)"
+      - extension_match: [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico"]
+        forbid_signatures_starting_with:
+          - "function"
+          - "(function"
+          - "<?php"
+          - "<script"
+          - "#!/"
+        rationale: "Image file with script content = steganography/disguise class"
+      - extension_match: [".txt", ".md", ".json", ".yaml", ".yml", ".toml", ".ini"]
+        forbid_signatures_starting_with:
+          - "MZ"
+          - "\\x7fELF"
+          - "\\xca\\xfe\\xba\\xbe"
+          - "\\xfe\\xed\\xfa"
+        rationale: "Text/config file with PE/ELF/Mach-O magic = binary disguise class"
+  gitignore_modification:
+    enabled: true
+    removed_patterns_require_human: true
+    # Modifications that ADD patterns to .gitignore are normal and unaffected.
+    # Modifications that REMOVE patterns trigger require_human because removing
+    # e.g. `.vscode/*` from .gitignore enables silent commit of attacker-injected
+    # editor config (blockchain-C2 gist stage 5).
+    rationale: "blockchain-C2 gist (mihai-r-lupu 2026-05-06) explicitly removed .vscode/* from .gitignore to enable committing the malicious tasks.json"

--- a/.control/rcs-parameters.toml
+++ b/.control/rcs-parameters.toml
@@ -1,0 +1,155 @@
+# =============================================================================
+# RCS — Workspace Stability Parameters (bstack default)
+# =============================================================================
+#
+# Per-level parameters for the Recursive Controlled Systems (RCS) stability
+# budget. These values are read by bstack/scripts/compute-lambda.sh and by
+# bstack doctor §14 to verify the composite system is exponentially stable.
+#
+# Formula (papers/p0-foundations/main.tex, Theorem 1):
+#
+#     lambda_i = gamma_i
+#              - L_theta_i * rho_i        (adaptation cost)
+#              - L_d_i * eta_i            (design evolution cost)
+#              - beta_i * tau_bar_i       (delay cost)
+#              - ln(nu_i) / tau_a_i       (switching cost)
+#
+# A level is stable iff lambda_i > 0. The composite hierarchy is exponentially
+# stable iff every level is individually stable.
+#
+# Defaults below are calibrated from broomva's Life runtime (research/rcs/
+# data/parameters.toml). For a generic bstack repo without Life, customize:
+#   - L0 (plant): match your runtime's inner loop (sub-second tool execution)
+#   - L1 (autonomic): match your agent's hysteresis / mode-transition layer
+#   - L2 (meta-control): match your EGRI / promotion cadence (default: hours)
+#   - L3 (governance): KEEP CONSERVATIVE — tau_a = 86400s (1 day) is the
+#     stability budget's load-bearing assumption. Faster governance churn
+#     destabilizes the whole hierarchy.
+#
+# Editing rules:
+#   - Bump schema_version below when adding/removing fields.
+#   - bstack doctor --strict verifies the cached [derived.lambda] block
+#     matches recomputed values; CI will fail if they drift.
+#   - Run `bash scripts/compute-lambda.sh --human` after edits to see the
+#     per-level impact before committing.
+
+schema_version = 1
+
+# -----------------------------------------------------------------------------
+# L0 — Plant (agent inner loop)
+# -----------------------------------------------------------------------------
+# Sub-second timescale: tool execution, streaming output, immediate response.
+# Source: Arcan agent loop default (or your equivalent).
+
+[[levels]]
+id             = "L0"
+name           = "plant"
+system         = "Agent loop / tool execution"
+gamma          = 2.0
+L_theta        = 0.3
+rho            = 0.5
+L_d            = 0.1
+eta            = 0.2
+beta           = 1.0
+tau_bar        = 0.01
+nu             = 1.2
+tau_a          = 0.5
+display_digits = 3
+
+# -----------------------------------------------------------------------------
+# L1 — Autonomic (per-session reasoning + hysteresis)
+# -----------------------------------------------------------------------------
+# Seconds timescale: hysteresis gates, mode transitions, validation backpressure.
+
+[[levels]]
+id             = "L1"
+name           = "autonomic"
+system         = "Agent reasoning / per-session loop"
+gamma          = 0.5
+L_theta        = 0.2
+rho            = 0.1
+L_d            = 0.1
+eta            = 0.05
+beta           = 0.5
+tau_bar        = 0.1
+nu             = 1.5
+tau_a          = 30.0
+display_digits = 3
+
+# -----------------------------------------------------------------------------
+# L2 — EGRI / meta-control
+# -----------------------------------------------------------------------------
+# Hours timescale: cross-session synthesis, candidate promotion, evaluator runs.
+
+[[levels]]
+id             = "L2"
+name           = "EGRI"
+system         = "EGRI / Crystallize (P16) / Bookkeeping (P6)"
+gamma          = 0.1
+L_theta        = 0.05
+rho            = 0.01
+L_d            = 0.02
+eta            = 0.01
+beta           = 0.0005
+tau_bar        = 60.0
+nu             = 1.1
+tau_a          = 3600.0
+display_digits = 3
+
+# -----------------------------------------------------------------------------
+# L3 — Governance
+# -----------------------------------------------------------------------------
+# Days timescale: CLAUDE.md / AGENTS.md / .control/policy.yaml mutations.
+#
+# CRITICAL: tau_a = 86400s (1 day) is the load-bearing assumption. Faster
+# governance churn destabilizes the entire RCS hierarchy. The bstack pre-commit
+# hook (`githook-pre-commit-l3-rate.sh`) enforces this rate by counting L3-class
+# commits in the last tau_a window.
+
+[[levels]]
+id             = "L3"
+name           = "governance"
+system         = "CLAUDE.md + AGENTS.md + .control/policy.yaml"
+gamma          = 0.01
+L_theta        = 0.001
+rho            = 0.001
+L_d            = 0.001
+eta            = 0.0005
+beta           = 0.000001
+tau_bar        = 3600.0
+nu             = 1.05
+tau_a          = 86400.0
+display_digits = 4
+
+# -----------------------------------------------------------------------------
+# Derived values — cached for human readers, verified by compute-lambda.sh
+# -----------------------------------------------------------------------------
+# scripts/compute-lambda.sh --strict recomputes these and fails if drift > 1e-4.
+
+[derived.lambda]
+L0 = 1.455357
+L1 = 0.411484
+L2 = 0.069274
+L3 = 0.006398
+
+[derived.omega]
+value = 0.006398
+level = "L3"
+
+# -----------------------------------------------------------------------------
+# Governance path patterns (read by l3-rate-gate.sh)
+# -----------------------------------------------------------------------------
+# Files that match these git-pathspec patterns count as L3 mutations.
+# Used by:
+#   - .githooks/pre-commit (pre-commit gate G1)
+#   - .github/workflows/l3-stability.yml (CI gate G2)
+#   - .claude/settings.json PreToolUse hook (Claude Code gate G0)
+
+[gates.l3_paths]
+patterns = [
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".control/policy.yaml",
+    ".control/rcs-parameters.toml",
+    "METALAYER.md",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -89,9 +89,9 @@ node_modules/
 /.roo/skills
 /.trae/rules/project_rules.md
 /.trae/rules/project_rules.md.bak
-/AGENTS.md
+# AGENTS.md + CLAUDE.md are committed (agent-native governance, no secrets).
+# Only the .bak scratch copies stay ignored.
 /AGENTS.md.bak
-/CLAUDE.md
 /CLAUDE.md.bak
 /CRUSH.md
 /CRUSH.md.bak
@@ -151,3 +151,6 @@ Cargo.lock
 packages/lago-client/
 .worktrees
 .superpowers
+
+# RCS control-loop audit logs (machine-local runtime telemetry)
+.control/audit/*.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# broomva.tech — Agent Guidelines
+
+## Learned User Preferences
+
+- When reporting a fix, provide evidence (reproduce in browser, check network/API) before claiming success
+- Use desaturated/muted blues and Apple-like liquid glass aesthetics — reject saturated "electric" accents as too loud
+- Follow `DESIGN.md` token semantics strictly: web3-green is for success/web3 meaning only, not generic hovers; accent surfaces should read as subtle glass lift
+- Vary article layouts with editorial rhythm — mix hero-width, side-by-side, and centered blocks; avoid uniformly full-width or uniformly shrunken figures
+- Keep navigation split: header for site/content routes, bottom dock for product routes; `/console` is a product route and must show dock Home
+- User supplies DOM paths + component names to anchor feedback — fix against those selectors and React components
+- Landing "stack" cards must link to correct distinct pages with real project names, never generic placeholders or duplicate targets
+- Skills install commands (`npx skills add ...`) must use real GitHub slugs and copy to clipboard on click with `cursor-pointer` affordance
+- Hero canvas/background must read edge-to-edge behind the fixed header with no visible "cut" band
+- OG/Twitter images must use absolute URLs and cover listing routes (`/`, `/writing`, etc.), not only slug pages
+- Prefer SSR-first resolution over client-side flash — resolve session/user data server-side to avoid layout shift; pass minimal props (e.g. `userName` string) across RSC boundaries
+- When installing shadcn blocks (e.g. `sidebar-07`), match the reference source exactly — do not strip components, merge structures, or improvise the layout shell
+
+## Learned Workspace Facts
+
+- Primary app surface is `apps/chat` (Next.js App Router, Bun, Turborepo, Tailwind, Biome)
+- Animation uses `motion/react` (Motion v12+), never import `framer-motion` as the package name
+- Arcan Glass variables live in `globals.css` (`--ag-ai-blue`, `--ag-web3-green`); changing AI blue affects site-wide link color via `a { color: var(--ag-ai-blue) }`
+- Three route-group layouts: `(site)` for marketing/writing, `(chat)` for the AI chat, `(console)` for the Agent OS dashboard — each has its own sidebar and layout shell
+- `(chat)` uses `AppSidebar` (chat history, new-chat button, search); `(console)` uses `ConsoleSidebar` (shadcn sidebar-07 pattern); never share a single sidebar component across both
+- Writing content lives in `apps/chat/content/writing/`; remark pipeline uses `remark-html` with `sanitize: false` and `remark-gfm` for tables
+- Writing thumbnails driven by optional `image` in post frontmatter via `ContentFrontmatter`/`ContentSummary`; media assets at `public/images/writing/{slug}/`
+- Global audio uses a single `<audio>` element in root `app/layout.tsx` via `AudioPlaybackProvider`; persistence via `audio-playback` cookie + `/api/audio-playback` REST endpoint for authenticated sync
+- tRPC hooks only exist in the chat subtree — site routes use REST/fetch for the same server capabilities
+- React StrictMode double-runs effects in dev; fire-on-mount patterns (auto-submit, ChatSync cleanup) must account for cleanup order
+- Multiple markdown renderers exist: Streamdown for chat, remark pipeline for site content — different feature sets for GFM, highlighting, sanitization
+- Bottom dock (`TopNav`) must be placed **inside** `SidebarProvider` in layouts that use it, not outside — placing it outside breaks the sidebar flex layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# broomva.tech — bstack-governed workspace
+
+## Identity
+
+This workspace is governed by **bstack** — twenty irreducible primitives (P1–P20) that turn an agent-driven workspace into a self-operating system. The full primitive contract lives in [AGENTS.md](AGENTS.md). Run `bstack doctor` to verify compliance.
+
+## Bstack Core Automation Primitives
+
+Twenty irreducible building blocks that make this workspace self-operating. All are always active. Full specification in `AGENTS.md`.
+
+Each primitive carries a **short name** for agent prose. When referencing a primitive in responses, PR bodies, commit messages, or comments, use the `Name (Pn)` form — *"applying Snapshot (P15)"*, *"via Dep-Chain (P14)"*, *"running Bookkeeping (P6)"* — not bare `Pn`. The number is the canonical identifier; the short name is the human-readable handle.
+
+**Short-name index**: Bridge (P1) · Gate (P2) · Tickets (P3) · Pipeline (P4) · Fanout (P5) · Bookkeeping (P6) · Freshness (P7) · Janitor (P8) · Wait (P9) · Hygiene (P10) · Empirical (P11) · Persist (P12) · Dream (P13) · Dep-Chain (P14) · Snapshot (P15) · Crystallize (P16) · Lens (P17) · Audience (P18) · Orchestrate (P19) · Cross-Review (P20).
+
+| # | Primitive | Mechanism | Invariant |
+|---|-----------|-----------|-----------|
+| P1 | **Bridge** — Conversation Bridge | Stop hook → JSONL → Obsidian docs → vault | Bridge stamp < 24h stale |
+| P2 | **Gate** — Control Gate | PreToolUse hook → `.control/policy.yaml` | G1–G4 blocking, never bypassed |
+| P3 | **Tickets** — Linear Tickets | Every work unit tracked Backlog → Done | No significant work without a ticket |
+| P4 | **Pipeline** — PR Pipeline | Branch → PR → CI → merge → deploy | Never merge with failing checks |
+| P5 | **Fanout** — Parallel Agents | Concurrent isolated agents via worktrees | No shared mutable file writes |
+| P6 | **Bookkeeping** — Knowledge Bookkeeping | `bookkeeping run` → score → promote → entity pages → synthesize | `research/entities/` never contains unscored items |
+| P7 | **Freshness** — Skill Freshness Check | SessionStart hook → reports stale-skill nudge if last update check ≥ 7d ago | Never blocks; closes silent-rot bug for `npx skills add` snapshots |
+| P8 | **Janitor** — Branch + Worktree Janitor | `make janitor` → detects squash-merged branches + dead worktrees, removes safely | Default `--dry-run`; never touches protected branches |
+| P9 | **Wait** — Productive Wait (`broomva/p9` skill) | wait-queue drains while a blocking operation runs (PR CI is the reference impl: `gh pr checks --watch` via `run_in_background` → classifier + evaluator self-heal). For non-PR waits (push-triggered deploys, builds), do a single direct check after kicking off next-priority work. | Never `sleep` on a blocking wait; merge defers to control metalayer |
+| P10 | **Hygiene** — Worktree Hygiene Discipline | Reflexive rule: decide worktree-or-not before first file; keep `git status` clean; auto-run P8 janitor after every merge | A clean tree is the only reliable reset point |
+| P11 | **Empirical** — Empirical Feedback Loop | Reflexive rule: validate by *interacting* — log-tails, browser E2E, screenshots, deploy verification, multi-level test composition | Reasoning isn't validation; interaction is |
+| P12 | **Persist** — Persistent Loop Discipline (`broomva/persist` skill) | Reflexive rule: cross-context restart loop — state in filesystem (PROMPT.md + git tree), each iteration spawns a fresh agent context | At long-horizon work (>1h), in-context loops decay; restart fresh, backpressure from compilers/tests |
+| P13 | **Dream** — Dream Cycle Discipline | Reflexive rule: any consolidation that crosses a cadence-tier boundary MUST follow the 5-phase shape (gather → replay → prune → consolidate → index) | Replay against frozen substrate is the runtime form of stop-gradient; without it, dense lower-tier signal corrupts sparse upper-tier rules |
+| P14 | **Dep-Chain** — Dependency-Chain Reasoning Discipline | Reflexive rule: before any substantive write, enumerate upstream (files, functions, types, contracts, deployed state this depends on) and downstream (consumers, tests, CI gates, docs, in-flight PRs depending on this). Concrete file paths + function names in the response or PR body — not in the agent's head. | "Think deeply through chain of dependencies" without a concrete enumeration step is ritual. P14 makes it machine-checkable. |
+| P15 | **Snapshot** — State-Snapshot Before Action | Reflexive rule: before any plan, the agent surfaces `git status` + branch + ahead/behind, in-flight PRs (`gh pr list`), Linear ticket state, bookkeeping/bridge freshness, last deploy state. The snapshot is *part of* the planning response — not deferred. | Plans built on stale state fail silently. P15 makes state-checking a cheap reflex, not a request the user has to make. |
+| P16 | **Crystallize** — Crystallization Discipline (the Bstack Engine) | Meta-primitive — the loop that produces every other primitive. Pattern recurs ≥3 times across sessions → propose promotion to skill / SKILL.md / AGENTS.md section / `.control/policy.yaml` gate, gated by the four conditions: ≥3 instances, concrete mechanism, stated invariant, stated failure mode. | The crystallization loop must run inside the workspace, not in the user's head. P1–P15 are *outputs* of this loop. |
+| P17 | **Lens** — Lens-Routed Request Articulation (`broomva/role-x` skill) | Reflexive rule: every substantive user input passes through `role/x` intake — select lens(es) from `roles/<name>.md` registry by scoring signals, load substantive context, decide mode (`augment` / `rewrite` / `decompose`); P5 fan-out becomes typed graph. | No `act as X` persona rewrites — lenses load substantive context only. Lens selection is logged. Mode decision is surfaced unless `augment`. |
+| P18 | **Audience** — Format-Follows-Audience Discipline | Reflexive rule: format follows audience. Agent-readable (LLM, system-prompt loaded, in-repo reference) → **markdown**. Human-readable (decisions, review, exploration) → **HTML**. Both (README, CHANGELOG, GitHub-browseable) → markdown (GitHub renders). ASCII pseudo-diagrams + unicode-color-approximation + >100-line markdown specs without HTML companion are explicit anti-patterns. Specs/plans/ADRs land in `docs/specs/`, `docs/plans/`, `docs/adrs/` as `.html`. | Format follows audience, not habit. Markdown's expressiveness ceiling means humans bounce off agent-produced specs at ~100 lines; HTML's information density carries the load. The 2-4× HTML generation cost is paid only on artifacts a human will actually read. |
+| P19 | **Orchestrate** — Orchestration-Mechanism Selection Discipline | At pre-flight of substantive autonomous work, apply the **2×2×2 mechanism cube** (session-scope × trigger-source × agent-count). **N=1 plane:** `/goal <condition>` (internal+in-session), Wait (P9) `p9 watch --background` (external+in-session), `/loop <interval>` (internal+across-session), Persist (P12) `persist iterate PROMPT.md` (external+across-session). **N>1 plane:** Fanout (P5) multi-`Agent` (external+in-session), **`bstack wave dispatch <plan...>`** (external+across-session — worktree per plan, JSONL state). Compose dynamically. | No autonomous-continuation work without explicit mechanism choice + cube-cell citation. "Continue please" / waiting for user prompts mid-arc is ritual and forbidden. |
+| P20 | **Cross-Review** — Cross-Model Adversarial Review Gate (`broomva/cross-review` skill) | Before substantive PRs merge, fire cross-model adversarial gate. Three strata: A (true cross-vendor via `codex exec`), B (fresh-context subagent under devil's-advocate brief), C (composed adversarial-review skills — `superpowers:constructive-dissent`, `devils-advocate`, `pr-review-toolkit:*`, `critique`, `premortem`). Anti-slop score ≥7/10; max 3 fix rounds; verdict logged in PR comments + Linear ticket (if workspace uses Linear). Fires *before* P4 auto-merge. | Substantive PRs (>200 LOC OR public API OR multi-file OR governance-class) cannot merge without cross-model verdict ≥7/10. Self-review by the writing model as sole verdict is forbidden. |
+
+> **Naming note.** Skill repo names are stable and don't always match primitive numbers. P6's skill repo is `broomva/bookkeeping` (named for the function). P9's skill repo is `broomva/p9` — name matches primitive number. Renaming any skill repo would break every `npx skills add` install, so when a skill repo carries a number, the primitive numbering commits to keeping it stable.
+
+## Plugin Skill Precedence
+
+Bstack primitives (P1–P19) and bstack-native skills (`/autonomous`, `/shape`, `/persist`, `/ship`, `/bookkeeping`, `/p9`, etc.) **supersede** plugin skills (`superpowers:*`, `pr-review-toolkit:*`, `codex:*`) wherever they conflict. Plugin skills carry no weight when they collide with workspace governance — the `superpowers:using-superpowers` skill itself encodes this priority: *"User's explicit instructions … highest priority. … If CLAUDE.md says X and a skill says Y, follow the user's instructions."*
+
+The most common collision: plugin skills that mandate user interaction before action (notably `superpowers:brainstorming`'s discovery interview, and the meta-rule that prompts the agent to invoke a skill "even if 1% might apply"). The bstack answer is **context-first, user-extract last**:
+
+1. Before any "interview the user" plugin skill fires, perform **Dep-Chain (P14)** + **Snapshot (P15)** over:
+   - Workspace memory files (auto-memory directory)
+   - `research/entities/{concept,pattern,tool,person,project}/` — knowledge graph (grep by topic before asking)
+   - `docs/` (per-project) — architecture, specs, plans, conversations
+   - Task-mentioned files (CV, spec, ticket body, PR diff)
+2. Synthesize what's known from those sources.
+3. **Ask the user only for irreducible residuals** — facts that genuinely cannot be derived from disk.
+4. If steps 1–2 fully determine the task, the plugin interview is skipped; proceed to execution.
+
+This is a precedence rule, not a new primitive — P14 + P15 already exist; this clarifies that plugin-skill rituals do not override them. The failure mode it shuts down is the "form-fill ritual" — agent asks N+ clarifying questions about facts already curated in the workspace's memory files and knowledge graph.
+
+## Governance Stack
+
+```
+CLAUDE.md           ← Invariants (you're reading this)
+AGENTS.md           ← Operational rules + primitive contract
+.control/policy.yaml ← Setpoints, gates, profiles (machine-readable)
+```
+
+## Hooks (Claude Code Integration)
+
+This workspace registers Claude Code hooks in `.claude/settings.json`:
+
+| Event | Hook | Purpose |
+|-------|------|---------|
+| `Stop` | `conversation-bridge-hook.sh` | Bridge (P1) — capture session to knowledge graph |
+| `Notification` | `conversation-bridge-hook.sh` | Bridge (P1) — backup trigger for bridge |
+| `PreToolUse` | `control-gate-hook.sh` | Gate (P2) — enforce safety shields |
+| `SessionStart` | `skill-freshness-hook.sh` | Freshness (P7) — nudge user when skills are stale |
+
+## Testing & Verification
+
+```bash
+bstack doctor             # Verify primitive contract compliance
+bstack repair             # Fix specific gaps
+bstack status --aggregate # Federation rollup across registered workspaces (≥ 0.18.0)
+make control-audit        # Full metalayer compliance audit
+make janitor              # Janitor (P8) dry-run
+```
+
+> **Federation (Phase 8, v0.18.0).** `bstack workspace` maintains an opt-in
+> host-level registry at `~/.broomva/global/registry.yaml`. It is a substrate
+> surface, not a new primitive — composes Snapshot (P15) + multi-layer
+> composite-ω (v0.16.0 §19). Doctor §20 surfaces registry health.
+
+## Conventions
+
+- **Git**: feature branches, squash merge via PR. Never force push main.
+- **Each project** in this workspace can have its own CLAUDE.md with project-specific context.
+
+## Self-Documenting Standards
+
+When modifying skills, architecture docs, or governance files:
+
+1. **Threshold consistency**: A scoring cutoff, layer count, or primitive count changed in one file must be updated in ALL files that reference it. `SKILL.md` is the authoritative source; other files defer to it.
+2. **Cross-reference integrity**: Adding a new entity type, status value, or pipeline stage requires updating both the schema/rubric AND the template files that use them.
+3. **Primitive count**: Adding a primitive (P-N+1) requires bumping the count in this file's "Bstack Core Automation Primitives" header, adding the table row here, adding the section in `AGENTS.md`, and updating the composition-loop diagram. Run `bstack doctor` after changes to verify lockstep.
+4. **Verification**: After modifying this file or any skill, run `bstack doctor` to confirm consistency.
+
+These rules are enforced by agent reasoning + `bstack doctor`, not hooks. The agent reads them and applies them; the doctor surfaces gaps.

--- a/METALAYER.md
+++ b/METALAYER.md
@@ -1,0 +1,128 @@
+# broomva.tech — Control Metalayer
+
+Behavioral governance manifest for the broomva.tech workspace. This file is scaffolded by `bstack bootstrap` and is the authoritative declaration of the workspace's control plant, controller, safety shields, and feedback loop.
+
+## Plant
+
+The **plant** is this workspace — the composition of repos / apps / services that bstack governs. The plant's measurable signals are declared as setpoints S1-S15 in `.control/policy.yaml` and measured by `scripts/metrics/measure-S<n>.sh` shipped by bstack (≥ v0.4.0).
+
+| Signal | Source | Type | Primitive |
+|---|---|---|---|
+| Git status across repos | `make status` (workspace-defined) | measured | — |
+| CI/CD check results | GitHub Actions + provider-specific | measured | P4 (Pipeline) |
+| Conversation bridge health | `~/.cache/broomva-bridge-stamp` mtime | measured | P1 (Bridge) |
+| Skills installed | union of `~/.agents/skills/` + `~/.claude/skills/` | measured | — (S10) |
+| Governance files present | `CLAUDE.md` + `AGENTS.md` + `METALAYER.md` + `.control/policy.yaml` + `schemas/` | measured | — (S11) |
+| Hooks wired | `.claude/settings.json` (Stop + PreToolUse + UserPromptSubmit) + `.git/hooks/pre-commit` | measured | P1 + P2 + P17 (S12) |
+| Control gate enforcement | `.control/policy.yaml` active gates G1-G11 | measured | P2 (Gate) |
+| Workspace-specific signals | (extend this table per workspace) | — | — |
+
+## Controller
+
+Agents operating in this workspace follow the policy in `.control/policy.yaml` (default `profile: governed`).
+
+**Decision flow per session:**
+1. Read `CLAUDE.md` + `AGENTS.md` for workspace invariants
+2. Read `.control/policy.yaml` for active gates + setpoints
+3. Check `docs/conversations/` for prior session context on branch/topic
+4. Apply reflexive primitives (P10 Hygiene, P11 Empirical, P14 Dep-Chain, P15 Snapshot, P18 Audience, P19 Orchestrate) before substantive work
+5. Execute within harness gates (G1-G4 hard gates enforced by `control-gate-hook.sh`)
+6. Create PRs as checkpoints — never merge with failing CI (P4 Pipeline)
+
+## Safety Shields
+
+Hard gates (G1-G4+) enforced by `control-gate-hook.sh` on every Bash/Write/Edit tool call. The full list lives in `.control/policy.yaml` `gates.hard` — at minimum:
+
+| Gate | Rule | Severity |
+|---|---|---|
+| G1 | No force-push to protected branches | blocking |
+| G2 | No `git reset --hard` without backup branch | blocking |
+| G3 | No `rm -rf` on home / root / protected paths | blocking |
+| G4 | No staging `.env`, credentials, secrets | blocking |
+
+Soft gates (G5-G10+) are advisory — agent guidance only. Extend in `.control/policy.yaml` `gates.soft` as workspace needs emerge.
+
+## Estimator
+
+Agent confidence is derived from:
+- **Code context**: files read, git history checked
+- **Conversation history**: prior sessions on same branch/topic (via P1 Bridge captures)
+- **Knowledge graph**: entity pages in `research/entities/` (via P6 Bookkeeping)
+- **CI signals**: test pass rate, build status (via P4 Pipeline + P9 Wait)
+- **Setpoint state**: current measurements via `bstack status` (≥ v0.5.0)
+
+## Feedback Loop
+
+```
+Session start
+  → SessionStart hooks fire (autoupdate, freshness, role-x coverage)
+  → Agent loads CLAUDE.md + AGENTS.md + policy.yaml
+  → Check docs/conversations/ for prior context
+
+Task execution
+  → Apply reflexive primitives (P10/P11/P14/P15/P18/P19)
+  → PreToolUse hook gates every Bash/Write/Edit against policy.yaml
+  → P9 watcher monitors CI in background after push
+
+Checkpoint
+  → PR opens (P3 Tickets + P4 Pipeline)
+  → CI runs → P20 Cross-Review if substantive
+  → Auto-merge when green per policy.yaml.auto_merge
+
+Post-merge
+  → release.yml auto-tag + GH release (if VERSION changed)
+  → P8 janitor cleans worktree + branch
+  → Stop hook captures session to docs/conversations/ (P1 Bridge)
+
+Observation update
+  → P6 Bookkeeping scores raw extracts → promotes to research/entities/
+  → Patterns recurring ≥3 times → P16 Crystallize candidate
+  → Eventually: new primitive promoted to substrate (rule-of-three)
+```
+
+## RCS Hierarchy (reference)
+
+The substrate operates under the Recursive Controlled Systems (RCS) hierarchy with measured stability margins:
+
+| Level | System | Controller Π | Time scale |
+|---|---|---|---|
+| L0 | External plant (codebase, deploy targets) | per-tool gate enforcement | seconds |
+| L1 | Agent internal (per-turn state) | reflexive primitives (P10-P20) | per-turn |
+| L2 | Meta-control (CI/CD, EGRI) | release pipeline + PR validation | minutes-days |
+| L3 | Governance (this metalayer) | CLAUDE.md + AGENTS.md + policy.yaml | days-weeks |
+
+**L3 has the narrowest stability margin** (λ₃ ≈ 0.006 measured in the reference Broomva workspace). Governance changes must be rare and deliberate — rule-of-three promotion gate.
+
+For the formal framework + canonical parameters, see the [RCS paper repo](https://github.com/broomva/bstack/tree/main/specs/) and `research/rcs/data/parameters.toml` if your workspace ships the RCS substrate.
+
+## Harness Commands
+
+```bash
+bstack doctor               # Validate primitive contract + governance file presence
+bstack metrics collect      # Compute every setpoint (≥ 0.4.0)
+bstack status               # Render substrate health summary (≥ 0.5.0)
+bstack repair               # Idempotent fix for gaps (governance files, hooks, policy blocks)
+bstack upgrade              # Pull latest bstack release into this install
+make janitor                # P8 — branch + worktree cleanup (if workspace defines)
+```
+
+## Schemas
+
+The substrate ships JSON Schemas for declarative surfaces in `schemas/`:
+
+- `policy.v1.json` — full `.control/policy.yaml` shape
+- `setpoint.v1.json` — single setpoint
+- `gate.v1.json` — single gate
+- `primitives.v1.json` — primitive registry shape
+
+Schemas v1 are stable from bstack v1.0.0 onwards (currently pre-1.0, additive changes only). Breaking changes ship a v2 schema + migration via `scripts/migrate.sh`.
+
+## Customization
+
+Workspaces extend this template by:
+1. Adding workspace-specific signals to the Plant table
+2. Defining additional gates in `.control/policy.yaml` `gates.hard` / `gates.soft`
+3. Adding workspace-specific harness commands to the Harness Commands section
+4. Documenting workspace-specific RCS instantiation in the RCS section (if applicable)
+
+The bstack-shipped sections (Controller, Safety Shields, Estimator, Feedback Loop, Schemas) are stable and should not be modified directly — they're the substrate contract.


### PR DESCRIPTION
## What

Instantiates the bstack RCS control loop (v0.22.0) on broomva.tech — full governance docs + closure arcs + RCS params, with the runtime loop wired locally and verified **`wired + running + closing`** (`bstack doctor` §23).

## Public-repo safety (the reason this was reviewed)

broomva.tech is the **public** website repo. It previously gitignored `/AGENTS.md` + `/CLAUDE.md` — but on inspection that was **default habit, not policy**:
- Scanned both files: **no secrets / credentials / private data**. `CLAUDE.md` is the generic bstack governance template; `AGENTS.md` is design-taste + app-architecture notes already visible in the public source.
- The sibling **stimulus** repo already commits both.
- Un-ignored the two real files; `.bak` scratch copies stay ignored.

## Committable (team-wide, no secrets)
`CLAUDE.md` · `AGENTS.md` · `METALAYER.md` · `.control/policy.yaml` · `.control/arcs.yaml` · `.control/rcs-parameters.toml` · `.control/audit/.gitkeep` (+ `.gitignore` ignores `.control/audit/*.jsonl`)

## Machine-local (stays gitignored, never committed)
`.claude/settings.json` — the L0/L1 audit hooks carry absolute bstack paths, so the loop **runs locally** through this gitignored file. `.control/audit/*.jsonl` runtime logs.

## Not touched
The tracked `.githooks/pre-commit` (broomva.tech's multimedia-asset validator). The full bootstrap *clobbers* it — that bstack **safety gap** + **gitignore-awareness** are tracked as a separate bstack fix (filed alongside this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)