### PR TITLE
feat(maestro): board Trigger button — drive proposed→triggered from the console [BRO-1393]

### DIFF
--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -47,11 +47,11 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
   const [error, setError] = useState<string | null>(null);
   const groups = groupBoardSpecs(docs);
 
-  async function mutate(id: string, init: RequestInit) {
+  async function mutate(id: string, init: RequestInit, suffix = "") {
     setPendingId(id);
     setError(null);
     try {
-      const resp = await fetch(`/api/docs/${id}`, init);
+      const resp = await fetch(`/api/docs/${id}${suffix}`, init);
       if (!resp.ok) {
         const body = (await resp.json().catch(() => null)) as {
           error?: string;
@@ -158,8 +158,22 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
+                    {d.orchState === "proposed" ||
+                    d.orchState === "reviewing" ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() =>
+                          mutate(d.id, { method: "POST" }, "/trigger")
+                        }
+                        title="Dispatch this spec (orch_state → triggered)"
+                        className="rounded-md border border-[color:var(--ag-ai-blue)]/40 px-2 py-1 text-[color:var(--ag-ai-blue)] text-xs transition-colors hover:bg-[color:var(--ag-ai-blue)]/10 disabled:opacity-50"
+                      >
+                        Trigger
+                      </button>
+                    ) : null}
                     <Link
-                      href={`/d/${ref}`}
+                      href={href}
                       className="rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
                     >
                       View

--- a/apps/broomva/app/maestro/page.tsx
+++ b/apps/broomva/app/maestro/page.tsx
@@ -50,12 +50,14 @@ export default async function MaestroPage() {
 
       <div className="mb-6 rounded-lg border border-dashed bg-muted/30 px-4 py-3 text-muted-foreground text-xs">
         <span className="font-medium text-foreground">
-          Orchestration state is live.
+          Trigger is live (control plane).
         </span>{" "}
-        Each spec now carries an orch-state (every spec starts{" "}
-        <code className="rounded bg-muted px-1 py-0.5">proposed</code>). The{" "}
-        <strong>Trigger</strong> action that drives it through running → review
-        → done — plus the run log and dispatch budget — lands in Phase 1.
+        Triggering a spec records a dispatch and advances its orch-state{" "}
+        <code className="rounded bg-muted px-1 py-0.5">
+          proposed → triggered
+        </code>{" "}
+        (N=1 per version). Handing the queued run to a live runtime — actually
+        running the agent — is the next slice.
       </div>
 
       <MaestroBoard docs={docs} />


### PR DESCRIPTION
## What
**Phase 1b-i** — wire the deployed Phase-1a `POST /api/docs/[id]/trigger` to the board: a **Trigger** button on triggerable specs (`orchState ∈ proposed/reviewing`) drives `proposed→triggered` from the console UI (records a queued `SpecDocRun`, the orch-state pill flips). No relay needed.

Closes BRO-1393.

## Changes
- `app/maestro/maestro-board.tsx` — Trigger button (accent-blue, shown when triggerable) → `POST …/trigger` (no body → relay-CC default target, D7); `201` → `router.refresh()`; `409` → inline error (not-triggerable / budget). `mutate()` generalized with a path suffix.
- **drive-by fix:** the "View" action link used `/d/<handle>` directly, which **404s for archived docs** (the bare route serves active states only); now uses `viewerHref` like the title link (version-pin for archived). Latent bug the earlier `replace_all` viewerHref fix missed (different indentation).
- `app/maestro/page.tsx` — banner: Trigger is live (control plane, N=1); the runtime *run* is the next slice.

## Deferred (Phase 1b-ii)
The relay **dispatcher** (recon: relay spawn = a DB-recorded command an external daemon polls + executes) that takes a queued run and spawns a Claude Code session, + the relay-event **write-back** driving `triggered→running→review`, + evidence-gated Review accept (D9).

## Test plan
- ✅ Biome · tsc (clean) · vitest 9/9 · local build (running)
- ⏳ deploy-verify: Trigger a throwaway doc via the UI/curl → `orchState=triggered`; archived "View" → version-pin (no 404)

P20: below the substantive threshold (a button + a 1-line link fix); CodeRabbit + build + tsc suffice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)