### PR TITLE
fix(docs): CodeRabbit review fixes on #217 (restore supersede + pin badge + CLI defaults) [BRO-1300]

### DIFF
--- a/apps/broomva/app/api/docs/[id]/route.test.ts
+++ b/apps/broomva/app/api/docs/[id]/route.test.ts
@@ -5,11 +5,13 @@ vi.mock("@/lib/prompts/resolve-auth", () => ({ resolveAuth: vi.fn() }));
 vi.mock("@/lib/db/spec-doc-queries", () => ({
   getSpecDocForOwner: vi.fn(),
   setSpecDocState: vi.fn(),
+  restoreSpecDoc: vi.fn(),
   softDeleteSpecDoc: vi.fn(),
 }));
 
 import {
   getSpecDocForOwner,
+  restoreSpecDoc,
   setSpecDocState,
   softDeleteSpecDoc,
 } from "@/lib/db/spec-doc-queries";
@@ -19,6 +21,7 @@ import { DELETE, GET, PATCH } from "./route";
 const mockAuth = vi.mocked(resolveAuth);
 const mockGet = vi.mocked(getSpecDocForOwner);
 const mockSetState = vi.mocked(setSpecDocState);
+const mockRestore = vi.mocked(restoreSpecDoc);
 const mockSoftDelete = vi.mocked(softDeleteSpecDoc);
 
 const getReq = () => new NextRequest("http://localhost/api/docs/doc-1");
@@ -36,6 +39,7 @@ beforeEach(() => {
   mockAuth.mockReset();
   mockGet.mockReset();
   mockSetState.mockReset();
+  mockRestore.mockReset();
   mockSoftDelete.mockReset();
 });
 
@@ -95,12 +99,14 @@ describe("PATCH /api/docs/[id]", () => {
     expect(await resp.json()).toEqual({ ok: true, state: "archived" });
   });
 
