### PR TITLE
feat(site): register broomva.tech as Base app via base:app_id meta tag [BRO-1297]

### DIFF
--- a/apps/broomva/app/layout.tsx
+++ b/apps/broomva/app/layout.tsx
@@ -16,6 +16,11 @@ import { config } from "@/lib/config";
 
 export const metadata: Metadata = {
   metadataBase: new URL(config.appUrl),
+  // Base app verification — registers broomva.tech in Base Dashboard (base.dev).
+  // Emits <meta name="base:app_id" content="..."/>; public identifier. BRO-1297.
+  other: {
+    "base:app_id": "6a1deda4d510a5a848efc662",
+  },
   title: {
     default: config.appTitle ?? config.appName ?? config.appName,
     template: `%s | ${config.appName}`,


### PR DESCRIPTION
## What

Registers **broomva.tech** as a Base app via Base Dashboard (base.dev) **domain verification**. Adds one meta tag through Next.js `metadata.other` in the root layout:

```
<meta name="base:app_id" content="6a1deda4d510a5a848efc662"/>
```

Public identifier, emitted on the apex `/`. Scope: **domain verification only** (Sign-in-with-Base / Mini App manifest deferred). Clears the "App ID not found in meta tag" step in Base Dashboard.

## Dep-Chain (P14)

- **Upstream:** `apps/broomva/app/layout.tsx` root `metadata` export · `chat.config.ts` `appUrl=https://broomva.tech` (apex confirmed) · Next.js `metadata.other` API · Vercel apex→`apps/broomva`.
- **Downstream:** deployed `<head>` on apex → Base verifier → Register click. No code consumers. Homepage `(site)/page.tsx` exports no `metadata`, so it inherits the layout's `other` (verified — no shadowing).

## Validation (P11)

- [x] Diff type-correct (`Metadata.other: {[k]: string|number|Array<…>}`) + Biome-style (double quotes, trailing comma, quoted key)
- [ ] CI: `turbo lint` + `typecheck` + build green
- [ ] Post-deploy: `curl -s https://broomva.tech | grep base:app_id` confirms tag live **before** clicking Register

## Cross-Review (P20)

Below substantive threshold (single file, 4 added lines, no public API/governance surface — a verification token, not a code interface). Full cross-model gate not triggered.

## Risk

Minimal + reversible — one public meta tag, no behavior change, no secrets.

Linear: BRO-1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)