### PR TITLE
feat(maestro): mission-control view — orch-state grouping + triage header [BRO-1402]

### DIFF
--- a/apps/broomva/app/maestro/group-specs.test.ts
+++ b/apps/broomva/app/maestro/group-specs.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "vitest";
 import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
 import {
+  activeCount,
+  archivedDocs,
+  attentionCount,
   claudeDeepLink,
   continuePrompt,
   groupBoardSpecs,
+  groupByOrchState,
   ORCH_STATE_META,
+  orchSummary,
   viewerHref,
 } from "./lib";
 
@@ -151,5 +156,54 @@ describe("continuePrompt + claudeDeepLink", () => {
     expect(claudeDeepLink(row({ sourceRepo: null }))).toContain(
       "repo=broomva/broomva.tech",
     );
+  });
+});
+
+describe("mission-control grouping (BRO-1402)", () => {
+  const set = [
+    row({ id: "a", state: "published", orchState: "proposed" }),
+    row({ id: "b", state: "published", orchState: "running" }),
+    row({ id: "c", state: "published", orchState: "blocked" }),
+    row({ id: "d", state: "published", orchState: "review" }),
+    row({ id: "e", state: "draft", orchState: "proposed" }),
+    row({ id: "f", state: "archived", orchState: "proposed" }),
+  ];
+
+  test("groupByOrchState: attention-first order, active-only, drops empty", () => {
+    const groups = groupByOrchState(set);
+    expect(groups.map((g) => g.state)).toEqual([
+      "blocked",
+      "review",
+      "running",
+      "proposed",
+    ]);
+    // archived 'f' is NOT folded into proposed — only active a + e
+    expect(
+      groups
+        .find((g) => g.state === "proposed")
+        ?.docs.map((x) => x.id)
+        .sort(),
+    ).toEqual(["a", "e"]);
+  });
+
+  test("orchSummary: per-state counts, attention-ordered, non-zero only", () => {
+    expect(orchSummary(set).map((s) => [s.state, s.count])).toEqual([
+      ["blocked", 1],
+      ["review", 1],
+      ["running", 1],
+      ["proposed", 2],
+    ]);
+  });
+
+  test("attentionCount: blocked + review among active only", () => {
+    expect(attentionCount(set)).toBe(2);
+    expect(
+      attentionCount([row({ state: "archived", orchState: "blocked" })]),
+    ).toBe(0);
+  });
+
+  test("activeCount excludes archived; archivedDocs returns only archived", () => {
+    expect(activeCount(set)).toBe(5);
+    expect(archivedDocs(set).map((x) => x.id)).toEqual(["f"]);
   });
 });

--- a/apps/broomva/app/maestro/lib.ts
+++ b/apps/broomva/app/maestro/lib.ts
@@ -133,3 +133,80 @@ export function claudeDeepLink(doc: ContinuableDoc): string {
   const repo = doc.sourceRepo ?? DEFAULT_REPO;
   return `claude-cli://open?repo=${repo}&q=${encodeURIComponent(continuePrompt(doc))}`;
 }
