### PR TITLE
feat(maestro): Continue deep-link + copy-prompt — hand a spec to a fresh session [BRO-1399]

### DIFF
--- a/apps/broomva/app/maestro/group-specs.test.ts
+++ b/apps/broomva/app/maestro/group-specs.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "vitest";
 import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
-import { groupBoardSpecs, ORCH_STATE_META, viewerHref } from "./lib";
+import {
+  claudeDeepLink,
+  continuePrompt,
+  groupBoardSpecs,
+  ORCH_STATE_META,
+  viewerHref,
+} from "./lib";
 
 function row(over: Partial<SpecDocSummary> = {}): SpecDocSummary {
   return {
@@ -107,5 +113,43 @@ describe("ORCH_STATE_META", () => {
       expect(meta.label).toBeTruthy();
       expect(meta.tone).toBeTruthy();
     }
+  });
+});
+
+describe("continuePrompt + claudeDeepLink", () => {
+  test("continuePrompt pulls the spec via the keystone + the /d URL", () => {
+    const p = continuePrompt(row({ handle: "alpha", title: "My Spec" }));
+    expect(p).toContain('Continue work on the Broomva spec "My Spec"');
+    expect(p).toContain("broomva docs get alpha");
+    expect(p).toContain("https://broomva.tech/d/alpha");
+    expect(p).toContain("CLAUDE.md / AGENTS.md");
+  });
+
+  test("continuePrompt includes source + ticket when present, omits when null", () => {
+    const withMeta = continuePrompt(
+      row({
+        sourcePath: "docs/x.html",
+        sourceRepo: "broomva/broomva.tech",
+        ticketId: "BRO-1",
+      }),
+    );
+    expect(withMeta).toContain("docs/x.html");
+    expect(withMeta).toContain("broomva/broomva.tech");
+    expect(withMeta).toContain("BRO-1");
+    const bare = continuePrompt(row({ sourcePath: null, ticketId: null }));
+    expect(bare).not.toContain("Spec source:");
+    expect(bare).not.toContain("Linear ticket:");
+  });
+
+  test("claudeDeepLink: claude-cli://open with repo + url-encoded prompt", () => {
+    const link = claudeDeepLink(row({ handle: "alpha", sourceRepo: "acme/x" }));
+    expect(link.startsWith("claude-cli://open?repo=acme/x&q=")).toBe(true);
+    expect(link).toContain("%20"); // spaces in the prompt are encoded
+  });
+
+  test("claudeDeepLink defaults repo to broomva/broomva.tech", () => {
+    expect(claudeDeepLink(row({ sourceRepo: null }))).toContain(
+      "repo=broomva/broomva.tech",
+    );
   });
 });

--- a/apps/broomva/app/maestro/lib.ts
+++ b/apps/broomva/app/maestro/lib.ts
@@ -85,3 +85,51 @@ export function viewerHref(
   const ref = doc.handle ?? doc.id;
   return doc.state === "archived" ? `/d/${ref}/v/${doc.version}` : `/d/${ref}`;
 }
