### PR TITLE
feat(maestro): dock button to /maestro + persist the dock on the console [BRO-1372]

### DIFF
--- a/apps/broomva/app/maestro/layout.tsx
+++ b/apps/broomva/app/maestro/layout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+import { ToolbarDockProvider } from "@/components/site/toolbar-dock-context";
+import { TopNav } from "@/components/site/top-nav";
+
+/**
+ * /maestro is a top-level route (outside the `(site)` group), so it doesn't get
+ * the navigation dock that `ConditionalSiteChrome` mounts. This layout adds the
+ * dock surgically (BRO-1372): the only context `TopNav` needs beyond root's
+ * `AudioPlaybackProvider` is `ToolbarDockProvider`. No full site header/footer —
+ * the console keeps its own chrome, just gains the dock.
+ */
+export default function MaestroLayout({ children }: { children: ReactNode }) {
+  return (
+    <ToolbarDockProvider>
+      {children}
+      <TopNav />
+    </ToolbarDockProvider>
+  );
+}

--- a/apps/broomva/app/maestro/page.tsx
+++ b/apps/broomva/app/maestro/page.tsx
@@ -29,7 +29,7 @@ export default async function MaestroPage() {
   const docs = await listBoardSpecDocs(userId);
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-4 py-8">
+    <div className="mx-auto w-full max-w-3xl px-4 pt-8 pb-28">
       <header className="mb-6">
         <h1 className="font-semibold text-2xl">Maestro</h1>
         <p className="mt-1 text-muted-foreground text-sm">

--- a/apps/broomva/components/site/top-nav.tsx
+++ b/apps/broomva/components/site/top-nav.tsx
@@ -9,6 +9,7 @@ import {
   Sparkles,
   Terminal,
   User,
+  Workflow,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { Route } from "next";
@@ -62,6 +63,13 @@ const allLinks = [
     href: "/console",
     label: "Console",
     icon: Terminal,
+    productOnly: false,
+    authOnly: true,
+  },
+  {
+    href: "/maestro",
+    label: "Maestro",
+    icon: Workflow,
     productOnly: false,
     authOnly: true,
   },


### PR DESCRIPTION
## What
Adds a **Maestro** button to the navigation dock and **renders the dock on `/maestro`** (it was absent — `/maestro` is a top-level route outside the `(site)` group that mounts the dock via `ConditionalSiteChrome`).

Closes BRO-1372.

## Changes (3 files, ~28 LOC)
| File | Change |
|---|---|
| `components/site/top-nav.tsx` | `Maestro` entry in `allLinks` → `/maestro` (Workflow icon; `authOnly: true` since the console is owner-gated, matching `/console`) |
| `app/maestro/layout.tsx` (new) | mounts the dock on `/maestro`: wraps the page in `ToolbarDockProvider` (the only context `TopNav` needs beyond root's `AudioPlaybackProvider`) + `<TopNav />`. Surgical — the dock, not the full site header/footer. |
| `app/maestro/page.tsx` | `py-8` → `pt-8 pb-28` so board content clears the floating `fixed bottom-4` dock |

## Test plan
- ✅ Biome · tsc (clean) · local `next build` compiled
- ⏳ deploy-verify: the dock renders on `/maestro` with a Maestro button (your tap — Interceptor hangs on `tab_create`)

P20: below the substantive threshold (a nav link + a layout wrapper); CodeRabbit + build + tsc suffice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)