+
+// ── Mission-control view (BRO-1402): group by ORCH-state, attention-first ─────
+
+/** Attention-first order for the orchestration view (needs-you → active → backlog → terminal). */
+export const ORCH_GROUP_ORDER: SpecDocOrchState[] = [
+  "blocked",
+  "review",
+  "running",
+  "triggered",
+  "reviewing",
+  "proposed",
+  "done",
+  "canceled",
+];
+
+/** Orch-states that need the human (surfaced first; drive the "needs attention" headline). */
+export const ATTENTION_STATES: SpecDocOrchState[] = ["blocked", "review"];
+
+/** Active (non-archived) docs — the ones in the orchestration flow. */
+function activeDocs(docs: SpecDocSummary[]): SpecDocSummary[] {
+  return docs.filter((d) => d.state === "published" || d.state === "draft");
+}
+
+export interface OrchGroup {
+  state: SpecDocOrchState;
+  label: string;
+  tone: OrchTone;
+  docs: SpecDocSummary[];
+}
+
+/**
+ * Group ACTIVE docs by orch-state, attention-first (ORCH_GROUP_ORDER), dropping
+ * empty groups. Archived docs are excluded (a manage concern — see archivedDocs).
+ */
+export function groupByOrchState(docs: SpecDocSummary[]): OrchGroup[] {
+  const active = activeDocs(docs);
+  return ORCH_GROUP_ORDER.map((state) => ({
+    state,
+    label: ORCH_STATE_META[state].label,
+    tone: ORCH_STATE_META[state].tone,
+    docs: active.filter((d) => d.orchState === state),
+  })).filter((g) => g.docs.length > 0);
+}
+
+export interface OrchSummaryItem {
+  state: SpecDocOrchState;
+  label: string;
+  tone: OrchTone;
+  count: number;
+}
+
+/** Per-orch-state counts (active docs), attention-ordered, non-zero only — the triage strip. */
+export function orchSummary(docs: SpecDocSummary[]): OrchSummaryItem[] {
+  const active = activeDocs(docs);
+  return ORCH_GROUP_ORDER.map((state) => ({
+    state,
+    label: ORCH_STATE_META[state].label,
+    tone: ORCH_STATE_META[state].tone,
+    count: active.filter((d) => d.orchState === state).length,
+  })).filter((s) => s.count > 0);
+}
+
+/** Count of active docs needing the human (blocked + review) — the headline. */
+export function attentionCount(docs: SpecDocSummary[]): number {
+  return activeDocs(docs).filter((d) => ATTENTION_STATES.includes(d.orchState))
+    .length;
+}
+
+/** Total active (non-archived) docs. */
+export function activeCount(docs: SpecDocSummary[]): number {
+  return activeDocs(docs).length;
+}
+
+/** Archived docs (the collapsed manage section, off the control view). */
+export function archivedDocs(docs: SpecDocSummary[]): SpecDocSummary[] {
+  return docs.filter((d) => d.state === "archived");
+}

--- a/apps/broomva/app/maestro/maestro-board.tsx
+++ b/apps/broomva/app/maestro/maestro-board.tsx
@@ -12,20 +12,24 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import type { SpecDocOrchState } from "@/lib/db/schema";
 import type { SpecDocSummary } from "@/lib/db/spec-doc-queries";
 import {
+  activeCount,
+  archivedDocs,
+  attentionCount,
   claudeDeepLink,
   continuePrompt,
-  groupBoardSpecs,
-  ORCH_STATE_META,
+  groupByOrchState,
   type OrchTone,
+  orchSummary,
   viewerHref,
 } from "./lib";
 
 const dateFmt = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
 
