### PR TITLE
feat(maestro): /maestro spec console — the board over /d specs [BRO-1349]

### DIFF
--- a/apps/broomva/app/maestro/group-specs.test.ts
+++ b/apps/broomva/app/maestro/group-specs.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
+import { groupBoardSpecs } from "./lib";
+
+function row(over: Partial<SpecDocSummary> = {}): SpecDocSummary {
+  return {
+    id: "d",
+    ownerId: "u",
+    handle: "h",
+    version: 1,
+    state: "published",
+    title: "T",
+    sourceRepo: null,
+    sourcePath: null,
+    sourceCommit: null,
+    ticketId: null,
+    prNumber: null,
+    sessionId: null,
+    expiresAt: null,
+    deletedAt: null,
+    createdAt: new Date("2026-06-01T00:00:00Z"),
+    updatedAt: new Date("2026-06-01T00:00:00Z"),
+    ...over,
+  } as SpecDocSummary;
+}
+
+describe("groupBoardSpecs", () => {
+  test("groups by state in canonical order (published, draft, archived)", () => {
+    const groups = groupBoardSpecs([
+      row({ id: "1", state: "archived" }),
+      row({ id: "2", state: "published" }),
+      row({ id: "3", state: "draft" }),
+      row({ id: "4", state: "published" }),
+    ]);
+    expect(groups.map((g) => g.state)).toEqual([
+      "published",
+      "draft",
+      "archived",
+    ]);
+    // preserves input order within a group
+    expect(groups[0]?.docs.map((d) => d.id)).toEqual(["2", "4"]);
+  });
+
+  test("drops empty groups", () => {
+    const groups = groupBoardSpecs([row({ state: "draft" })]);
+    expect(groups.map((g) => g.state)).toEqual(["draft"]);
+  });
+
+  test("empty input → no groups", () => {
+    expect(groupBoardSpecs([])).toEqual([]);
+  });
+
+  test("unexpected states (superseded/expired) are dropped — never a stray group", () => {
+    const groups = groupBoardSpecs([
+      row({ id: "s", state: "superseded" }),
+      row({ id: "e", state: "expired" }),
+    ]);
+    expect(groups).toEqual([]);
+  });
+
+  test("each group carries its label + hint", () => {
+    const [g] = groupBoardSpecs([row({ state: "published" })]);
+    expect(g?.label).toBe("Published");
+    expect(g?.hint).toContain("/d/<handle>");
+  });
+});

--- a/apps/broomva/app/maestro/group-specs.test.ts
+++ b/apps/broomva/app/maestro/group-specs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
-import { groupBoardSpecs } from "./lib";
+import { groupBoardSpecs, viewerHref } from "./lib";
 
 function row(over: Partial<SpecDocSummary> = {}): SpecDocSummary {
   return {
@@ -62,5 +62,28 @@ describe("groupBoardSpecs", () => {
     const [g] = groupBoardSpecs([row({ state: "published" })]);
     expect(g?.label).toBe("Published");
     expect(g?.hint).toContain("/d/<handle>");
+  });
+});
+
+describe("viewerHref", () => {
+  test("active docs → bare handle route", () => {
+    expect(
+      viewerHref(row({ handle: "alpha", state: "published", version: 2 })),
+    ).toBe("/d/alpha");
+    expect(
+      viewerHref(row({ handle: "alpha", state: "draft", version: 1 })),
+    ).toBe("/d/alpha");
+  });
+
+  test("archived doc → version-pin route (the bare handle 404s for archived)", () => {
+    expect(
+      viewerHref(row({ handle: "alpha", state: "archived", version: 3 })),
+    ).toBe("/d/alpha/v/3");
+  });
+
+  test("falls back to id when handle is null", () => {
+    expect(
+      viewerHref(row({ handle: null, id: "xyz", state: "published" })),
+    ).toBe("/d/xyz");
   });
 });

