### PR TITLE
feat(docs): GET /api/docs/[id]/content + broomva docs get (Maestro Phase 0a) [BRO-1335]

### DIFF
--- a/apps/broomva/app/api/docs/[id]/content/route.test.ts
+++ b/apps/broomva/app/api/docs/[id]/content/route.test.ts
@@ -1,0 +1,96 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/prompts/resolve-auth", () => ({ resolveAuth: vi.fn() }));
+vi.mock("@/lib/db/spec-doc-queries", () => ({
+  resolveSpecDocForViewer: vi.fn(),
+}));
+
+import { resolveSpecDocForViewer } from "@/lib/db/spec-doc-queries";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+import { GET } from "./route";
+
+const mockAuth = vi.mocked(resolveAuth);
+const mockResolve = vi.mocked(resolveSpecDocForViewer);
+
+const req = (url = "http://localhost/api/docs/maestro/content") =>
+  new NextRequest(url);
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const row = (over: Record<string, unknown> = {}) => ({
+  id: "doc-1",
+  ownerId: "owner-1",
+  handle: "maestro",
+  version: 2,
+  state: "published",
+  title: "Maestro",
+  html: "<h1>body</h1>",
+  sourceRepo: null,
+  sourcePath: null,
+  sourceCommit: null,
+  ticketId: null,
+  prNumber: null,
+  sessionId: null,
+  expiresAt: null,
+  deletedAt: null,
+  createdAt: new Date("2026-06-02T00:00:00Z"),
+  updatedAt: new Date("2026-06-02T00:00:00Z"),
+  ...over,
+});
+
+beforeEach(() => {
+  mockAuth.mockReset();
+  mockResolve.mockReset();
+});
+
+describe("GET /api/docs/[id]/content", () => {
+  test("401 when unauthenticated — never touches the DB", async () => {
+    mockAuth.mockResolvedValue(null);
+    const resp = await GET(req(), params("maestro"));
+    expect(resp.status).toBe(401);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  test("200 returns the html body, resolved by ref + owner-scoped", async () => {
+    mockAuth.mockResolvedValue({ userId: "owner-1", email: "a@b.com" });
+    mockResolve.mockResolvedValue(row() as never);
+    const resp = await GET(req(), params("maestro"));
+    expect(resp.status).toBe(200);
+    expect(mockResolve).toHaveBeenCalledWith("maestro", "owner-1", undefined);
+    const body = await resp.json();
+    expect(body.html).toBe("<h1>body</h1>");
+    expect(body.handle).toBe("maestro");
+    expect(body.version).toBe(2);
+  });
+
+  test("404 when not the owner's / missing (no existence leak)", async () => {
+    mockAuth.mockResolvedValue({ userId: "intruder", email: "x@y.com" });
+    mockResolve.mockResolvedValue(null);
+    const resp = await GET(req(), params("maestro"));
+    expect(resp.status).toBe(404);
+    expect(mockResolve).toHaveBeenCalledWith("maestro", "intruder", undefined);
+  });
+
+  test("?version=<n> pins a specific version", async () => {
+    mockAuth.mockResolvedValue({ userId: "owner-1", email: "a@b.com" });
+    mockResolve.mockResolvedValue(
+      row({ version: 1, state: "superseded" }) as never,
+    );
+    const resp = await GET(
+      req("http://localhost/api/docs/maestro/content?version=1"),
+      params("maestro"),
+    );
+    expect(resp.status).toBe(200);
+    expect(mockResolve).toHaveBeenCalledWith("maestro", "owner-1", 1);
+  });
+
+  test("400 on an invalid version", async () => {
+    mockAuth.mockResolvedValue({ userId: "owner-1", email: "a@b.com" });
+    const resp = await GET(
+      req("http://localhost/api/docs/maestro/content?version=abc"),
+      params("maestro"),
+    );
+    expect(resp.status).toBe(400);
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+});

--- a/apps/broomva/app/api/docs/[id]/content/route.ts
+++ b/apps/broomva/app/api/docs/[id]/content/route.ts
@@ -1,0 +1,51 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { resolveSpecDocForViewer } from "@/lib/db/spec-doc-queries";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+
+/**
+ * GET /api/docs/[id]/content — returns the full HTML body of an owned doc.
+ *
+ * The sibling `GET /api/docs/[id]` deliberately strips `html` to metadata-only;
+ * this endpoint returns it. `[id]` is treated as a REF (a stable handle →
+ * latest active version, or a legacy/standalone id); `?version=<n>` pins a
+ * specific version. Owner-scoped via resolveAuth + resolveSpecDocForViewer
+ * (404 when not the owner's or missing — no existence leak).
+ *
+ * This is the cross-session "continue" keystone (BRO-1335): a continuing agent,
+ * a fresh chat, or a service fetches the EXACT operating spec body by ref +
+ * Bearer — including, recursively, /d/maestro itself.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const versionParam = new URL(request.url).searchParams.get("version");
+  let version: number | undefined;
+  if (versionParam != null) {
+    version = Number.parseInt(versionParam, 10);
+    if (!Number.isInteger(version) || version < 1) {
+      return NextResponse.json({ error: "Invalid version" }, { status: 400 });
+    }
+  }
+
+  const doc = await resolveSpecDocForViewer(id, auth.userId, version);
+  if (!doc) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    id: doc.id,
+    handle: doc.handle,
+    version: doc.version,
+    state: doc.state,
+    title: doc.title,
+    html: doc.html,
+  });
+}

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -232,6 +232,22 @@ impl BroomvaClient {
         Ok(resp.json().await?)
     }
 
+    /// Fetch an owned doc's HTML content by ref (handle or id), optional version.
+    pub async fn get_doc_content(
+        &self,
+        reference: &str,
+        version: Option<i64>,
+    ) -> BroomvaResult<DocContentResponse> {
+        let mut req =
+            self.request(Method::GET, &format!("/api/docs/{reference}/content"));
+        if let Some(v) = version {
+            req = req.query(&[("version", v.to_string())]);
+        }
+        let resp = req.send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
     /// Delete an owned doc by id.
     pub async fn delete_doc(&self, id: &str) -> BroomvaResult<()> {
         let resp = self

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -541,6 +541,22 @@ pub struct DocSummary {
     pub created_at: String,
 }
 
+/// Response of `GET /api/docs/[ref]/content` — the html body + metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocContentResponse {
+    pub id: String,
+    #[serde(default)]
+    pub handle: Option<String>,
+    #[serde(default = "default_doc_version")]
+    pub version: i64,
+    #[serde(default = "default_doc_state")]
+    pub state: String,
+    #[serde(default)]
+    pub title: String,
+    pub html: String,
+}
+
 #[cfg(test)]
 mod telemetry_types_tests {
     use super::*;

--- a/crates/broomva-cli/src/cli/docs.rs
+++ b/crates/broomva-cli/src/cli/docs.rs
@@ -152,6 +152,30 @@ pub async fn handle_versions(
     Ok(())
 }
 
+/// Fetch a doc's HTML to a local file — the cross-session continue keystone.
+pub async fn handle_get(
+    client: &BroomvaClient,
+    reference: &str,
+    output: Option<&str>,
+    version: Option<i64>,
+    format: OutputFormat,
+) -> BroomvaResult<()> {
+    let doc = client.get_doc_content(reference, version).await?;
+    let path = output
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("{}.html", doc.handle.as_deref().unwrap_or(reference)));
+    fs::write(&path, &doc.html)?;
+
+    if format == OutputFormat::Json {
+        print_json(&doc);
+    } else {
+        print_kv("Saved", &path);
+        print_kv("Version", &format!("v{}", doc.version));
+        print_kv("Title", &doc.title);
+    }
+    Ok(())
+}
+
 /// Open a doc's gated URL in the default browser.
 pub async fn handle_open(client: &BroomvaClient, id: &str) -> BroomvaResult<()> {
     let url = format!("{}/d/{}", client.base_url().trim_end_matches('/'), id);

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -311,6 +311,17 @@ pub enum DocsCommand {
         /// The document handle.
         handle: String,
     },
+    /// Fetch a published document's HTML to a local file (to continue / fast-forward it).
+    Get {
+        /// Document handle or id.
+        reference: String,
+        /// Output file (default: <handle>.html).
+        #[arg(short, long)]
+        output: Option<String>,
+        /// Pin a specific version (default: latest).
+        #[arg(long)]
+        version: Option<i64>,
+    },
     /// Open a published document in the browser by handle or id.
     Open { id: String },
     /// Delete a published document by id.
@@ -626,6 +637,14 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
             DocsCommand::List => docs::handle_list(&client, format).await,
             DocsCommand::Versions { handle } => {
                 docs::handle_versions(&client, &handle, format).await
+            }
+            DocsCommand::Get {
+                reference,
+                output,
+                version,
+            } => {
+                docs::handle_get(&client, &reference, output.as_deref(), version, format)
+                    .await
             }
             DocsCommand::Open { id } => docs::handle_open(&client, &id).await,
             DocsCommand::Rm { id } => docs::handle_rm(&client, &id).await,


### PR DESCRIPTION
**Maestro (BRO-1332) Phase 0a** — the cross-session **continue** keystone, and the first design-led increment of the spec-orchestration plane (`/d/maestro`).

A continuing agent / fresh chat / service can now fetch the **exact html body** of a spec by ref + Bearer — including, recursively, `/d/maestro` itself — so `review`/`continue`/`fast-forward` works across sessions/agents without the doc having been git-committed.

## Changes
- **API** `GET /api/docs/[id]/content` — resolves `[id]` as a ref (handle→latest active, or legacy id); `?version=<n>` pins. Returns `{id, handle, version, state, title, html}`. The sibling `GET /api/docs/[id]` still strips `html` to metadata-only.
- **CLI** `broomva docs get <ref> [-o file] [--version N]` → writes the html to disk.

## Security
**Zero new auth logic.** The endpoint is `resolveAuth(request)` → `resolveSpecDocForViewer(ref, userId, version)` → 404-no-leak. `resolveSpecDocForViewer` is the **already-P20-reviewed** (BRO-1300) owner-scoped, soft-delete-excluding resolver. This returns the **same data the viewer already serves the owner** (via the sandboxed `srcDoc` iframe), just as JSON to the same authenticated owner — no new exposure surface.

## Validation
5 vitest (owner 200 / non-owner 404 / no-token 401 / `?version` pin / invalid-version 400) · `cargo build` + `clippy -D warnings` + 6 Rust unit · Biome · tsc. Additive, <150 LOC.

Parent: BRO-1332 · enables the loop (review/continue/fast-forward by handle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)