-// Orchestration-state pill tones → Arcan Glass tokens (BRO-1336). The board is
-// grouped by content-state, so the per-card pill shows ORCH-state only.
+// Orchestration-state tones → Arcan Glass tokens (BRO-1336). Used by the group
+// headers and the triage filter chips.
 const ORCH_TONE_CLASS: Record<OrchTone, string> = {
   muted: "border-muted-foreground/30 text-muted-foreground",
   active: "border-[color:var(--ag-ai-blue)]/40 text-[color:var(--ag-ai-blue)]",
@@ -40,14 +44,26 @@ const SECONDARY_BTN =
   "rounded-md px-2.5 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50";
 const PRIMARY_BTN =
   "rounded-md border border-[color:var(--ag-ai-blue)]/40 px-2.5 py-1 text-[color:var(--ag-ai-blue)] text-xs transition-colors hover:bg-[color:var(--ag-ai-blue)]/10 disabled:opacity-50";
+const CARD =
+  "rounded-xl border border-border/60 bg-bg-surface/40 px-4 py-3 transition-colors hover:border-[color:var(--ag-ai-blue)]/30";
+
+function chipClass(selected: boolean, tone?: OrchTone): string {
+  const base = "rounded-full border px-2.5 py-1 text-xs transition-colors";
+  if (selected) {
+    return `${base} border-[color:var(--ag-ai-blue)]/50 bg-[color:var(--ag-ai-blue)]/10 text-foreground`;
+  }
+  return `${base} ${
+    tone ? ORCH_TONE_CLASS[tone] : "border-border/60 text-muted-foreground"
+  } hover:bg-muted/50`;
+}
 
 /**
- * The Maestro board (BRO-1349) — client island over the owner's specs, grouped
- * by content-state. Mobile-first card layout (BRO-1400): each spec is a card
- * that stacks title / meta / actions vertically so nothing collides on a phone
- * (the Omnara webview); secondary actions live in a ⋯ overflow menu. Wires
- * Continue/Copy (BRO-1399), Trigger (BRO-1393), and archive/restore/delete to
- * the owner-scoped endpoints, refreshing the server component on success.
+ * The Maestro board (BRO-1349) — the spec orchestration control surface. Grouped
+ * by ORCH-state, attention-first (BRO-1402): a triage header surfaces what needs
+ * the human, a filter strip narrows by state, and specs flow Blocked → Review →
+ * Running → … → Done. Archived specs collapse into a manage section. Cards are
+ * mobile-first (BRO-1400) and wire Continue/Copy (BRO-1399), Trigger (BRO-1393),
+ * and archive/restore/delete to the owner-scoped endpoints.
  */
 export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
   const router = useRouter();
@@ -55,7 +71,13 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
-  const groups = groupBoardSpecs(docs);
+  const [filter, setFilter] = useState<SpecDocOrchState | null>(null);
+
+  const groups = groupByOrchState(docs);
+  const summary = orchSummary(docs);
+  const attention = attentionCount(docs);
+  const active = activeCount(docs);
+  const archived = archivedDocs(docs);
 
   async function mutate(id: string, init: RequestInit, suffix = "") {
     setPendingId(id);
@@ -91,14 +113,13 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
     try {
       await navigator.clipboard.writeText(continuePrompt(d));
       setCopiedId(d.id);
-      // Guard the reset so a later copy on another row isn't cleared early.
       setTimeout(() => setCopiedId((cur) => (cur === d.id ? null : cur)), 1500);
     } catch {
       setError("Clipboard unavailable — open the spec and copy manually.");
     }
   }
 
-  if (groups.length === 0) {
+  if (active === 0 && archived.length === 0) {
     return (
       <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground text-sm">
         No specs yet. Publish one with{" "}
@@ -110,168 +131,216 @@ export function MaestroBoard({ docs }: { docs: SpecDocSummary[] }) {
     );
   }
 
+  const visibleGroups = filter
+    ? groups.filter((g) => g.state === filter)
+    : groups;
+
+  const renderCard = (d: SpecDocSummary) => {
+    const href = viewerHref(d) as Route;
+    const ref = d.handle ?? d.id;
+    const busy = pendingId === d.id;
+    const triggerable =
+      d.orchState === "proposed" || d.orchState === "reviewing";
+    return (
+      <div key={d.id} className={CARD}>
+        <div className="flex items-start gap-2">
+          <Link
+            href={href}
+            className="min-w-0 flex-1 truncate font-medium text-sm leading-6 hover:underline"
+          >
+            {d.title}
+          </Link>
+          {d.state === "draft" ? (
+            <span className="mt-0.5 shrink-0 rounded-full border border-[color:var(--ag-warning)]/40 px-1.5 py-0.5 text-[10px] text-[color:var(--ag-warning)] uppercase tracking-wide">
+              draft
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-xs">
+          <code className="rounded bg-muted px-1 py-0.5">{ref}</code>
+          {d.version > 1 ? <span>v{d.version}</span> : null}
+          {d.sourcePath ? (
+            <span className="max-w-[60%] truncate">{d.sourcePath}</span>
+          ) : null}
+          {d.ticketId ? <span>{d.ticketId}</span> : null}
+          <span>{dateFmt.format(d.createdAt)}</span>
+        </div>
+
+        {confirmId === d.id ? (
+          <div className="mt-3 flex items-center gap-2">
+            <span className="flex-1 text-destructive text-xs">
+              Delete this spec?
+            </span>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => mutate(d.id, { method: "DELETE" })}
+              className="rounded-md bg-destructive/10 px-2.5 py-1 text-destructive text-xs transition-colors hover:bg-destructive/20 disabled:opacity-50"
+            >
+              Delete
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => setConfirmId(null)}
+              className={SECONDARY_BTN}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <div className="mt-3 flex items-center gap-1.5">
+            <a
+              href={claudeDeepLink(d)}
+              title="Open Claude Code in the repo with a continue-prompt pre-filled"
+              className={PRIMARY_BTN}
+            >
+              Continue
+            </a>
+            <button
+              type="button"
+              onClick={() => copyPrompt(d)}
+              title="Copy the continue-prompt — paste into a new Omnara session from your phone"
+              className={SECONDARY_BTN}
+            >
+              {copiedId === d.id ? "Copied" : "Copy"}
+            </button>
+            {triggerable ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => mutate(d.id, { method: "POST" }, "/trigger")}
+                title="Dispatch this spec (orch_state → triggered)"
+                className={PRIMARY_BTN}
+              >
+                Trigger
+              </button>
+            ) : null}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="More actions"
+                  className="ml-auto rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <MoreHorizontal className="size-4" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem asChild>
+                  <Link href={href}>Open spec</Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  disabled={busy}
+                  onClick={() =>
+                    mutate(
+                      d.id,
+                      patch(d.state === "archived" ? "restore" : "archive"),
+                    )
+                  }
+                >
+                  {d.state === "archived" ? "Restore" : "Archive"}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  disabled={busy}
+                  onClick={() => setConfirmId(d.id)}
+                  className="text-destructive focus:text-destructive"
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        )}
+      </div>
+    );
+  };
+
   return (
-    <div className="space-y-7">
+    <div className="space-y-6">
       {error ? (
         <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive text-xs">
           {error}
         </div>
       ) : null}
-      {groups.map((group) => (
-        <section key={group.state}>
-          <div className="mb-2.5 flex items-baseline gap-2">
-            <h2 className="font-semibold text-sm uppercase tracking-wide">
-              {group.label}
-            </h2>
-            <span className="text-muted-foreground text-xs">
-              {group.docs.length}
-            </span>
-            <span className="hidden text-muted-foreground text-xs sm:inline">
-              · {group.hint}
-            </span>
-          </div>
-          <div className="space-y-2.5">
-            {group.docs.map((d) => {
-              const href = viewerHref(d) as Route;
-              const ref = d.handle ?? d.id;
-              const busy = pendingId === d.id;
-              const orch = ORCH_STATE_META[d.orchState];
-              const triggerable =
-                d.orchState === "proposed" || d.orchState === "reviewing";
-              return (
-                <div
-                  key={d.id}
-                  className="rounded-xl border border-border/60 bg-bg-surface/40 px-4 py-3 transition-colors hover:border-[color:var(--ag-ai-blue)]/30"
-                >
-                  {/* Title + orch-state */}
-                  <div className="flex items-start gap-2">
-                    <Link
-                      href={href}
-                      className="min-w-0 flex-1 truncate font-medium text-sm leading-6 hover:underline"
-                    >
-                      {d.title}
-                    </Link>
-                    <span
-                      title="Orchestration state"
-                      className={`mt-0.5 shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${ORCH_TONE_CLASS[orch.tone]}`}
-                    >
-                      {orch.label}
-                    </span>
-                  </div>
 
-                  {/* Meta */}
-                  <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground text-xs">
-                    <code className="rounded bg-muted px-1 py-0.5">{ref}</code>
-                    {d.version > 1 ? <span>v{d.version}</span> : null}
-                    {d.sourcePath ? (
-                      <span className="max-w-[60%] truncate">
-                        {d.sourcePath}
-                      </span>
-                    ) : null}
-                    {d.ticketId ? <span>{d.ticketId}</span> : null}
-                    <span>{dateFmt.format(d.createdAt)}</span>
-                  </div>
-
-                  {/* Actions */}
-                  {confirmId === d.id ? (
-                    <div className="mt-3 flex items-center gap-2">
-                      <span className="flex-1 text-destructive text-xs">
-                        Delete this spec?
-                      </span>
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => mutate(d.id, { method: "DELETE" })}
-                        className="rounded-md bg-destructive/10 px-2.5 py-1 text-destructive text-xs transition-colors hover:bg-destructive/20 disabled:opacity-50"
-                      >
-                        Delete
-                      </button>
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() => setConfirmId(null)}
-                        className={SECONDARY_BTN}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="mt-3 flex items-center gap-1.5">
-                      <a
-                        href={claudeDeepLink(d)}
-                        title="Open Claude Code in the repo with a continue-prompt pre-filled"
-                        className={PRIMARY_BTN}
-                      >
-                        Continue
-                      </a>
-                      <button
-                        type="button"
-                        onClick={() => copyPrompt(d)}
-                        title="Copy the continue-prompt — paste into a new Omnara session from your phone"
-                        className={SECONDARY_BTN}
-                      >
-                        {copiedId === d.id ? "Copied" : "Copy"}
-                      </button>
-                      {triggerable ? (
-                        <button
-                          type="button"
-                          disabled={busy}
-                          onClick={() =>
-                            mutate(d.id, { method: "POST" }, "/trigger")
-                          }
-                          title="Dispatch this spec (orch_state → triggered)"
-                          className={PRIMARY_BTN}
-                        >
-                          Trigger
-                        </button>
-                      ) : null}
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            aria-label="More actions"
-                            className="ml-auto rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                          >
-                            <MoreHorizontal className="size-4" />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem asChild>
-                            <Link href={href}>Open spec</Link>
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            disabled={busy}
-                            onClick={() =>
-                              mutate(
-                                d.id,
-                                patch(
-                                  d.state === "archived"
-                                    ? "restore"
-                                    : "archive",
-                                ),
-                              )
-                            }
-                          >
-                            {d.state === "archived" ? "Restore" : "Archive"}
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem
-                            disabled={busy}
-                            onClick={() => setConfirmId(d.id)}
-                            className="text-destructive focus:text-destructive"
-                          >
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+      {/* Triage header */}
+      <div className={CARD}>
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          {attention > 0 ? (
+            <span className="font-medium text-[color:var(--ag-warning)] text-sm">
+              {attention} {attention === 1 ? "spec needs" : "specs need"} your
+              attention
+            </span>
+          ) : (
+            <span className="font-medium text-[color:var(--ag-success)] text-sm">
+              All clear
+            </span>
+          )}
+          <span className="text-muted-foreground text-xs">
+            · {active} active
+            {archived.length > 0 ? ` · ${archived.length} archived` : ""}
+          </span>
+        </div>
+        {summary.length > 1 || filter ? (
+          <div className="mt-2.5 flex flex-wrap gap-1.5">
+            <button
+              type="button"
+              onClick={() => setFilter(null)}
+              className={chipClass(filter === null)}
+            >
+              All
+            </button>
+            {summary.map((s) => (
+              <button
+                key={s.state}
+                type="button"
+                onClick={() => setFilter(filter === s.state ? null : s.state)}
+                className={chipClass(filter === s.state, s.tone)}
+              >
+                {s.label} <span className="opacity-60">{s.count}</span>
+              </button>
+            ))}
           </div>
-        </section>
-      ))}
+        ) : null}
+      </div>
+
+      {/* Orch-state groups (attention-first) */}
+      {visibleGroups.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-6 text-center text-muted-foreground text-sm">
+          No specs in this state.
+        </div>
+      ) : (
+        visibleGroups.map((group) => (
+          <section key={group.state}>
+            <div className="mb-2 flex items-center gap-2">
+              <span
+                className={`rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide ${ORCH_TONE_CLASS[group.tone]}`}
+              >
+                {group.label}
+              </span>
+              <span className="text-muted-foreground text-xs">
+                {group.docs.length}
+              </span>
+            </div>
+            <div className="space-y-2.5">{group.docs.map(renderCard)}</div>
+          </section>
+        ))
+      )}
+
+      {/* Archived — collapsed manage section, off the control view */}
+      {archived.length > 0 && !filter ? (
+        <details className="rounded-xl border border-border/60 bg-bg-surface/20">
+          <summary className="cursor-pointer select-none px-4 py-2.5 text-muted-foreground text-sm">
+            Archived · {archived.length}
+          </summary>
+          <div className="space-y-2.5 px-3 pb-3">
+            {archived.map(renderCard)}
+          </div>
+        </details>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What
Re-presents `/maestro` as a **control surface** for the orchestration job, instead of a content-state list with a uniform button bar. (User picked "mission-control" after questioning whether a tabular list is the right idea.)

Closes BRO-1402. Builds on the responsive cards from #228.

## The reframe
Maestro has two orthogonal axes: **content-state** (draft/published/archived — *manage*) ⊥ **orch-state** (proposed→running→review→done — *orchestrate*). The board's flagship job is orchestration, so it should group on the **orch axis** and surface what needs attention — which is what `/d/maestro` v3 §7 specifies.

## Changes (frontend-only)
- **Triage header** — `"N specs need your attention"` (blocked + review) / `"All clear"`, + a tappable **orch-state filter strip** (count per state, attention-ordered).
- **Group by orch-state, attention-first** — Blocked → Review → Running → Triggered → Reviewing → Proposed → Done → Canceled. Tapping a chip filters to that group.
- **Archived** → a collapsed `<details>` manage section, off the control view.
- Drops the redundant per-card orch pill (the group header carries it); adds a subtle `draft` tag.
- `lib.ts`: `groupByOrchState` · `orchSummary` · `attentionCount` · `activeCount` · `archivedDocs` — pure, **+4 vitest (17 total)**.

## Test plan
- ✅ Biome · tsc clean · vitest **17/17** · local build (running)
- ⏳ deploy-verify on the **Omnara phone** (the real target)

P20: single-component UI + pure helpers (no API/migration); CodeRabbit + build + visual phone check are the gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)