--- a/apps/broomva/app/maestro/lib.ts
+++ b/apps/broomva/app/maestro/lib.ts
@@ -43,3 +43,16 @@ export function groupBoardSpecs(docs: SpecDocSummary[]): BoardGroup[] {
     docs: docs.filter((d) => d.state === state),
   })).filter((g) => g.docs.length > 0);
 }
+
+/**
+ * The viewer URL for a board row. The bare `/d/<handle>` route serves only
+ * ACTIVE_STATES (published/draft), so an archived doc must link to its
+ * version-pin route `/d/<handle>/v/<n>` (which serves any non-deleted version)
+ * — otherwise the link dead-ends at 404. Keeps the archive round-trip navigable.
+ */
+export function viewerHref(
+  doc: Pick<SpecDocSummary, "handle" | "id" | "state" | "version">,
+): string {
+  const ref = doc.handle ?? doc.id;
+  return doc.state === "archived" ? `/d/${ref}/v/${doc.version}` : `/d/${ref}`;
+}

--- a/apps/broomva/app/maestro/lib.ts
+++ b/apps/broomva/app/maestro/lib.ts
@@ -1,0 +1,45 @@
+import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
+
+/** The content-states the Maestro board groups by (mirrors BOARD_STATES). */
+export type BoardState = "published" | "draft" | "archived";
+
+/** Canonical display order of the board groups. */
+export const BOARD_GROUP_ORDER: BoardState[] = [
+  "published",
+  "draft",
+  "archived",
+];
+
+export const BOARD_GROUP_META: Record<
+  BoardState,
+  { label: string; hint: string }
+> = {
+  published: { label: "Published", hint: "Live at /d/<handle>" },
+  draft: { label: "Draft", hint: "Work in progress" },
+  archived: {
+    label: "Archived",
+    hint: "Hidden from /d — restore to republish",
+  },
+};
+
+export interface BoardGroup {
+  state: BoardState;
+  label: string;
+  hint: string;
+  docs: SpecDocSummary[];
+}
+
+/**
+ * Group board docs by content-state into the canonical display order, dropping
+ * empty groups. Pure — the single piece of board logic worth unit-testing; the
+ * upstream query already restricts to BOARD_STATES, but this also drops any
+ * unexpected state (defense in depth) so the board never renders a stray group.
+ */
+export function groupBoardSpecs(docs: SpecDocSummary[]): BoardGroup[] {
+  return BOARD_GROUP_ORDER.map((state) => ({
+    state,
+    label: BOARD_GROUP_META[state].label,
+    hint: BOARD_GROUP_META[state].hint,
+    docs: docs.filter((d) => d.state === state),
+  })).filter((g) => g.docs.length > 0);
+}

--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -9,9 +9,11 @@ import { type BoardState, groupBoardSpecs, viewerHref } from "./lib";
 
 const dateFmt = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
 
+// Arcan Glass semantic tokens (globals.css) — not raw Tailwind palette colors.
 const STATE_BADGE_CLASS: Record<BoardState, string> = {
-  published: "border-emerald-500/40 text-emerald-600 dark:text-emerald-400",
-  draft: "border-amber-500/40 text-amber-600 dark:text-amber-400",
+  published:
+    "border-[color:var(--ag-success)]/40 text-[color:var(--ag-success)]",
+  draft: "border-[color:var(--ag-warning)]/40 text-[color:var(--ag-warning)]",
   archived: "border-muted-foreground/30 text-muted-foreground",
 };
 