+
+/** Fields the continue-session helpers read off a board doc. */
+type ContinuableDoc = Pick<
+  SpecDocSummary,
+  "handle" | "id" | "title" | "sourcePath" | "sourceRepo" | "ticketId"
+>;
+
+/** Default repo when a spec has no recorded sourceRepo (most specs live here). */
+const DEFAULT_REPO = "broomva/broomva.tech";
+
+/**
+ * The seed prompt handed to a fresh agent session to CONTINUE a spec (BRO-1399).
+ * Leans on the BRO-1335 content-GET keystone (`broomva docs get <handle>`) so the
+ * agent pulls the exact spec body, then reads the referenced source and continues
+ * under the workspace conventions. Pure — unit-tested.
+ */
+export function continuePrompt(doc: ContinuableDoc): string {
+  const handle = doc.handle ?? doc.id;
+  const lines = [
+    `Continue work on the Broomva spec "${doc.title}".`,
+    "",
+    `Pull the full spec: \`broomva docs get ${handle} -o spec.html\` (or open https://broomva.tech/d/${handle}).`,
+  ];
+  if (doc.sourcePath) {
+    lines.push(
+      `Spec source: \`${doc.sourcePath}\`${doc.sourceRepo ? ` in ${doc.sourceRepo}` : ""}.`,
+    );
+  }
+  if (doc.ticketId) {
+    lines.push(`Linear ticket: ${doc.ticketId}.`);
+  }
+  lines.push(
+    "",
+    "Read the spec and the files it references, check the current state of the work, then continue the implementation under the workspace conventions (CLAUDE.md / AGENTS.md). Think through the dependency chain before editing.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * A Claude Code deep link (`claude-cli://open`, v2.1.91+) that opens a session in
+ * the spec's repo with the continue-prompt pre-filled (not auto-sent). `repo`
+ * resolves to a local clone Claude Code has already seen. Omnara has no public
+ * prompt-carrying deep link, so its path is `continuePrompt` + clipboard paste.
+ */
+export function claudeDeepLink(doc: ContinuableDoc): string {
+  const repo = doc.sourceRepo ?? DEFAULT_REPO;
+  return `claude-cli://open?repo=${repo}&q=${encodeURIComponent(continuePrompt(doc))}`;
+}

--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -84,7 +84,9 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
     try {
       await navigator.clipboard.writeText(continuePrompt(d));
       setCopiedId(d.id);
-      setTimeout(() => setCopiedId(null), 1500);
+      // Guard the reset: a later copy on another row must not be cleared by
+      // this row's stale timer (only clear if still showing this id).
+      setTimeout(() => setCopiedId((cur) => (cur === d.id ? null : cur)), 1500);
     } catch {
       setError("Clipboard unavailable — open the spec and copy manually.");
     }
@@ -175,7 +177,7 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
                     <a
                       href={claudeDeepLink(d)}
                       title="Open Claude Code in the repo with a continue-prompt pre-filled (claude-cli://)"
-                      className="rounded-md border border-[color:var(--ag-accent-blue)]/40 px-2 py-1 text-[color:var(--ag-accent-blue)] text-xs transition-colors hover:bg-[color:var(--ag-accent-blue)]/10"
+                      className="rounded-md border border-[color:var(--ag-ai-blue)]/40 px-2 py-1 text-[color:var(--ag-ai-blue)] text-xs transition-colors hover:bg-[color:var(--ag-ai-blue)]/10"
                     >
                       Continue
                     </a>

--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -7,6 +7,8 @@ import { startTransition, useState } from "react";
 import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
 import {
   type BoardState,
+  claudeDeepLink,
+  continuePrompt,
   groupBoardSpecs,
   ORCH_STATE_META,
   type OrchTone,
@@ -45,6 +47,7 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
   const groups = groupBoardSpecs(docs);
 
   async function mutate(id: string, init: RequestInit, suffix = "") {
@@ -74,6 +77,17 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ action }),
     };
+  }
+
+  // Copy the continue-prompt to the clipboard (the phone → Omnara paste path).
+  async function copyPrompt(d: SpecDocSummary) {
+    try {
+      await navigator.clipboard.writeText(continuePrompt(d));
+      setCopiedId(d.id);
+      setTimeout(() => setCopiedId(null), 1500);
+    } catch {
+      setError("Clipboard unavailable — open the spec and copy manually.");
+    }
   }
 
   if (groups.length === 0) {
@@ -158,6 +172,21 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
                     </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
+                    <a
+                      href={claudeDeepLink(d)}
+                      title="Open Claude Code in the repo with a continue-prompt pre-filled (claude-cli://)"
+                      className="rounded-md border border-[color:var(--ag-accent-blue)]/40 px-2 py-1 text-[color:var(--ag-accent-blue)] text-xs transition-colors hover:bg-[color:var(--ag-accent-blue)]/10"
+                    >
+                      Continue
+                    </a>
+                    <button
+                      type="button"
+                      onClick={() => copyPrompt(d)}
+                      title="Copy the continue-prompt — paste into a new Omnara session from your phone"
+                      className="rounded-md px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+                    >
+                      {copiedId === d.id ? "Copied" : "Copy"}
+                    </button>
                     {d.orchState === "proposed" ||
                     d.orchState === "reviewing" ? (
                       <button


### PR DESCRIPTION
## What
A **minimal-scope** "continue this spec in a new agent session" — no relay/daemon. Each board card gets two work-starting actions:
- **Continue** — a `claude-cli://open?repo=…&q=<seed prompt>` deep-link: one-click on your laptop, opens Claude Code in the repo with the prompt pre-filled (not auto-sent).
- **Copy** — copies the seed prompt to the clipboard → paste into a fresh **Omnara** session from your phone (Omnara has no public prompt-carrying deep-link; its launch is an authed dashboard/API action — recon confirmed via [docs](https://docs.omnara.com/quickstart) / [open-in-agent](https://github.com/anxkhn/open-in-agent)).

Closes BRO-1399. (User chose "Both".)

## The seed prompt (leans on the BRO-1335 content-GET keystone)
> Continue work on the Broomva spec "<title>". Pull the full spec: `broomva docs get <handle> -o spec.html` (or open `/d/<handle>`). Spec source: `<sourcePath>` in `<sourceRepo>`. Linear ticket <ticketId>. Read the spec + the files it references, check current state, continue under CLAUDE.md / AGENTS.md, dep-chain first.

## Changes (3 files, frontend-only)
- `app/maestro/lib.ts` — `continuePrompt(doc)` + `claudeDeepLink(doc)` — pure, unit-tested.
- `app/maestro/maestro-board.tsx` — Continue `<a>` + Copy `<button>` (with "Copied" feedback) per card.
- `group-specs.test.ts` — +4 tests (prompt content/omission, deep-link scheme + encoding + default repo).

## Test plan
- ✅ Biome · tsc clean · vitest **13/13** · local build (running)
- ⏳ deploy-verify (your tap): Continue opens Claude Code with the prompt; Copy → paste into Omnara

P20: below the substantive threshold (pure helpers + two buttons); CodeRabbit + build + tsc suffice. (`claude-cli://` is documented + inert until you press Enter.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to continue Maestro sessions directly in Claude Code with a one-click deep link.
  * Added "Copy" button to copy continuation prompts to clipboard for manual session continuation.
  * Continuation prompts include relevant context such as source path, repository, and ticket references when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->