-  test("restore → setSpecDocState(published)", async () => {
+  test("restore → restoreSpecDoc (supersedes siblings, publishes target)", async () => {
     mockAuth.mockResolvedValue({ userId: "owner-1", email: "a@b.com" });
-    mockSetState.mockResolvedValue(true);
+    mockRestore.mockResolvedValue(true);
     const resp = await PATCH(patchReq({ action: "restore" }), params("doc-1"));
     expect(resp.status).toBe(200);
-    expect(mockSetState).toHaveBeenCalledWith("doc-1", "owner-1", "published");
+    expect(mockRestore).toHaveBeenCalledWith("doc-1", "owner-1");
+    expect(mockSetState).not.toHaveBeenCalled();
+    expect(await resp.json()).toEqual({ ok: true, state: "published" });
   });
 
   test("400 on an unknown action", async () => {

--- a/apps/broomva/app/api/docs/[id]/route.ts
+++ b/apps/broomva/app/api/docs/[id]/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
   getSpecDocForOwner,
+  restoreSpecDoc,
   setSpecDocState,
   softDeleteSpecDoc,
 } from "@/lib/db/spec-doc-queries";
@@ -54,11 +55,16 @@ export async function PATCH(
     );
   }
   const { id } = await params;
-  const nextState = action === "archive" ? "archived" : "published";
-  const ok = await setSpecDocState(id, auth.userId, nextState);
+  // restore supersedes sibling active versions (one active per handle); archive
+  // is a simple state set.
+  const ok =
+    action === "archive"
+      ? await setSpecDocState(id, auth.userId, "archived")
+      : await restoreSpecDoc(id, auth.userId);
   if (!ok) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
+  const nextState = action === "archive" ? "archived" : "published";
   return NextResponse.json({ ok: true, state: nextState });
 }
 

--- a/apps/broomva/components/spec-doc/doc-frame.tsx
+++ b/apps/broomva/components/spec-doc/doc-frame.tsx
@@ -31,9 +31,13 @@ export function DocFrame({
     timeStyle: "short",
   }).format(doc.createdAt);
 
+  // On a version-pin route the pinned version is the salient label (so
+  // /d/<handle>/v/1 and /v/2 don't both read "Superseded"); elsewhere the
+  // lifecycle state is the badge.
   const badge =
-    STATE_BADGE[doc.state] ??
-    (pinnedVersion != null ? `v${pinnedVersion}` : null);
+    pinnedVersion != null
+      ? `v${pinnedVersion}`
+      : (STATE_BADGE[doc.state] ?? null);
 
   return (
     <div className="flex h-dvh max-h-dvh w-full flex-col bg-background">

--- a/apps/broomva/lib/db/spec-doc-queries.ts
+++ b/apps/broomva/lib/db/spec-doc-queries.ts
@@ -11,7 +11,7 @@
  * query layer (defense in depth), independent of the route-level auth gate.
  */
 
-import { and, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { type SpecDoc, type SpecDocState, specDoc } from "@/lib/db/schema";
 
@@ -300,9 +300,10 @@ export async function promoteLatestDraft(
 }
 
 /**
- * Set a doc's state by exact id (archive / restore). Owner-scoped, and only on
- * non-deleted docs — `deletedAt` is left untouched, so archive/restore never
- * undeletes a soft-deleted doc (un-delete is a Phase-2 concern).
+ * Set a doc's state by exact id (e.g. archive). Owner-scoped, non-deleted only —
+ * `deletedAt` is left untouched, so this never undeletes a soft-deleted doc
+ * (un-delete is a Phase-2 concern). For restore use {@link restoreSpecDoc},
+ * which also supersedes sibling active versions.
  */
 export async function setSpecDocState(
   id: string,
@@ -321,6 +322,55 @@ export async function setSpecDocState(
     )
     .returning({ id: specDoc.id });
   return updated.length > 0;
+}
+
+/**
+ * Restore a doc (by id) to `published` as the SOLE active version of its handle:
+ * in one transaction, supersede any other active version of the handle, then
+ * publish the target. Prevents two active versions for one handle (the failure
+ * a naive state-set would create). Owner-scoped, non-deleted only.
+ */
+export async function restoreSpecDoc(
+  id: string,
+  ownerId: string,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const [target] = await tx
+      .select({ handle: specDoc.handle })
+      .from(specDoc)
+      .where(
+        and(
+          eq(specDoc.id, id),
+          eq(specDoc.ownerId, ownerId),
+          isNull(specDoc.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!target) return false;
+
+    // Supersede sibling active versions of the same handle (a null/standalone
+    // handle has no siblings to collide with).
+    if (target.handle) {
+      await tx
+        .update(specDoc)
+        .set({ state: "superseded" })
+        .where(
+          and(
+            eq(specDoc.ownerId, ownerId),
+            eq(specDoc.handle, target.handle),
+            inArray(specDoc.state, ACTIVE_STATES),
+            isNull(specDoc.deletedAt),
+            ne(specDoc.id, id),
+          ),
+        );
+    }
+
+    await tx
+      .update(specDoc)
+      .set({ state: "published" })
+      .where(and(eq(specDoc.id, id), eq(specDoc.ownerId, ownerId)));
+    return true;
+  });
 }
 
 /** Soft-delete a doc by id (sets `deletedAt`); the Phase-2 reconciler GCs it. */

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -497,15 +497,24 @@ pub struct PublishDocRequest {
     pub source: Option<DocSource>,
 }
 
+/// Back-compat defaults: a pre-lifecycle server omits these fields; a doc with
+/// no explicit lifecycle is version 1, published (not 0 / empty-string).
+fn default_doc_version() -> i64 {
+    1
+}
+fn default_doc_state() -> String {
+    "published".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublishDocResponse {
     pub id: String,
     #[serde(default)]
     pub handle: Option<String>,
-    #[serde(default)]
+    #[serde(default = "default_doc_version")]
     pub version: i64,
-    #[serde(default)]
+    #[serde(default = "default_doc_state")]
     pub state: String,
     #[serde(default)]
     pub title: String,


### PR DESCRIPTION
Fix-forward for the 3 inline comments [CodeRabbit posted on #217](https://github.com/broomva/broomva.tech/pull/217) (merged before they were read — recovering by fixing forward).

1. **(Major, latent) `restore` could create two active versions of one handle.** PATCH `restore` did a blind `setSpecDocState(published)`. New **`restoreSpecDoc(id)`** runs in a transaction: supersede sibling active versions of the handle → publish the target → exactly one active version. Latent because archive/restore are API-only in Phase 1 (no CLI path yet), but a real correctness gap the P20 pair missed — CodeRabbit earns the catch.
2. **(Minor) pin badge shadowed by state.** `/d/<handle>/v/1` and `/v/2` both rendered "Superseded". `DocFrame` now shows the pinned version (`v1`) on pin routes; the state badge elsewhere. *Confirmed live during #217 deploy-verify.*
3. **(Minor) CLI `PublishDocResponse` semantic defaults** — `version`→1, `state`→`"published"` (not `0`/`""`) so pre-lifecycle servers that omit the fields stay back-compat.

## Validation
16 vitest (restore test now asserts `restoreSpecDoc` + that `setSpecDocState` is *not* called) · Biome · tsc · `cargo clippy -D warnings` + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)