@@ -159,14 +161,24 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
                       </button>
                     )}
                     {confirmId === d.id ? (
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => mutate(d.id, { method: "DELETE" })}
-                        className="rounded-md bg-destructive/10 px-2 py-1 text-destructive text-xs transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                      >
-                        Confirm?
-                      </button>
+                      <>
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => mutate(d.id, { method: "DELETE" })}
+                          className="rounded-md bg-destructive/10 px-2 py-1 text-destructive text-xs transition-colors hover:bg-destructive/20 disabled:opacity-50"
+                        >
+                          Confirm?
+                        </button>
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() => setConfirmId(null)}
+                          className="rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+                        >
+                          Cancel
+                        </button>
+                      </>
                     ) : (
                       <button
                         type="button"

--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { startTransition, useState } from "react";
+import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
+import { type BoardState, groupBoardSpecs } from "./lib";
+
+const dateFmt = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
+
+const STATE_BADGE_CLASS: Record<BoardState, string> = {
+  published: "border-emerald-500/40 text-emerald-600 dark:text-emerald-400",
+  draft: "border-amber-500/40 text-amber-600 dark:text-amber-400",
+  archived: "border-muted-foreground/30 text-muted-foreground",
+};
+
+/**
+ * The Maestro board (BRO-1349) — client island over the owner's specs. Lists
+ * them grouped by content-state and wires the archive / restore / delete
+ * actions to the existing owner-scoped /api/docs/[id] endpoints (cookie auth,
+ * same origin), refreshing the server component on success.
+ */
+export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
+  const router = useRouter();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const groups = groupBoardSpecs(docs);
+
+  async function mutate(id: string, init: RequestInit) {
+    setPendingId(id);
+    setError(null);
+    try {
+      const resp = await fetch(`/api/docs/${id}`, init);
+      if (!resp.ok) {
+        const body = (await resp.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        setError(body?.error ?? `Action failed (${resp.status})`);
+        return;
+      }
+      startTransition(() => router.refresh());
+    } catch {
+      setError("Network error — please retry.");
+    } finally {
+      setPendingId(null);
+      setConfirmId(null);
+    }
+  }
+
+  function patch(action: "archive" | "restore"): RequestInit {
+    return {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action }),
+    };
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground text-sm">
+        No specs yet. Publish one with{" "}
+        <code className="rounded bg-muted px-1 py-0.5 text-xs">
+          broomva docs publish file.html --as &lt;handle&gt;
+        </code>
+        .
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive text-xs">
+          {error}
+        </div>
+      ) : null}
+      {groups.map((group) => (
+        <section key={group.state}>
+          <div className="mb-2 flex items-baseline gap-2">
+            <h2 className="font-semibold text-sm uppercase tracking-wide">
+              {group.label}
+            </h2>
+            <span className="text-muted-foreground text-xs">
+              {group.docs.length}
+            </span>
+            <span className="text-muted-foreground text-xs">
+              · {group.hint}
+            </span>
+          </div>
+          <ul className="divide-y rounded-lg border">
+            {group.docs.map((d) => {
+              const ref = d.handle ?? d.id;
+              const busy = pendingId === d.id;
+              return (
+                <li key={d.id} className="flex items-center gap-3 px-4 py-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <Link
+                        href={`/d/${ref}`}
+                        className="truncate font-medium text-sm hover:underline"
+                      >
+                        {d.title}
+                      </Link>
+                      <span
+                        className={`shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${STATE_BADGE_CLASS[d.state as BoardState]}`}
+                      >
+                        {d.state}
+                      </span>
+                      {d.version > 1 ? (
+                        <span className="shrink-0 text-muted-foreground text-xs">
+                          v{d.version}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="mt-0.5 flex items-center gap-2 text-muted-foreground text-xs">
+                      <code className="rounded bg-muted px-1 py-0.5">
+                        {ref}
+                      </code>
+                      {d.sourcePath ? (
+                        <span className="truncate">{d.sourcePath}</span>
+                      ) : null}
+                      {d.ticketId ? (
+                        <span className="shrink-0">{d.ticketId}</span>
+                      ) : null}
+                      <span className="shrink-0">
+                        {dateFmt.format(d.createdAt)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Link
+                      href={`/d/${ref}`}
+                      className="rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+                    >
+                      View
+                    </Link>
+                    {d.state === "archived" ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => mutate(d.id, patch("restore"))}
+                        className="rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+                      >
+                        Restore
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => mutate(d.id, patch("archive"))}
+                        className="rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+                      >
+                        Archive
+                      </button>
+                    )}
+                    {confirmId === d.id ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => mutate(d.id, { method: "DELETE" })}
+                        className="rounded-md bg-destructive/10 px-2 py-1 text-destructive text-xs transition-colors hover:bg-destructive/20 disabled:opacity-50"
+                      >
+                        Confirm?
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => setConfirmId(d.id)}
+                        className="rounded-md px-2 py-1 text-destructive/80 text-xs transition-colors hover:bg-destructive/10 disabled:opacity-50"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import type { Route } from "next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { startTransition, useState } from "react";
 import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
-import { type BoardState, groupBoardSpecs } from "./lib";
+import { type BoardState, groupBoardSpecs, viewerHref } from "./lib";
 
 const dateFmt = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
 
@@ -91,13 +92,16 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
           <ul className="divide-y rounded-lg border">
             {group.docs.map((d) => {
               const ref = d.handle ?? d.id;
+              // viewerHref returns a validated route string; cast to the Next
+              // typed-routes brand (the dynamic /d/<handle>[/v/<n>] target).
+              const href = viewerHref(d) as Route;
               const busy = pendingId === d.id;
               return (
                 <li key={d.id} className="flex items-center gap-3 px-4 py-3">
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
                       <Link
-                        href={`/d/${ref}`}
+                        href={href}
                         className="truncate font-medium text-sm hover:underline"
                       >
                         {d.title}

--- a/apps/broomva/app/maestro/page.tsx
+++ b/apps/broomva/app/maestro/page.tsx
@@ -1,0 +1,63 @@
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getSafeSession } from "@/lib/auth";
+import { listBoardSpecDocs } from "@/lib/db/spec-doc-queries";
+import { MaestroBoard } from "./maestro-board";
+
+export const metadata = {
+  title: "Maestro — spec console",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * /maestro — the spec orchestration console (BRO-1349, Maestro Phase 1). The
+ * human-facing board over the documents served at /d/<handle>: list, open,
+ * archive, restore, delete. Owner-gated (same identity gate as /d). Defined by
+ * the spec at /d/maestro. The orchestration plane (Trigger / run-state) lands
+ * in Phase 1b — this console manages the content plane today.
+ */
+export default async function MaestroPage() {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  const userId = session?.user?.id;
+  if (!userId) {
+    redirect("/login?next=/maestro");
+  }
+
+  const docs = await listBoardSpecDocs(userId);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="font-semibold text-2xl">Maestro</h1>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Spec orchestration console. Manage the docs published at{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            /d/&lt;handle&gt;
+          </code>{" "}
+          — open, archive, restore, delete. Defined by{" "}
+          <Link
+            href="/d/maestro"
+            className="underline transition-colors hover:text-foreground"
+          >
+            /d/maestro
+          </Link>
+          .
+        </p>
+      </header>
+
+      <div className="mb-6 rounded-lg border border-dashed bg-muted/30 px-4 py-3 text-muted-foreground text-xs">
+        <span className="font-medium text-foreground">
+          Orchestration plane — Phase 1b.
+        </span>{" "}
+        Trigger, run-state (proposed → running → review → done), and dispatch
+        land next (BRO-1336 migration). This console manages the content plane
+        today.
+      </div>
+
+      <MaestroBoard docs={docs} />
+    </div>
+  );
+}

--- a/apps/broomva/lib/db/spec-doc-queries.ts
+++ b/apps/broomva/lib/db/spec-doc-queries.ts
@@ -18,6 +18,14 @@ import { type SpecDoc, type SpecDocState, specDoc } from "@/lib/db/schema";
 /** Active states shown in the default list and superseded on re-publish. */
 const ACTIVE_STATES: SpecDocState[] = ["published", "draft"];
 
+/**
+ * States shown on the Maestro board: active (published/draft) plus archived
+ * (manageable — restore/delete). Superseded + expired are version history
+ * (reachable via /d/<handle>/v/<n>), and deleted rows are gone — none belong
+ * on the board.
+ */
+const BOARD_STATES: SpecDocState[] = ["published", "draft", "archived"];
+
 /** Max rows returned by list endpoints — bounds the response. */
 const LIST_LIMIT = 200;
 
@@ -247,6 +255,29 @@ export async function listSpecDocs(ownerId: string): Promise<SpecDocSummary[]> {
       and(
         eq(specDoc.ownerId, ownerId),
         inArray(specDoc.state, ACTIVE_STATES),
+        isNull(specDoc.deletedAt),
+      ),
+    )
+    .orderBy(desc(specDoc.createdAt))
+    .limit(LIST_LIMIT);
+}
+
+/**
+ * The Maestro board view — the owner's published, draft, and archived docs
+ * (BRO-1349), newest first. Superseded/expired/deleted are excluded (they are
+ * version history or gone). Like {@link listSpecDocs} this is owner-scoped and
+ * excludes the html body.
+ */
+export async function listBoardSpecDocs(
+  ownerId: string,
+): Promise<SpecDocSummary[]> {
+  return db
+    .select(SUMMARY_COLUMNS)
+    .from(specDoc)
+    .where(
+      and(
+        eq(specDoc.ownerId, ownerId),
+        inArray(specDoc.state, BOARD_STATES),
         isNull(specDoc.deletedAt),
       ),
     )


### PR DESCRIPTION
## What

`broomva.tech/maestro` — the **Maestro Phase 1 spec-management console** (the "Linear for specs" board) over the documents served at `/d/<handle>`. Implements [`/d/maestro`](https://broomva.tech/d/maestro) v3 §5, content-plane first.

Closes BRO-1349 (sub-issue of BRO-1332).

## Dep-chain (P14)

- **Upstream:** `lib/db/spec-doc-queries.ts` (new `listBoardSpecDocs`) · `lib/auth.ts` (`getSafeSession` gate) · `app/api/docs/[id]` PATCH/DELETE (existing, owner-scoped) · the shipped content plane (BRO-1293/1300/1335).
- **Downstream:** the `/d/<handle>` viewer links · CI gates · no in-flight PRs depend on this.

## Changes

| File | What |
|---|---|
| `lib/db/spec-doc-queries.ts` | `listBoardSpecDocs(ownerId)` — published+draft+archived (not superseded/expired/deleted), owner-scoped, html-excluded |
| `app/maestro/page.tsx` | owner-gated server component (same `getSafeSession` gate as `/d` → `/login` redirect) + honest Phase-1b orchestration scaffold |
| `app/maestro/maestro-board.tsx` | client board grouped by content-state; archive / restore / delete → existing `/api/docs/[id]` (cookie auth) + `router.refresh()`; inline confirm + error (no `alert`) |
| `app/maestro/lib.ts` | `groupBoardSpecs` (pure) |
| `app/maestro/group-specs.test.ts` | 5 vitest cases |

## Honest scope (carrier-state discipline)

The **orchestration plane** (Trigger / orch_state / dispatch) is shown as a clearly-labeled **Phase-1b scaffold** — NOT faked state. It's gated on BRO-1336 (migration 0072). This PR manages the **content plane** (the specs that exist today).

## Test plan (P11)

- ✅ Biome (clean) · ✅ tsc `--noEmit` (full, clean) · ✅ vitest 5/5 (`groupBoardSpecs`)
- ⏳ local `next build` (RSC/client boundary) — running
- ⏳ deploy-verify: `/maestro` unauth→login redirect (gate) · authed render · `broomva docs list` data parity · archive/delete round-trip reflected
- ⏳ P20 cross-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maestro specs board page to view and manage spec documents.
  * Docs grouped by state (published, draft, archived) with per-group sections and empty-state messaging.
  * Per-spec metadata shown (title link, version, handle/source, ticket, created date).
  * Archive/restore and delete actions with confirmation and request-state handling.

* **Tests**
  * Added tests covering grouping behavior and link generation for different doc states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->