### PR TITLE
refactor(maestro): retire the plain /d list — redirect /d → /maestro [BRO-1352]

### DIFF
--- a/apps/broomva/app/d/page.tsx
+++ b/apps/broomva/app/d/page.tsx
@@ -1,86 +1,12 @@
-import { headers } from "next/headers";
-import Link from "next/link";
 import { redirect } from "next/navigation";
-import { getSafeSession } from "@/lib/auth";
-import { listSpecDocs } from "@/lib/db/spec-doc-queries";
 
 /**
- * /d — the authenticated owner's list of published documents (BRO-1293).
+ * /d — retired. The plain document list is superseded by the Maestro console
+ * (BRO-1349 / BRO-1352); `/d` now routes to `/maestro`, so both URLs reach the
+ * same page. The `/d/<handle>` viewer and `/d/<handle>/v/<n>` version-pin are
+ * unchanged — specs still live there. Auth is enforced by `/maestro`'s own gate,
+ * so this redirects unconditionally (307 — reversible while this area evolves).
  */
-export default async function DocsListPage() {
-  const { data: session } = await getSafeSession({
-    fetchOptions: { headers: await headers() },
-  });
-  const userId = session?.user?.id;
-  if (!userId) {
-    redirect("/login?next=/d");
-  }
-
-  const docs = await listSpecDocs(userId);
-  const dateFmt = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
-
-  return (
-    <div className="mx-auto w-full max-w-2xl px-4 py-8">
-      <header className="mb-6">
-        <h1 className="font-semibold text-2xl">Your documents</h1>
-        <p className="mt-1 text-muted-foreground text-sm">
-          Specs, PRDs, and reports published with{" "}
-          <code className="rounded bg-muted px-1 py-0.5 text-xs">
-            broomva docs publish
-          </code>
-          . Visible only to you.
-        </p>
-      </header>
-
-      {docs.length === 0 ? (
-        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground text-sm">
-          No documents yet. Publish one with{" "}
-          <code className="rounded bg-muted px-1 py-0.5 text-xs">
-            broomva docs publish file.html
-          </code>
-          .
-        </div>
-      ) : (
-        <ul className="divide-y rounded-lg border">
-          {docs.map((d) => (
-            <li key={d.id}>
-              <Link
-                href={`/d/${d.handle ?? d.id}`}
-                className="flex items-center justify-between gap-3 px-4 py-3 transition-colors hover:bg-muted/50"
-              >
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-center gap-2">
-                    <span className="truncate font-medium text-sm">
-                      {d.title}
-                    </span>
-                    {d.state === "draft" ? (
-                      <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wide">
-                        draft
-                      </span>
-                    ) : null}
-                    {d.version > 1 ? (
-                      <span className="shrink-0 text-muted-foreground text-xs">
-                        v{d.version}
-                      </span>
-                    ) : null}
-                  </span>
-                  {d.sourcePath ? (
-                    <span className="block truncate text-muted-foreground text-xs">
-                      {d.sourcePath}
-                    </span>
-                  ) : null}
-                </span>
-                <time
-                  dateTime={d.createdAt.toISOString()}
-                  className="shrink-0 text-muted-foreground text-xs"
-                >
-                  {dateFmt.format(d.createdAt)}
-                </time>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
+export default function DocsListRedirect() {
+  redirect("/maestro");
 }

--- a/apps/broomva/components/spec-doc/doc-frame.tsx
+++ b/apps/broomva/components/spec-doc/doc-frame.tsx
@@ -43,11 +43,11 @@ export function DocFrame({
     <div className="flex h-dvh max-h-dvh w-full flex-col bg-background">
       <header className="flex shrink-0 items-center gap-3 border-b px-3 py-2">
         <Link
-          href="/d"
-          aria-label="Back to your documents"
+          href="/maestro"
+          aria-label="Back to the Maestro console"
           className="shrink-0 rounded-md px-2 py-1 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground"
         >
-          ← Docs
+          ← Maestro
         </Link>
         <h1
           className="min-w-0 flex-1 truncate font-medium text-sm"


### PR DESCRIPTION
## What

The bare `/d` document list is superseded by the **Maestro console** (`/maestro`, BRO-1349). `/d` now redirects to `/maestro`, so both URLs reach the same page and the plain list page no longer exists.

Closes BRO-1352.

## Changes (2 files, ~10 LOC)

| File | Change |
|---|---|
| `app/d/page.tsx` | plain list → `redirect("/maestro")` (307, reversible). Auth enforced by `/maestro`'s gate → `/d` redirects unconditionally. |
| `components/spec-doc/doc-frame.tsx` | viewer back-link `/d` → `/maestro` ("← Maestro"), avoiding a redirect hop. |

## Unchanged
`/d/<handle>` (viewer) + `/d/<handle>/v/<n>` (version pin) — specs still live there. Dep-chain swept: these were the only two `/d`-list references in the codebase.

## Test plan
- ✅ Biome clean · `tsc` clean (incl. typed-route `href="/maestro"`) · local `next build` (running)
- ⏳ deploy-verify: `/d` → 307 → `/maestro` · viewer "← Maestro" lands on the console

P20: below the substantive threshold (trivial redirect + one link href); CodeRabbit + build + tsc suffice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)