### PR TITLE
feat(maestro): handoff queue — push /handoff docs, relate to specs, realtime stream + analytics [BRO-1415]

### DIFF
--- a/apps/broomva/app/api/handoffs/[id]/route.ts
+++ b/apps/broomva/app/api/handoffs/[id]/route.ts
@@ -1,0 +1,89 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  getHandoffForOwner,
+  isHandoffAction,
+  softDeleteHandoff,
+  transitionHandoff,
+} from "@/lib/db/handoff-queries";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+
+/**
+ * /api/handoffs/[id] — metadata / queue transition / soft-delete a single owned
+ * handoff. Owner-scoped: a handoff owned by a different user (or missing)
+ * returns 404, so callers cannot probe for existence.
+ */
+
+/** GET — full handoff (includes markdown body) for one owned row. */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const row = await getHandoffForOwner(id, auth.userId);
+  if (!row) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(row);
+}
+
+/**
+ * PATCH — queue transition by id:
+ * `{ action: "pick_up" | "complete" | "archive" | "requeue" }`.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const action = (body as { action?: unknown })?.action;
+  if (!isHandoffAction(action)) {
+    return NextResponse.json(
+      {
+        error: "action must be 'pick_up', 'complete', 'archive', or 'requeue'",
+      },
+      { status: 400 },
+    );
+  }
+  const { id } = await params;
+  const nextStatus = await transitionHandoff(
+    id,
+    auth.userId,
+    action,
+    auth.agentId ? "agent" : "web",
+  );
+  if (!nextStatus) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true, status: nextStatus });
+}
+
+/** DELETE — soft-delete one owned handoff (sets deletedAt). */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const ok = await softDeleteHandoff(id, auth.userId);
+  if (!ok) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/apps/broomva/app/api/handoffs/events/route.ts
+++ b/apps/broomva/app/api/handoffs/events/route.ts
@@ -1,0 +1,127 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { listHandoffEvents } from "@/lib/db/handoff-queries";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+
+/**
+ * GET /api/handoffs/events — Server-Sent Events stream powering the realtime
+ * timeline card on /maestro/queue (BRO-1415). Tails the owner's HandoffEvent
+ * log: on connect it streams nothing historical (the page is server-rendered
+ * with the current timeline), then pushes each NEW event as it lands.
+ *
+ * The client passes `?since=<ISO>` — the createdAt of the newest event it has —
+ * so no event is missed between SSR and the EventSource connecting. The stream
+ * self-closes after ~55s; EventSource auto-reconnects with an updated cursor,
+ * which keeps us within serverless function-duration limits.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Poll cadence + hard lifetime — re-tuned together (lifetime ≫ serverless cap). */
+const POLL_MS = 2500;
+const MAX_LIFETIME_MS = 55_000;
+
+export async function GET(request: NextRequest) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const ownerId = auth.userId;
+
+  const sinceParam = request.nextUrl.searchParams.get("since");
+  const parsedSince = sinceParam ? new Date(sinceParam) : null;
+  let cursor =
+    parsedSince && !Number.isNaN(parsedSince.getTime())
+      ? parsedSince
+      : new Date();
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let closed = false;
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      };
+
+      const send = (event: string, data: unknown) => {
+        if (closed) return;
+        controller.enqueue(
+          encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+        );
+      };
+
+      // Abort when the client disconnects.
+      request.signal.addEventListener("abort", close);
+
+      send("ready", { since: cursor.toISOString() });
+
+      const startedAt = Date.now();
+      try {
+        while (!closed && Date.now() - startedAt < MAX_LIFETIME_MS) {
+          const events = await listHandoffEvents(ownerId, { since: cursor });
+          if (events.length > 0) {
+            // listHandoffEvents returns newest-first; emit oldest-first so the
+            // client appends in chronological order.
+            for (const ev of events.slice().reverse()) {
+              send("handoff", {
+                id: ev.id,
+                handoffId: ev.handoffId,
+                type: ev.type,
+                actor: ev.actor,
+                message: ev.message,
+                metadata: ev.metadata,
+                createdAt: ev.createdAt,
+              });
+            }
+            const newest = events[0];
+            if (newest) cursor = new Date(newest.createdAt);
+          } else {
+            // Heartbeat comment keeps proxies from buffering / timing out.
+            if (!closed) controller.enqueue(encoder.encode(": ping\n\n"));
+          }
+          await sleep(POLL_MS, request.signal);
+        }
+      } catch {
+        // DB hiccup or aborted wait — end the stream; client reconnects.
+      } finally {
+        send("bye", { reconnect: true });
+        close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+      "x-accel-buffering": "no",
+    },
+  });
+}
+
+/** Promise that resolves after `ms`, or rejects early if the signal aborts. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/apps/broomva/app/api/handoffs/events/route.ts
+++ b/apps/broomva/app/api/handoffs/events/route.ts
@@ -11,15 +11,19 @@ import { resolveAuth } from "@/lib/prompts/resolve-auth";
  *
  * The client passes `?since=<ISO>` — the createdAt of the newest event it has —
  * so no event is missed between SSR and the EventSource connecting. The stream
- * self-closes after ~55s; EventSource auto-reconnects with an updated cursor,
- * which keeps us within serverless function-duration limits.
+ * self-closes after ~55s; the client reconnects with an updated cursor, which
+ * keeps us within serverless function-duration limits.
+ *
+ * No `runtime`/`dynamic` route-segment config: this app runs with
+ * `cacheComponents`, which forbids those exports. Reading `request` (auth
+ * headers + `?since`) already makes the handler dynamic, and the default
+ * runtime is Node.js (required for the DB tail).
  */
-export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
 
-/** Poll cadence + hard lifetime — re-tuned together (lifetime ≫ serverless cap). */
+/** Poll cadence + hard lifetime + per-tick batch (lifetime ≫ serverless cap). */
 const POLL_MS = 2500;
 const MAX_LIFETIME_MS = 55_000;
+const BATCH_LIMIT = 100;
 
 export async function GET(request: NextRequest) {
   const auth = await resolveAuth(request);
@@ -36,6 +40,7 @@ export async function GET(request: NextRequest) {
       : new Date();
 
   const encoder = new TextEncoder();
+  const signal = request.signal;
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -49,6 +54,8 @@ export async function GET(request: NextRequest) {
           // already closed
         }
       };
+      // Abort when the client disconnects.
+      signal.addEventListener("abort", close);
 
       const send = (event: string, data: unknown) => {
         if (closed) return;
@@ -57,16 +64,20 @@ export async function GET(request: NextRequest) {
         );
       };
 
-      // Abort when the client disconnects.
-      request.signal.addEventListener("abort", close);
-
       send("ready", { since: cursor.toISOString() });
 
       const startedAt = Date.now();
       try {
         while (!closed && Date.now() - startedAt < MAX_LIFETIME_MS) {
-          const events = await listHandoffEvents(ownerId, { since: cursor });
-          if (events.length > 0) {
+          // Drain forward in batches so a burst of > BATCH_LIMIT events between
+          // polls is never skipped (a naïve jump-to-newest would lose the tail).
+          let emitted = 0;
+          for (;;) {
+            const events = await listHandoffEvents(ownerId, {
+              since: cursor,
+              limit: BATCH_LIMIT,
+            });
+            if (events.length === 0) break;
             // listHandoffEvents returns newest-first; emit oldest-first so the
             // client appends in chronological order.
             for (const ev of events.slice().reverse()) {
@@ -79,19 +90,23 @@ export async function GET(request: NextRequest) {
                 metadata: ev.metadata,
                 createdAt: ev.createdAt,
               });
+              emitted++;
             }
             const newest = events[0];
             if (newest) cursor = new Date(newest.createdAt);
-          } else {
-            // Heartbeat comment keeps proxies from buffering / timing out.
-            if (!closed) controller.enqueue(encoder.encode(": ping\n\n"));
+            if (events.length < BATCH_LIMIT || closed) break;
           }
-          await sleep(POLL_MS, request.signal);
+          // Heartbeat comment keeps proxies from buffering / timing out.
+          if (emitted === 0 && !closed) {
+            controller.enqueue(encoder.encode(": ping\n\n"));
+          }
+          await sleep(POLL_MS, signal);
         }
       } catch {
         // DB hiccup or aborted wait — end the stream; client reconnects.
       } finally {
         send("bye", { reconnect: true });
+        signal.removeEventListener("abort", close);
         close();
       }
     },

--- a/apps/broomva/app/api/handoffs/route.ts
+++ b/apps/broomva/app/api/handoffs/route.ts
@@ -1,0 +1,136 @@
+import { nanoid } from "nanoid";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { listQueueHandoffs, pushHandoff } from "@/lib/db/handoff-queries";
+import { env } from "@/lib/env";
+import { resolveAuth } from "@/lib/prompts/resolve-auth";
+
+/**
+ * /api/handoffs — push + list handoff-queue entries (BRO-1415). A handoff is
+ * the human-readable narrative the `/handoff` skill writes; pushing it makes it
+ * visible at /maestro/queue, related to specs, and runnable via Copy/Continue.
+ *
+ * Owner is the authenticated identity (CLI Bearer token's `sub` OR browser
+ * session `user.id`, resolved by resolveAuth). Owner-gated; nothing hardcoded.
+ */
+
+/** 1 MB cap on the markdown body — generous for a narrative handoff. */
+const MAX_BODY_BYTES = 1_000_000;
+
+const pushSchema = z.object({
+  title: z.string().trim().min(1).max(300).optional(),
+  body: z.string().min(1).max(MAX_BODY_BYTES),
+  /** Stable arc identity; re-pushing the same slug appends a version. */
+  slug: z.string().trim().min(1).max(128).optional(),
+  /** One-sentence queue headline. */
+  tldr: z.string().trim().max(600).optional(),
+  /** The Copy-button payload (continue-prompt / first action). */
+  firstAction: z.string().trim().max(4000).optional(),
+  /** Related spec handles (the HTML specs at /d/<handle>). */
+  specRefs: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
+  /** Queue ordering hint — higher floats up. */
+  priority: z.number().int().min(-100).max(100).optional(),
+  source: z
+    .object({
+      repo: z.string().max(500).optional(),
+      path: z.string().max(1000).optional(),
+      commit: z.string().max(64).optional(),
+      branch: z.string().max(300).optional(),
+      ticket: z.string().max(64).optional(),
+      pr: z.number().int().optional(),
+      session: z.string().max(128).optional(),
+    })
+    .optional(),
+});
+
+/** Canonical queue URL. The queue is a single board, not per-handoff routes. */
+function queueUrl(request: NextRequest): string {
+  const base = (env.APP_URL || new URL(request.url).origin).replace(/\/+$/, "");
+  return `${base}/maestro/queue`;
+}
+
+/** Best-effort title from the first markdown `# ` heading. */
+function deriveTitle(body: string): string {
+  const h1 = body.match(/^#\s+(.+)$/m);
+  if (h1?.[1]?.trim()) return h1[1].trim().slice(0, 300);
+  const firstLine = body.split("\n").find((l) => l.trim().length > 0);
+  return firstLine?.trim().slice(0, 300) || "Untitled handoff";
+}
+
+/** Best-effort TL;DR from a `**TL;DR.**` / `**TL;DR:**` lead line. */
+function deriveTldr(body: string): string | undefined {
+  const m = body.match(/\*\*TL;DR[.:]?\*\*\s*(.+)/i);
+  const text = m?.[1]?.replace(/\s+/g, " ").trim();
+  return text ? text.slice(0, 600) : undefined;
+}
+
+/** POST /api/handoffs — push a handoff onto the queue. Returns the queue URL. */
+export async function POST(request: NextRequest) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  const parsed = pushSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const id = nanoid(12);
+  const title = parsed.data.title?.trim() || deriveTitle(parsed.data.body);
+  const tldr = parsed.data.tldr?.trim() || deriveTldr(parsed.data.body) || null;
+
+  const row = await pushHandoff({
+    id,
+    ownerId: auth.userId,
+    title,
+    body: parsed.data.body,
+    slug: parsed.data.slug ?? null,
+    tldr,
+    firstAction: parsed.data.firstAction ?? null,
+    specRefs: parsed.data.specRefs ?? [],
+    priority: parsed.data.priority ?? 0,
+    sourceRepo: parsed.data.source?.repo ?? null,
+    sourcePath: parsed.data.source?.path ?? null,
+    sourceCommit: parsed.data.source?.commit ?? null,
+    branch: parsed.data.source?.branch ?? null,
+    ticketId: parsed.data.source?.ticket ?? null,
+    prNumber: parsed.data.source?.pr ?? null,
+    sessionId: parsed.data.source?.session ?? null,
+    actor: auth.agentId ? "agent" : "cli",
+  });
+
+  return NextResponse.json(
+    {
+      id: row.id,
+      slug: row.slug,
+      version: row.version,
+      status: row.status,
+      title: row.title,
+      specRefs: row.specRefs,
+      url: queueUrl(request),
+      createdAt: row.createdAt,
+    },
+    { status: 201 },
+  );
+}
+
+/** GET /api/handoffs — list the owner's active queue (metadata only). */
+export async function GET(request: NextRequest) {
+  const auth = await resolveAuth(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const rows = await listQueueHandoffs(auth.userId);
+  return NextResponse.json(rows);
+}

--- a/apps/broomva/app/maestro/analytics/lib.test.ts
+++ b/apps/broomva/app/maestro/analytics/lib.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildThroughputChart,
+  type DailyBucket,
+  niceMax,
+  shortDate,
+  statusSegments,
+} from "./lib";
+
+describe("niceMax", () => {
+  test("rounds up to nice axis bounds", () => {
+    expect(niceMax(0)).toBe(1);
+    expect(niceMax(1)).toBe(1);
+    expect(niceMax(3)).toBe(5);
+    expect(niceMax(7)).toBe(10);
+    expect(niceMax(12)).toBe(20);
+    expect(niceMax(23)).toBe(25);
+  });
+});
+
+describe("shortDate", () => {
+  test("strips leading zeros", () => {
+    expect(shortDate("2026-06-05")).toBe("6/5");
+    expect(shortDate("2026-12-31")).toBe("12/31");
+  });
+});
+
+describe("buildThroughputChart", () => {
+  const daily: DailyBucket[] = [
+    { date: "2026-06-03", pushed: 0, completed: 0 },
+    { date: "2026-06-04", pushed: 4, completed: 2 },
+    { date: "2026-06-05", pushed: 2, completed: 3 },
+  ];
+
+  test("computes a nice yMax from the series peak", () => {
+    expect(buildThroughputChart(daily).yMax).toBe(5);
+  });
+
+  test("emits two series with non-empty line + area paths", () => {
+    const chart = buildThroughputChart(daily);
+    expect(chart.series.map((s) => s.key)).toEqual(["pushed", "completed"]);
+    for (const s of chart.series) {
+      expect(s.line.startsWith("M")).toBe(true);
+      expect(s.area.endsWith("Z")).toBe(true);
+    }
+  });
+
+  test("handles an all-zero series without NaN", () => {
+    const flat = buildThroughputChart([
+      { date: "2026-06-05", pushed: 0, completed: 0 },
+    ]);
+    expect(flat.yMax).toBe(1);
+    expect(flat.series[0]?.line).not.toContain("NaN");
+  });
+});
+
+describe("statusSegments", () => {
+  test("computes proportional widths and drops zero counts", () => {
+    const segs = statusSegments([
+      { status: "queued", label: "Queued", count: 3 },
+      { status: "done", label: "Done", count: 1 },
+      { status: "archived", label: "Archived", count: 0 },
+    ]);
+    expect(segs.map((s) => s.status)).toEqual(["queued", "done"]);
+    expect(segs[0]?.pct).toBe(75);
+    expect(segs[1]?.pct).toBe(25);
+  });
+
+  test("returns empty when total is zero", () => {
+    expect(
+      statusSegments([{ status: "queued", label: "Queued", count: 0 }]),
+    ).toEqual([]);
+  });
+});

--- a/apps/broomva/app/maestro/analytics/lib.ts
+++ b/apps/broomva/app/maestro/analytics/lib.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure chart geometry for /maestro/analytics (BRO-1415). The analytics page is
+ * a server component rendering crisp inline SVG (no client charting lib), so
+ * the geometry math lives here — pure + unit-tested, decoupled from React.
+ */
+
+export interface DailyBucket {
+  date: string;
+  pushed: number;
+  completed: number;
+}
+
+export interface ChartSeries {
+  key: string;
+  /** SVG `d` for the connecting line. */
+  line: string;
+  /** SVG `d` for the filled area under the line. */
+  area: string;
+  /** Last point (for the leading marker dot). */
+  lastX: number;
+  lastY: number;
+}
+
+export interface ThroughputChart {
+  width: number;
+  height: number;
+  yMax: number;
+  baselineY: number;
+  yTicks: Array<{ value: number; y: number }>;
+  xTicks: Array<{ label: string; x: number }>;
+  series: ChartSeries[];
+}
+
+/** Round a max value up to a "nice" axis bound (1/2/2.5/5 × 10ⁿ). */
+export function niceMax(value: number): number {
+  if (value <= 1) return 1;
+  const pow = 10 ** Math.floor(Math.log10(value));
+  for (const f of [1, 2, 2.5, 5, 10]) {
+    const candidate = f * pow;
+    if (value <= candidate) return candidate;
+  }
+  return 10 * pow;
+}
+
+/** "2026-06-05" → "6/5" (no leading zeros), for compact x-axis labels. */
+export function shortDate(iso: string): string {
+  const [, m, d] = iso.split("-");
+  if (!m || !d) return iso;
+  return `${Number(m)}/${Number(d)}`;
+}
+
+const WIDTH = 680;
+const HEIGHT = 190;
+const PAD_L = 26;
+const PAD_R = 10;
+const PAD_T = 12;
+const PAD_B = 22;
+
+/**
+ * Build the throughput chart geometry: two series (pushed, completed) over the
+ * daily buckets. Returns line + area paths plus axis ticks. Coordinates are in
+ * a fixed 680×190 viewBox; the SVG scales responsively via width="100%".
+ */
+export function buildThroughputChart(daily: DailyBucket[]): ThroughputChart {
+  const innerW = WIDTH - PAD_L - PAD_R;
+  const innerH = HEIGHT - PAD_T - PAD_B;
+  const baselineY = PAD_T + innerH;
+  const n = daily.length;
+
+  const rawMax = daily.reduce((m, d) => Math.max(m, d.pushed, d.completed), 0);
+  const yMax = niceMax(rawMax);
+
+  const xAt = (i: number) =>
+    n <= 1 ? PAD_L + innerW / 2 : PAD_L + (i / (n - 1)) * innerW;
+  const yAt = (v: number) => PAD_T + innerH - (v / yMax) * innerH;
+
+  const buildSeries = (key: "pushed" | "completed"): ChartSeries => {
+    const pts = daily.map((d, i) => [xAt(i), yAt(d[key])] as const);
+    const line = pts
+      .map(([x, y], i) => `${i === 0 ? "M" : "L"}${round(x)} ${round(y)}`)
+      .join(" ");
+    const first = pts[0];
+    const last = pts[pts.length - 1];
+    const area =
+      pts.length > 0 && first && last
+        ? `${line} L${round(last[0])} ${round(baselineY)} L${round(first[0])} ${round(baselineY)} Z`
+        : "";
+    return {
+      key,
+      line,
+      area,
+      lastX: last ? round(last[0]) : 0,
+      lastY: last ? round(last[1]) : baselineY,
+    };
+  };
+
+  const yTicks = [0, yMax / 2, yMax].map((value) => ({
+    value,
+    y: round(yAt(value)),
+  }));
+
+  const step = Math.max(1, Math.ceil(n / 5));
+  const xTicks: Array<{ label: string; x: number }> = [];
+  for (let i = 0; i < n; i += step) {
+    const bucket = daily[i];
+    if (bucket)
+      xTicks.push({ label: shortDate(bucket.date), x: round(xAt(i)) });
+  }
+
+  return {
+    width: WIDTH,
+    height: HEIGHT,
+    yMax,
+    baselineY: round(baselineY),
+    yTicks,
+    xTicks,
+    series: [buildSeries("pushed"), buildSeries("completed")],
+  };
+}
+
+/** A horizontal stacked-proportion bar segment for the status distribution. */
+export interface StatusBarSegment {
+  status: string;
+  label: string;
+  count: number;
+  /** Width as a percentage of the total (0–100). */
+  pct: number;
+}
+
+/**
+ * Proportional segments for the status distribution bar. Zero-count statuses
+ * are dropped; pct sums to ~100 when total > 0.
+ */
+export function statusSegments(
+  counts: Array<{ status: string; label: string; count: number }>,
+): StatusBarSegment[] {
+  const total = counts.reduce((s, c) => s + c.count, 0);
+  if (total === 0) return [];
+  return counts
+    .filter((c) => c.count > 0)
+    .map((c) => ({
+      status: c.status,
+      label: c.label,
+      count: c.count,
+      pct: Math.round((c.count / total) * 1000) / 10,
+    }));
+}
+
+function round(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/apps/broomva/app/maestro/analytics/page.tsx
+++ b/apps/broomva/app/maestro/analytics/page.tsx
@@ -1,0 +1,335 @@
+import type { Route } from "next";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getSafeSession } from "@/lib/auth";
+import { getQueueAnalytics } from "@/lib/db/handoff-queries";
+import type { HandoffStatus } from "@/lib/db/schema";
+import { buildThroughputChart, statusSegments } from "./lib";
+
+export const metadata = {
+  title: "Maestro — queue analytics",
+  robots: { index: false, follow: false },
+};
+
+/** Status → Arcan Glass color var, for the distribution bar + legend. */
+const STATUS_COLOR: Record<HandoffStatus, string> = {
+  queued: "var(--ag-accent-blue)",
+  in_progress: "var(--ag-ai-blue)",
+  done: "var(--ag-success)",
+  archived: "var(--muted-foreground, #8a8f98)",
+  superseded: "var(--ag-error)",
+};
+const STATUS_LABEL: Record<HandoffStatus, string> = {
+  queued: "Queued",
+  in_progress: "In progress",
+  done: "Done",
+  archived: "Archived",
+  superseded: "Superseded",
+};
+
+/** Minutes → compact human duration ("2h 5m", "45m", "3d 2h"). */
+function fmtMinutes(min: number | null): string {
+  if (min == null) return "—";
+  if (min < 1) return "<1m";
+  if (min < 60) return `${Math.round(min)}m`;
+  const hours = Math.floor(min / 60);
+  if (hours < 24) {
+    const rem = Math.round(min % 60);
+    return rem ? `${hours}h ${rem}m` : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  const rem = hours % 24;
+  return rem ? `${days}d ${rem}h` : `${days}d`;
+}
+
+/**
+ * /maestro/analytics — queue analytics (BRO-1415). The /impeccable view over
+ * the handoff queue: KPI tiles, a 14-day throughput chart (pushed vs
+ * completed), pickup latency, status distribution, and spec-linkage density.
+ * Server-rendered crisp inline SVG (no client charting lib). Owner-gated.
+ */
+export default async function MaestroAnalyticsPage() {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  const userId = session?.user?.id;
+  if (!userId) {
+    redirect("/login?next=/maestro/analytics");
+  }
+
+  const a = await getQueueAnalytics(userId);
+  const chart = buildThroughputChart(a.daily);
+  const segments = statusSegments(
+    (Object.keys(a.statusCounts) as HandoffStatus[]).map((status) => ({
+      status,
+      label: STATUS_LABEL[status],
+      count: a.statusCounts[status],
+    })),
+  );
+
+  const kpis: Array<{ label: string; value: string; tone: string }> = [
+    {
+      label: "Queued",
+      value: String(a.statusCounts.queued),
+      tone: "var(--ag-accent-blue)",
+    },
+    {
+      label: "In progress",
+      value: String(a.statusCounts.in_progress),
+      tone: "var(--ag-ai-blue)",
+    },
+    {
+      label: "Done",
+      value: String(a.statusCounts.done),
+      tone: "var(--ag-success)",
+    },
+    {
+      label: "Pushed · 7d",
+      value: String(a.pushed7d),
+      tone: "var(--ag-accent-blue)",
+    },
+    {
+      label: "Completed · 7d",
+      value: String(a.completed7d),
+      tone: "var(--ag-success)",
+    },
+    {
+      label: "Median pickup",
+      value: fmtMinutes(a.medianPickupMinutes),
+      tone: "var(--ag-warning)",
+    },
+    {
+      label: "Specs / handoff",
+      value: a.avgSpecsPerHandoff.toFixed(1),
+      tone: "var(--ag-ai-blue)",
+    },
+    { label: "Total", value: String(a.total), tone: "var(--foreground)" },
+  ];
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 pt-8 pb-28">
+      <header className="mb-6">
+        <div className="flex items-center gap-2">
+          <Link
+            href="/maestro"
+            className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+          >
+            Maestro
+          </Link>
+          <span className="text-muted-foreground/50 text-sm">/</span>
+          <Link
+            href={"/maestro/queue" as Route}
+            className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+          >
+            Queue
+          </Link>
+          <span className="text-muted-foreground/50 text-sm">/</span>
+          <h1 className="font-semibold text-2xl">Analytics</h1>
+        </div>
+        <p className="mt-1 text-muted-foreground text-sm">
+          Throughput, pickup latency, and spec-linkage density across the
+          handoff queue. Last 14 days.
+        </p>
+      </header>
+
+      {/* KPI grid */}
+      <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-4">
+        {kpis.map((k) => (
+          <div
+            key={k.label}
+            className="rounded-xl border border-border/60 bg-bg-surface/40 px-3.5 py-3"
+          >
+            <div
+              className="font-semibold text-2xl tabular-nums"
+              style={{ color: k.tone }}
+            >
+              {k.value}
+            </div>
+            <div className="mt-0.5 text-[11px] text-muted-foreground uppercase tracking-wide">
+              {k.label}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Throughput chart */}
+      <section className="mt-6 rounded-xl border border-border/60 bg-bg-surface/40 px-4 py-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="font-medium text-sm">Throughput · 14 days</h2>
+          <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+            <Legend color="var(--ag-accent-blue)" label="Pushed" />
+            <Legend color="var(--ag-success)" label="Completed" />
+          </div>
+        </div>
+        {a.total === 0 ? (
+          <p className="py-6 text-center text-muted-foreground text-xs">
+            No handoffs yet — push one to see throughput.
+          </p>
+        ) : (
+          <svg
+            viewBox={`0 0 ${chart.width} ${chart.height}`}
+            className="h-auto w-full"
+            role="img"
+            aria-label="Handoffs pushed vs completed over the last 14 days"
+          >
+            <title>Handoffs pushed vs completed, last 14 days</title>
+            <defs>
+              <linearGradient id="grad-pushed" x1="0" x2="0" y1="0" y2="1">
+                <stop
+                  offset="0%"
+                  stopColor="var(--ag-accent-blue)"
+                  stopOpacity="0.28"
+                />
+                <stop
+                  offset="100%"
+                  stopColor="var(--ag-accent-blue)"
+                  stopOpacity="0"
+                />
+              </linearGradient>
+              <linearGradient id="grad-completed" x1="0" x2="0" y1="0" y2="1">
+                <stop
+                  offset="0%"
+                  stopColor="var(--ag-success)"
+                  stopOpacity="0.22"
+                />
+                <stop
+                  offset="100%"
+                  stopColor="var(--ag-success)"
+                  stopOpacity="0"
+                />
+              </linearGradient>
+            </defs>
+
+            {/* y gridlines + labels */}
+            {chart.yTicks.map((t) => (
+              <g key={t.value}>
+                <line
+                  x1={26}
+                  x2={chart.width - 10}
+                  y1={t.y}
+                  y2={t.y}
+                  stroke="currentColor"
+                  strokeOpacity={0.08}
+                  className="text-foreground"
+                />
+                <text
+                  x={20}
+                  y={t.y + 3}
+                  textAnchor="end"
+                  className="fill-muted-foreground"
+                  style={{ fontSize: 9 }}
+                >
+                  {t.value}
+                </text>
+              </g>
+            ))}
+
+            {/* areas + lines */}
+            <path d={chart.series[0]?.area} fill="url(#grad-pushed)" />
+            <path d={chart.series[1]?.area} fill="url(#grad-completed)" />
+            <path
+              d={chart.series[0]?.line}
+              fill="none"
+              stroke="var(--ag-accent-blue)"
+              strokeWidth={1.75}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+            <path
+              d={chart.series[1]?.line}
+              fill="none"
+              stroke="var(--ag-success)"
+              strokeWidth={1.75}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+            />
+            {/* leading dots */}
+            <circle
+              cx={chart.series[0]?.lastX}
+              cy={chart.series[0]?.lastY}
+              r={2.6}
+              fill="var(--ag-accent-blue)"
+            />
+            <circle
+              cx={chart.series[1]?.lastX}
+              cy={chart.series[1]?.lastY}
+              r={2.6}
+              fill="var(--ag-success)"
+            />
+
+            {/* x labels */}
+            {chart.xTicks.map((t) => (
+              <text
+                key={t.label}
+                x={t.x}
+                y={chart.height - 6}
+                textAnchor="middle"
+                className="fill-muted-foreground"
+                style={{ fontSize: 9 }}
+              >
+                {t.label}
+              </text>
+            ))}
+          </svg>
+        )}
+      </section>
+
+      {/* Status distribution */}
+      <section className="mt-6 rounded-xl border border-border/60 bg-bg-surface/40 px-4 py-4">
+        <h2 className="mb-3 font-medium text-sm">Status distribution</h2>
+        {segments.length === 0 ? (
+          <p className="py-3 text-center text-muted-foreground text-xs">
+            No handoffs to distribute yet.
+          </p>
+        ) : (
+          <>
+            <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted/40">
+              {segments.map((s) => (
+                <div
+                  key={s.status}
+                  style={{
+                    width: `${s.pct}%`,
+                    backgroundColor: STATUS_COLOR[s.status as HandoffStatus],
+                  }}
+                  title={`${s.label}: ${s.count} (${s.pct}%)`}
+                />
+              ))}
+            </div>
+            <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
+              {segments.map((s) => (
+                <div
+                  key={s.status}
+                  className="flex items-center gap-1.5 text-xs"
+                >
+                  <span
+                    className="size-2.5 rounded-sm"
+                    style={{
+                      backgroundColor: STATUS_COLOR[s.status as HandoffStatus],
+                    }}
+                  />
+                  <span className="text-foreground">{s.label}</span>
+                  <span className="text-muted-foreground tabular-nums">
+                    {s.count} · {s.pct}%
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span
+        className="inline-block h-0.5 w-3 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      {label}
+    </span>
+  );
+}

--- a/apps/broomva/app/maestro/page.tsx
+++ b/apps/broomva/app/maestro/page.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -31,13 +32,36 @@ export default async function MaestroPage() {
   return (
     <div className="mx-auto w-full max-w-3xl px-4 pt-8 pb-28">
       <header className="mb-6">
-        <h1 className="font-semibold text-2xl">Maestro</h1>
+        <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+          <h1 className="font-semibold text-2xl">Maestro</h1>
+          <nav className="flex items-center gap-3 text-sm">
+            <Link
+              href={"/maestro/queue" as Route}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Handoff queue →
+            </Link>
+            <Link
+              href={"/maestro/analytics" as Route}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Analytics
+            </Link>
+          </nav>
+        </div>
         <p className="mt-1 text-muted-foreground text-sm">
           Spec orchestration console. Manage the docs published at{" "}
           <code className="rounded bg-muted px-1 py-0.5 text-xs">
             /d/&lt;handle&gt;
           </code>{" "}
-          — open, archive, restore, delete. Defined by{" "}
+          — open, archive, restore, delete. Hand the next session a{" "}
+          <Link
+            href={"/maestro/queue" as Route}
+            className="underline transition-colors hover:text-foreground"
+          >
+            handoff
+          </Link>
+          . Defined by{" "}
           <Link
             href="/d/maestro"
             className="underline transition-colors hover:text-foreground"

--- a/apps/broomva/app/maestro/queue/lib.test.ts
+++ b/apps/broomva/app/maestro/queue/lib.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "vitest";
+import { densifyDailyBuckets } from "@/lib/db/handoff-buckets";
+import type { HandoffSummary } from "@/lib/db/handoff-queries";
+import {
+  groupQueue,
+  handoffContinuePrompt,
+  handoffDeepLink,
+  mergeTimeline,
+  queueSummary,
+  relativeTime,
+  type TimelineEvent,
+  waitingCount,
+} from "./lib";
+
+function row(over: Partial<HandoffSummary> = {}): HandoffSummary {
+  return {
+    id: "h1",
+    ownerId: "u",
+    slug: "arc",
+    version: 1,
+    status: "queued",
+    priority: 0,
+    title: "Arc title",
+    tldr: null,
+    firstAction: null,
+    specRefs: [],
+    sourceRepo: null,
+    sourcePath: null,
+    sourceCommit: null,
+    branch: null,
+    ticketId: null,
+    prNumber: null,
+    sessionId: null,
+    pickedUpAt: null,
+    completedAt: null,
+    expiresAt: null,
+    deletedAt: null,
+    createdAt: new Date("2026-06-01T00:00:00Z"),
+    updatedAt: new Date("2026-06-01T00:00:00Z"),
+    ...over,
+  };
+}
+
+describe("groupQueue", () => {
+  test("groups by status in flow order (queued, in_progress, done, archived)", () => {
+    const groups = groupQueue([
+      row({ id: "1", status: "done" }),
+      row({ id: "2", status: "queued" }),
+      row({ id: "3", status: "in_progress" }),
+      row({ id: "4", status: "queued" }),
+      row({ id: "5", status: "archived" }),
+    ]);
+    expect(groups.map((g) => g.status)).toEqual([
+      "queued",
+      "in_progress",
+      "done",
+      "archived",
+    ]);
+    expect(groups[0]?.handoffs.map((h) => h.id)).toEqual(["2", "4"]);
+  });
+
+  test("drops empty groups and never surfaces superseded", () => {
+    const groups = groupQueue([
+      row({ id: "1", status: "queued" }),
+      row({ id: "2", status: "superseded" }),
+    ]);
+    expect(groups.map((g) => g.status)).toEqual(["queued"]);
+  });
+});
+
+describe("queueSummary + waitingCount", () => {
+  test("counts non-zero statuses in flow order", () => {
+    const items = queueSummary([
+      row({ id: "1", status: "queued" }),
+      row({ id: "2", status: "queued" }),
+      row({ id: "3", status: "done" }),
+    ]);
+    expect(items).toEqual([
+      expect.objectContaining({ status: "queued", count: 2 }),
+      expect.objectContaining({ status: "done", count: 1 }),
+    ]);
+  });
+
+  test("waitingCount counts only queued", () => {
+    expect(
+      waitingCount([
+        row({ status: "queued" }),
+        row({ status: "in_progress" }),
+        row({ status: "queued" }),
+      ]),
+    ).toBe(2);
+  });
+});
+
+describe("handoffContinuePrompt", () => {
+  test("uses explicit firstAction verbatim when present", () => {
+    const prompt = handoffContinuePrompt(
+      row({ firstAction: "Run `make deploy` and verify the preview." }),
+    );
+    expect(prompt).toBe("Run `make deploy` and verify the preview.");
+  });
+
+  test("synthesizes an orienting prompt with related specs + ticket", () => {
+    const prompt = handoffContinuePrompt(
+      row({
+        title: "Handoff Queue",
+        tldr: "Ship the queue.",
+        specRefs: ["maestro-handoff-queue", "relay-1b"],
+        sourcePath: "docs/handoffs/2026-06-05-queue.md",
+        sourceRepo: "broomva/broomva",
+        branch: "feat/q",
+        ticketId: "BRO-1415",
+      }),
+    );
+    expect(prompt).toContain('Continue the Broomva arc "Handoff Queue".');
+    expect(prompt).toContain("Ship the queue.");
+    expect(prompt).toContain("broomva docs get maestro-handoff-queue");
+    expect(prompt).toContain("/d/relay-1b");
+    expect(prompt).toContain("docs/handoffs/2026-06-05-queue.md");
+    expect(prompt).toContain("branch feat/q");
+    expect(prompt).toContain("Linear ticket: BRO-1415.");
+  });
+});
+
+describe("handoffDeepLink", () => {
+  test("encodes the continue-prompt and defaults the repo", () => {
+    const link = handoffDeepLink(row({ firstAction: "do x" }));
+    expect(link).toBe("claude-cli://open?repo=broomva/broomva.tech&q=do%20x");
+  });
+});
+
+describe("mergeTimeline", () => {
+  const ev = (id: string, iso: string): TimelineEvent => ({
+    id,
+    handoffId: "h",
+    type: "pushed",
+    actor: "cli",
+    message: id,
+    createdAt: iso,
+  });
+
+  test("dedupes by id, sorts newest-first, and caps length", () => {
+    const merged = mergeTimeline(
+      [ev("a", "2026-06-01T00:00:00Z")],
+      [ev("a", "2026-06-01T00:00:00Z"), ev("b", "2026-06-02T00:00:00Z")],
+    );
+    expect(merged.map((e) => e.id)).toEqual(["b", "a"]);
+  });
+
+  test("respects the cap", () => {
+    const many = Array.from({ length: 10 }, (_, i) =>
+      ev(`e${i}`, `2026-06-0${(i % 9) + 1}T00:00:00Z`),
+    );
+    expect(mergeTimeline([], many, 3)).toHaveLength(3);
+  });
+});
+
+describe("relativeTime", () => {
+  const now = new Date("2026-06-05T12:00:00Z");
+  test("formats compact deltas", () => {
+    expect(relativeTime("2026-06-05T11:59:40Z", now)).toBe("now");
+    expect(relativeTime("2026-06-05T11:30:00Z", now)).toBe("30m");
+    expect(relativeTime("2026-06-05T09:00:00Z", now)).toBe("3h");
+    expect(relativeTime("2026-06-03T12:00:00Z", now)).toBe("2d");
+    expect(relativeTime("2026-05-22T12:00:00Z", now)).toBe("2w");
+  });
+});
+
+describe("densifyDailyBuckets", () => {
+  test("produces a contiguous window oldest→newest with zero-fill", () => {
+    const now = new Date("2026-06-05T12:00:00Z");
+    const buckets = densifyDailyBuckets(
+      new Map([["2026-06-05", 3]]),
+      new Map([["2026-06-04", 1]]),
+      now,
+      3,
+    );
+    expect(buckets).toEqual([
+      { date: "2026-06-03", pushed: 0, completed: 0 },
+      { date: "2026-06-04", pushed: 0, completed: 1 },
+      { date: "2026-06-05", pushed: 3, completed: 0 },
+    ]);
+  });
+});

--- a/apps/broomva/app/maestro/queue/lib.ts
+++ b/apps/broomva/app/maestro/queue/lib.ts
@@ -1,0 +1,203 @@
+import type { HandoffSummary } from "@/lib/db/handoff-queries";
+import type { HandoffEventType, HandoffStatus } from "@/lib/db/schema";
+
+/** Visual tone per queue status (mapped to Arcan Glass tokens in the client). */
+export type QueueTone = "queued" | "active" | "done" | "muted" | "history";
+
+/**
+ * Display metadata per queue status. Keyed by the full enum so a missing case
+ * is a compile error if the enum grows.
+ */
+export const HANDOFF_STATUS_META: Record<
+  HandoffStatus,
+  { label: string; tone: QueueTone }
+> = {
+  queued: { label: "Queued", tone: "queued" },
+  in_progress: { label: "In progress", tone: "active" },
+  done: { label: "Done", tone: "done" },
+  archived: { label: "Archived", tone: "muted" },
+  superseded: { label: "Superseded", tone: "history" },
+};
+
+/** Queue groups shown on the board, attention/flow order (next-up first). */
+export const QUEUE_GROUP_ORDER: HandoffStatus[] = [
+  "queued",
+  "in_progress",
+  "done",
+  "archived",
+];
+
+export interface QueueGroup {
+  status: HandoffStatus;
+  label: string;
+  tone: QueueTone;
+  handoffs: HandoffSummary[];
+}
+
+/**
+ * Group queue handoffs by status into the canonical flow order, dropping empty
+ * groups. Pure — the single piece of board logic worth unit-testing. `done`
+ * and `archived` are kept (they're the queue's recent history); `superseded`
+ * never reaches the board (the query excludes it).
+ */
+export function groupQueue(handoffs: HandoffSummary[]): QueueGroup[] {
+  return QUEUE_GROUP_ORDER.map((status) => ({
+    status,
+    label: HANDOFF_STATUS_META[status].label,
+    tone: HANDOFF_STATUS_META[status].tone,
+    handoffs: handoffs.filter((h) => h.status === status),
+  })).filter((g) => g.handoffs.length > 0);
+}
+
+/** Per-status counts (active queue), flow-ordered, non-zero only — triage strip. */
+export interface QueueSummaryItem {
+  status: HandoffStatus;
+  label: string;
+  tone: QueueTone;
+  count: number;
+}
+
+export function queueSummary(handoffs: HandoffSummary[]): QueueSummaryItem[] {
+  return QUEUE_GROUP_ORDER.map((status) => ({
+    status,
+    label: HANDOFF_STATUS_META[status].label,
+    tone: HANDOFF_STATUS_META[status].tone,
+    count: handoffs.filter((h) => h.status === status).length,
+  })).filter((s) => s.count > 0);
+}
+
+/** Count of handoffs waiting to be picked up — the queue's headline number. */
+export function waitingCount(handoffs: HandoffSummary[]): number {
+  return handoffs.filter((h) => h.status === "queued").length;
+}
+
+/** Default repo when a handoff records none (most arcs live in the workspace). */
+const DEFAULT_REPO = "broomva/broomva.tech";
+
+/** Fields the continue helpers read off a queue row. */
+type ContinuableHandoff = Pick<
+  HandoffSummary,
+  | "slug"
+  | "id"
+  | "title"
+  | "tldr"
+  | "firstAction"
+  | "specRefs"
+  | "sourcePath"
+  | "sourceRepo"
+  | "branch"
+  | "ticketId"
+>;
+
+/**
+ * The seed prompt handed to a fresh session to CONTINUE a handoff (the Copy
+ * button payload). When the handoff carries an explicit `firstAction` (the
+ * "First action" the `/handoff` skill writes), that IS the payload — it's the
+ * single concrete next step. Otherwise we synthesize an orienting prompt that
+ * points at the handoff queue + the related specs (which have their own
+ * `broomva docs get`). Pure — unit-tested.
+ */
+export function handoffContinuePrompt(h: ContinuableHandoff): string {
+  const explicit = h.firstAction?.trim();
+  if (explicit) return explicit;
+
+  const lines = [`Continue the Broomva arc "${h.title}".`];
+  if (h.tldr?.trim()) lines.push("", h.tldr.trim());
+  lines.push("", "Open the handoff queue: https://broomva.tech/maestro/queue.");
+  const refs = h.specRefs ?? [];
+  if (refs.length > 0) {
+    lines.push("", "Related specs:");
+    for (const ref of refs) {
+      lines.push(
+        `- \`broomva docs get ${ref} -o ${ref}.html\` (or open https://broomva.tech/d/${ref})`,
+      );
+    }
+  }
+  if (h.sourcePath) {
+    lines.push(
+      "",
+      `Source: \`${h.sourcePath}\`${h.sourceRepo ? ` in ${h.sourceRepo}` : ""}${
+        h.branch ? ` (branch ${h.branch})` : ""
+      }.`,
+    );
+  }
+  if (h.ticketId) lines.push(`Linear ticket: ${h.ticketId}.`);
+  lines.push(
+    "",
+    "Read the handoff and the specs it references, check the current state of the work, then continue under the workspace conventions (CLAUDE.md / AGENTS.md). Think through the dependency chain before editing.",
+  );
+  return lines.join("\n");
+}
+
+/**
+ * A Claude Code deep link (`claude-cli://open`) that opens a session in the
+ * arc's repo with the continue-prompt pre-filled (not auto-sent).
+ */
+export function handoffDeepLink(h: ContinuableHandoff): string {
+  const repo = h.sourceRepo ?? DEFAULT_REPO;
+  return `claude-cli://open?repo=${repo}&q=${encodeURIComponent(
+    handoffContinuePrompt(h),
+  )}`;
+}
+
+// ── Timeline (the realtime stream card) ──────────────────────────────────────
+
+/** A timeline entry — the shape the SSE stream and the SSR feed both produce. */
+export interface TimelineEvent {
+  id: string;
+  handoffId: string;
+  type: HandoffEventType;
+  actor: string;
+  message: string | null;
+  createdAt: string | Date;
+}
+
+/** Glyph + tone per event type for the timeline dots. */
+export const EVENT_META: Record<
+  HandoffEventType,
+  { glyph: string; tone: QueueTone; verb: string }
+> = {
+  pushed: { glyph: "↑", tone: "queued", verb: "Queued" },
+  picked_up: { glyph: "▶", tone: "active", verb: "Picked up" },
+  completed: { glyph: "✓", tone: "done", verb: "Completed" },
+  archived: { glyph: "⌅", tone: "muted", verb: "Archived" },
+  restored: { glyph: "↺", tone: "queued", verb: "Re-queued" },
+  superseded: { glyph: "⤳", tone: "history", verb: "Superseded" },
+  linked: { glyph: "🔗", tone: "active", verb: "Linked spec" },
+  note: { glyph: "•", tone: "muted", verb: "Note" },
+};
+
+/**
+ * Merge a fresh batch of streamed events into the existing timeline: dedupe by
+ * id, keep newest-first, cap length. Pure — the client's only state-merge logic,
+ * so it's the piece worth unit-testing.
+ */
+export function mergeTimeline(
+  current: TimelineEvent[],
+  incoming: TimelineEvent[],
+  cap = 80,
+): TimelineEvent[] {
+  const byId = new Map<string, TimelineEvent>();
+  for (const e of [...incoming, ...current]) byId.set(e.id, e);
+  return [...byId.values()]
+    .sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt))
+    .slice(0, cap);
+}
+
+/** A compact relative-time label ("3m", "2h", "5d") for timeline + cards. */
+export function relativeTime(
+  value: string | Date,
+  now: Date = new Date(),
+): string {
+  const then = new Date(value).getTime();
+  const secs = Math.max(0, Math.round((now.getTime() - then) / 1000));
+  if (secs < 45) return "now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.round(days / 7);
+  return `${weeks}w`;
+}

--- a/apps/broomva/app/maestro/queue/page.tsx
+++ b/apps/broomva/app/maestro/queue/page.tsx
@@ -1,0 +1,89 @@
+import type { Route } from "next";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getSafeSession } from "@/lib/auth";
+import { listHandoffEvents, listQueueHandoffs } from "@/lib/db/handoff-queries";
+import type { TimelineEvent } from "./lib";
+import { QueueBoard } from "./queue-board";
+import { QueueStream } from "./queue-stream";
+
+export const metadata = {
+  title: "Maestro — handoff queue",
+  robots: { index: false, follow: false },
+};
+
+/**
+ * /maestro/queue — the handoff queue (BRO-1415). The human-readable layer that
+ * articulates what to hand off NEXT: the `/handoff` skill pushes a narrative
+ * here via `broomva handoff push`, it queues, relates to the HTML specs at
+ * /d/<handle>, and is run by Copy/Continue (the same fresh-session trigger the
+ * spec board uses, BRO-1399). A realtime stream card with a timeline sits on
+ * top; the queue list sits below. Owner-gated (same identity gate as /maestro).
+ */
+export default async function MaestroQueuePage() {
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: await headers() },
+  });
+  const userId = session?.user?.id;
+  if (!userId) {
+    redirect("/login?next=/maestro/queue");
+  }
+
+  const [handoffs, events] = await Promise.all([
+    listQueueHandoffs(userId),
+    listHandoffEvents(userId, { limit: 40 }),
+  ]);
+
+  const timeline: TimelineEvent[] = events.map((e) => ({
+    id: e.id,
+    handoffId: e.handoffId,
+    type: e.type,
+    actor: e.actor,
+    message: e.message,
+    createdAt: e.createdAt,
+  }));
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-4 pt-8 pb-28">
+      <header className="mb-6">
+        <div className="flex items-center gap-2">
+          <Link
+            href="/maestro"
+            className="text-muted-foreground text-sm transition-colors hover:text-foreground"
+          >
+            Maestro
+          </Link>
+          <span className="text-muted-foreground/50 text-sm">/</span>
+          <h1 className="font-semibold text-2xl">Queue</h1>
+        </div>
+        <p className="mt-1 text-muted-foreground text-sm">
+          The handoff queue — what to hand to the next session. Push one with{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">
+            broomva handoff push file.md
+          </code>
+          . Each entry relates to its{" "}
+          <Link
+            href="/maestro"
+            className="underline transition-colors hover:text-foreground"
+          >
+            specs
+          </Link>{" "}
+          and runs via <span className="font-medium text-foreground">Copy</span>{" "}
+          / <span className="font-medium text-foreground">Continue</span>.{" "}
+          <Link
+            href={"/maestro/analytics" as Route}
+            className="underline transition-colors hover:text-foreground"
+          >
+            Analytics →
+          </Link>
+        </p>
+      </header>
+
+      <QueueStream initial={timeline} />
+      <div className="mt-6">
+        <QueueBoard handoffs={handoffs} />
+      </div>
+    </div>
+  );
+}

--- a/apps/broomva/app/maestro/queue/queue-board.tsx
+++ b/apps/broomva/app/maestro/queue/queue-board.tsx
@@ -234,23 +234,27 @@ function HandoffCard({
   const [expanded, setExpanded] = useState(false);
   const [body, setBody] = useState<string | null>(null);
   const [loadingBody, setLoadingBody] = useState(false);
+  const [bodyError, setBodyError] = useState(false);
   const specRefs = h.specRefs ?? [];
 
   async function toggleBody() {
     const next = !expanded;
     setExpanded(next);
+    // Fetch when expanding and not yet loaded. On error we leave `body` null so
+    // collapsing + re-expanding retries (rather than caching the error string).
     if (next && body === null && !loadingBody) {
       setLoadingBody(true);
+      setBodyError(false);
       try {
         const resp = await fetch(`/api/handoffs/${h.id}`);
         if (resp.ok) {
           const data = (await resp.json()) as { body?: string };
           setBody(data.body ?? "");
         } else {
-          setBody("_Could not load handoff body._");
+          setBodyError(true);
         }
       } catch {
-        setBody("_Could not load handoff body._");
+        setBodyError(true);
       } finally {
         setLoadingBody(false);
       }
@@ -311,6 +315,10 @@ function HandoffCard({
         <div className="mt-3 ml-5 rounded-lg border border-border/50 bg-bg-surface/30 px-3 py-2.5">
           {loadingBody ? (
             <p className="text-muted-foreground text-xs">Loading handoff…</p>
+          ) : bodyError ? (
+            <p className="text-destructive text-xs">
+              Couldn't load the handoff body — collapse and re-open to retry.
+            </p>
           ) : (
             <div className="prose prose-invert prose-sm max-w-none prose-headings:text-sm prose-headings:font-semibold prose-p:text-xs prose-li:text-xs prose-code:text-[11px] prose-pre:text-[11px] text-muted-foreground">
               <ReactMarkdown>{body ?? ""}</ReactMarkdown>

--- a/apps/broomva/app/maestro/queue/queue-board.tsx
+++ b/apps/broomva/app/maestro/queue/queue-board.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { ChevronDown, MoreHorizontal } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { startTransition, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { HandoffSummary } from "@/lib/db/handoff-queries";
+import type { HandoffStatus } from "@/lib/db/schema";
+import {
+  groupQueue,
+  handoffContinuePrompt,
+  handoffDeepLink,
+  type QueueTone,
+  queueSummary,
+  waitingCount,
+} from "./lib";
+
+const dateFmt = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
+
+const TONE_CLASS: Record<QueueTone, string> = {
+  queued:
+    "border-[color:var(--ag-accent-blue)]/40 text-[color:var(--ag-accent-blue)]",
+  active: "border-[color:var(--ag-ai-blue)]/40 text-[color:var(--ag-ai-blue)]",
+  done: "border-[color:var(--ag-success)]/40 text-[color:var(--ag-success)]",
+  muted: "border-muted-foreground/30 text-muted-foreground",
+  history: "border-[color:var(--ag-error)]/40 text-[color:var(--ag-error)]",
+};
+
+const SECONDARY_BTN =
+  "rounded-md px-2.5 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50";
+const PRIMARY_BTN =
+  "rounded-md border border-[color:var(--ag-ai-blue)]/40 px-2.5 py-1 text-[color:var(--ag-ai-blue)] text-xs transition-colors hover:bg-[color:var(--ag-ai-blue)]/10 disabled:opacity-50";
+const CARD =
+  "rounded-xl border border-border/60 bg-bg-surface/40 px-4 py-3 transition-colors hover:border-[color:var(--ag-ai-blue)]/30";
+
+function chipClass(selected: boolean, tone?: QueueTone): string {
+  const base = "rounded-full border px-2.5 py-1 text-xs transition-colors";
+  if (selected) {
+    return `${base} border-[color:var(--ag-ai-blue)]/50 bg-[color:var(--ag-ai-blue)]/10 text-foreground`;
+  }
+  return `${base} ${
+    tone ? TONE_CLASS[tone] : "border-border/60 text-muted-foreground"
+  } hover:bg-muted/50`;
+}
+
+/**
+ * The handoff queue board (BRO-1415). Grouped by status, flow-ordered
+ * (Queued → In progress → Done → Archived) with a triage header + filter strip.
+ * Each card relates to its specs (chips → /d/<handle>), runs via Copy
+ * (continue-prompt → clipboard) / Continue (claude-cli:// deep link), and
+ * transitions via the owner-scoped PATCH/DELETE endpoints. The full markdown
+ * body lazy-loads on expand.
+ */
+export function QueueBoard({ handoffs }: { handoffs: HandoffSummary[] }) {
+  const router = useRouter();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [filter, setFilter] = useState<HandoffStatus | null>(null);
+
+  const groups = groupQueue(handoffs);
+  const summary = queueSummary(handoffs);
+  const waiting = waitingCount(handoffs);
+
+  async function mutate(id: string, init: RequestInit) {
+    setPendingId(id);
+    setError(null);
+    try {
+      const resp = await fetch(`/api/handoffs/${id}`, init);
+      if (!resp.ok) {
+        const body = (await resp.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        setError(body?.error ?? `Action failed (${resp.status})`);
+        return;
+      }
+      startTransition(() => router.refresh());
+    } catch {
+      setError("Network error — please retry.");
+    } finally {
+      setPendingId(null);
+      setConfirmId(null);
+    }
+  }
+
+  function action(
+    a: "pick_up" | "complete" | "archive" | "requeue",
+  ): RequestInit {
+    return {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: a }),
+    };
+  }
+
+  async function copyPrompt(h: HandoffSummary) {
+    try {
+      await navigator.clipboard.writeText(handoffContinuePrompt(h));
+      setCopiedId(h.id);
+      setTimeout(() => setCopiedId((cur) => (cur === h.id ? null : cur)), 1500);
+    } catch {
+      setError("Clipboard unavailable — open the handoff and copy manually.");
+    }
+  }
+
+  if (handoffs.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground text-sm">
+        Queue is empty. Push a handoff with{" "}
+        <code className="rounded bg-muted px-1 py-0.5 text-xs">
+          broomva handoff push docs/handoffs/&lt;arc&gt;.md
+        </code>
+        .
+      </div>
+    );
+  }
+
+  const visibleGroups = filter
+    ? groups.filter((g) => g.status === filter)
+    : groups;
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive text-xs">
+          {error}
+        </div>
+      ) : null}
+
+      {/* Triage header */}
+      <div className={CARD}>
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+          {waiting > 0 ? (
+            <span className="font-medium text-[color:var(--ag-accent-blue)] text-sm">
+              {waiting} {waiting === 1 ? "handoff" : "handoffs"} waiting to pick
+              up
+            </span>
+          ) : (
+            <span className="font-medium text-[color:var(--ag-success)] text-sm">
+              Queue clear
+            </span>
+          )}
+          <span className="text-muted-foreground text-xs">
+            · {handoffs.length} total
+          </span>
+        </div>
+        {summary.length > 1 || filter ? (
+          <div className="mt-2.5 flex flex-wrap gap-1.5">
+            <button
+              type="button"
+              onClick={() => setFilter(null)}
+              className={chipClass(filter === null)}
+            >
+              All
+            </button>
+            {summary.map((s) => (
+              <button
+                key={s.status}
+                type="button"
+                onClick={() => setFilter(filter === s.status ? null : s.status)}
+                className={chipClass(filter === s.status, s.tone)}
+              >
+                {s.label} <span className="opacity-60">{s.count}</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {visibleGroups.map((group) => (
+        <section key={group.status}>
+          <div className="mb-2 flex items-center gap-2">
+            <span
+              className={`rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide ${TONE_CLASS[group.tone]}`}
+            >
+              {group.label}
+            </span>
+            <span className="text-muted-foreground text-xs">
+              {group.handoffs.length}
+            </span>
+          </div>
+          <div className="space-y-2.5">
+            {group.handoffs.map((h) => (
+              <HandoffCard
+                key={h.id}
+                h={h}
+                busy={pendingId === h.id}
+                confirming={confirmId === h.id}
+                copied={copiedId === h.id}
+                onCopy={() => copyPrompt(h)}
+                onAction={(a) => mutate(h.id, action(a))}
+                onConfirmDelete={() => setConfirmId(h.id)}
+                onCancelDelete={() => setConfirmId(null)}
+                onDelete={() => mutate(h.id, { method: "DELETE" })}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function HandoffCard({
+  h,
+  busy,
+  confirming,
+  copied,
+  onCopy,
+  onAction,
+  onConfirmDelete,
+  onCancelDelete,
+  onDelete,
+}: {
+  h: HandoffSummary;
+  busy: boolean;
+  confirming: boolean;
+  copied: boolean;
+  onCopy: () => void;
+  onAction: (a: "pick_up" | "complete" | "archive" | "requeue") => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+  onDelete: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [body, setBody] = useState<string | null>(null);
+  const [loadingBody, setLoadingBody] = useState(false);
+  const specRefs = h.specRefs ?? [];
+
+  async function toggleBody() {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && body === null && !loadingBody) {
+      setLoadingBody(true);
+      try {
+        const resp = await fetch(`/api/handoffs/${h.id}`);
+        if (resp.ok) {
+          const data = (await resp.json()) as { body?: string };
+          setBody(data.body ?? "");
+        } else {
+          setBody("_Could not load handoff body._");
+        }
+      } catch {
+        setBody("_Could not load handoff body._");
+      } finally {
+        setLoadingBody(false);
+      }
+    }
+  }
+
+  return (
+    <div className={CARD}>
+      <div className="flex items-start gap-2">
+        <button
+          type="button"
+          onClick={toggleBody}
+          className="min-w-0 flex-1 text-left"
+        >
+          <span className="flex items-center gap-1.5">
+            <ChevronDown
+              className={`size-3.5 shrink-0 text-muted-foreground transition-transform ${
+                expanded ? "rotate-0" : "-rotate-90"
+              }`}
+            />
+            <span className="truncate font-medium text-sm leading-6 hover:underline">
+              {h.title}
+            </span>
+          </span>
+        </button>
+        {h.version > 1 ? (
+          <span className="mt-0.5 shrink-0 rounded-full border border-muted-foreground/30 px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            v{h.version}
+          </span>
+        ) : null}
+      </div>
+
+      {h.tldr ? (
+        <p className="mt-1 line-clamp-2 pl-5 text-muted-foreground text-xs leading-5">
+          {h.tldr}
+        </p>
+      ) : null}
+
+      {/* meta + related spec chips */}
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 pl-5 text-muted-foreground text-xs">
+        {h.slug ? (
+          <code className="rounded bg-muted px-1 py-0.5">{h.slug}</code>
+        ) : null}
+        {h.ticketId ? <span>{h.ticketId}</span> : null}
+        <span>{dateFmt.format(h.createdAt)}</span>
+        {specRefs.map((ref) => (
+          <Link
+            key={ref}
+            href={`/d/${ref}`}
+            className="rounded-full border border-[color:var(--ag-ai-blue)]/30 px-1.5 py-0.5 text-[10px] text-[color:var(--ag-ai-blue)] transition-colors hover:bg-[color:var(--ag-ai-blue)]/10"
+          >
+            /d/{ref}
+          </Link>
+        ))}
+      </div>
+
+      {expanded ? (
+        <div className="mt-3 ml-5 rounded-lg border border-border/50 bg-bg-surface/30 px-3 py-2.5">
+          {loadingBody ? (
+            <p className="text-muted-foreground text-xs">Loading handoff…</p>
+          ) : (
+            <div className="prose prose-invert prose-sm max-w-none prose-headings:text-sm prose-headings:font-semibold prose-p:text-xs prose-li:text-xs prose-code:text-[11px] prose-pre:text-[11px] text-muted-foreground">
+              <ReactMarkdown>{body ?? ""}</ReactMarkdown>
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      {confirming ? (
+        <div className="mt-3 flex items-center gap-2 pl-5">
+          <span className="flex-1 text-destructive text-xs">
+            Delete this handoff?
+          </span>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onDelete}
+            className="rounded-md bg-destructive/10 px-2.5 py-1 text-destructive text-xs transition-colors hover:bg-destructive/20 disabled:opacity-50"
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onCancelDelete}
+            className={SECONDARY_BTN}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <div className="mt-3 flex items-center gap-1.5 pl-5">
+          {h.status === "queued" ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onAction("pick_up")}
+              className={PRIMARY_BTN}
+              title="Mark in progress (a fresh session is taking this)"
+            >
+              Pick up
+            </button>
+          ) : null}
+          {h.status === "in_progress" ? (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onAction("complete")}
+              className={PRIMARY_BTN}
+              title="Mark this handoff done"
+            >
+              Done
+            </button>
+          ) : null}
+          <a
+            href={handoffDeepLink(h)}
+            title="Open Claude Code in the repo with the continue-prompt pre-filled"
+            className={
+              h.status === "queued" || h.status === "in_progress"
+                ? SECONDARY_BTN
+                : PRIMARY_BTN
+            }
+          >
+            Continue
+          </a>
+          <button
+            type="button"
+            onClick={onCopy}
+            title="Copy the continue-prompt — paste into a fresh session (Omnara, etc.)"
+            className={SECONDARY_BTN}
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="More actions"
+                className="ml-auto rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <MoreHorizontal className="size-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {h.status !== "queued" ? (
+                <DropdownMenuItem
+                  disabled={busy}
+                  onClick={() => onAction("requeue")}
+                >
+                  Re-queue
+                </DropdownMenuItem>
+              ) : null}
+              {h.status !== "archived" ? (
+                <DropdownMenuItem
+                  disabled={busy}
+                  onClick={() => onAction("archive")}
+                >
+                  Archive
+                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={busy}
+                onClick={onConfirmDelete}
+                className="text-destructive focus:text-destructive"
+              >
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/broomva/app/maestro/queue/queue-stream.tsx
+++ b/apps/broomva/app/maestro/queue/queue-stream.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  EVENT_META,
+  mergeTimeline,
+  type QueueTone,
+  relativeTime,
+  type TimelineEvent,
+} from "./lib";
+
+/** Tone → Arcan Glass token classes for the timeline nodes. */
+const TONE_DOT: Record<QueueTone, string> = {
+  queued: "bg-[color:var(--ag-accent-blue)]",
+  active: "bg-[color:var(--ag-ai-blue)]",
+  done: "bg-[color:var(--ag-success)]",
+  muted: "bg-muted-foreground/50",
+  history: "bg-[color:var(--ag-error)]/70",
+};
+const TONE_TEXT: Record<QueueTone, string> = {
+  queued: "text-[color:var(--ag-accent-blue)]",
+  active: "text-[color:var(--ag-ai-blue)]",
+  done: "text-[color:var(--ag-success)]",
+  muted: "text-muted-foreground",
+  history: "text-[color:var(--ag-error)]",
+};
+
+type ConnState = "connecting" | "live" | "reconnecting";
+
+/**
+ * The realtime stream card (BRO-1415). Server-renders with the current
+ * timeline, then opens an EventSource to /api/handoffs/events and tails new
+ * events live. The horizontal rail reads newest-first (left→right); a pulsing
+ * status pill shows the connection. New status/push events trigger a throttled
+ * `router.refresh()` so the queue board below stays in sync without a reload.
+ */
+export function QueueStream({ initial }: { initial: TimelineEvent[] }) {
+  const router = useRouter();
+  const [events, setEvents] = useState<TimelineEvent[]>(initial);
+  const [conn, setConn] = useState<ConnState>("connecting");
+
+  // Newest createdAt we've seen — the SSE reconnect cursor.
+  const cursorRef = useRef<string>(
+    initial[0]?.createdAt
+      ? new Date(initial[0].createdAt).toISOString()
+      : new Date().toISOString(),
+  );
+  const lastRefresh = useRef<number>(0);
+  const esRef = useRef<EventSource | null>(null);
+  const retryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleRefresh = useCallback(() => {
+    const now = Date.now();
+    if (now - lastRefresh.current > 1500) {
+      lastRefresh.current = now;
+      router.refresh();
+    }
+  }, [router]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      return;
+    }
+    let disposed = false;
+
+    const connect = () => {
+      if (disposed) return;
+      const es = new EventSource(
+        `/api/handoffs/events?since=${encodeURIComponent(cursorRef.current)}`,
+      );
+      esRef.current = es;
+
+      es.addEventListener("ready", () => {
+        if (!disposed) setConn("live");
+      });
+
+      es.addEventListener("handoff", (e) => {
+        if (disposed) return;
+        try {
+          const ev = JSON.parse((e as MessageEvent).data) as TimelineEvent;
+          cursorRef.current = new Date(ev.createdAt).toISOString();
+          setEvents((cur) => mergeTimeline(cur, [ev]));
+          scheduleRefresh();
+        } catch {
+          // ignore malformed frame
+        }
+      });
+
+      es.addEventListener("bye", () => {
+        es.close();
+        if (disposed) return;
+        setConn("reconnecting");
+        retryRef.current = setTimeout(connect, 300);
+      });
+
+      es.onerror = () => {
+        es.close();
+        if (disposed) return;
+        setConn("reconnecting");
+        retryRef.current = setTimeout(connect, 2500);
+      };
+    };
+
+    connect();
+    return () => {
+      disposed = true;
+      if (retryRef.current) clearTimeout(retryRef.current);
+      esRef.current?.close();
+    };
+  }, [scheduleRefresh]);
+
+  return (
+    <section className="rounded-xl border border-border/60 bg-bg-surface/40 px-4 py-3.5">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="font-medium text-sm">Activity</h2>
+          <span className="text-muted-foreground/70 text-xs">
+            {events.length > 0
+              ? `${events.length} event${events.length === 1 ? "" : "s"}`
+              : "no activity yet"}
+          </span>
+        </div>
+        <LiveBadge state={conn} />
+      </div>
+
+      {events.length === 0 ? (
+        <p className="py-3 text-muted-foreground text-xs">
+          Push a handoff to start the stream —{" "}
+          <code className="rounded bg-muted px-1 py-0.5">
+            broomva handoff push file.md
+          </code>
+          .
+        </p>
+      ) : (
+        <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1">
+          {/* connecting rail line behind the nodes */}
+          {events.map((ev, i) => {
+            const meta = EVENT_META[ev.type];
+            return (
+              <div
+                key={ev.id}
+                className="relative flex min-w-[8.5rem] max-w-[12rem] shrink-0 flex-col gap-1"
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className={`size-2 shrink-0 rounded-full ${TONE_DOT[meta.tone]} ${
+                      i === 0 ? "ring-2 ring-[color:var(--ag-ai-blue)]/30" : ""
+                    }`}
+                  />
+                  {i < events.length - 1 ? (
+                    <span className="h-px flex-1 bg-border/70" />
+                  ) : null}
+                </div>
+                <div className="flex items-baseline gap-1.5">
+                  <span className={`text-xs ${TONE_TEXT[meta.tone]}`}>
+                    {meta.glyph}
+                  </span>
+                  <span className="truncate font-medium text-foreground text-xs">
+                    {ev.message ?? meta.verb}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <span className="rounded bg-muted px-1 py-px uppercase tracking-wide">
+                    {ev.actor}
+                  </span>
+                  <span>{relativeTime(ev.createdAt)}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function LiveBadge({ state }: { state: ConnState }) {
+  const cfg = {
+    connecting: {
+      label: "Connecting",
+      dot: "bg-muted-foreground/60",
+      pulse: false,
+    },
+    live: { label: "Live", dot: "bg-[color:var(--ag-success)]", pulse: true },
+    reconnecting: {
+      label: "Reconnecting",
+      dot: "bg-[color:var(--ag-warning)]",
+      pulse: true,
+    },
+  }[state];
+  return (
+    <span className="flex items-center gap-1.5 rounded-full border border-border/60 px-2 py-0.5 text-[11px] text-muted-foreground">
+      <span className="relative flex size-1.5">
+        {cfg.pulse ? (
+          <span
+            className={`absolute inline-flex size-full animate-ping rounded-full opacity-60 ${cfg.dot}`}
+          />
+        ) : null}
+        <span
+          className={`relative inline-flex size-1.5 rounded-full ${cfg.dot}`}
+        />
+      </span>
+      {cfg.label}
+    </span>
+  );
+}

--- a/apps/broomva/lib/db/handoff-buckets.ts
+++ b/apps/broomva/lib/db/handoff-buckets.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure date-bucketing for handoff queue analytics (BRO-1415). Kept in its own
+ * module — free of any DB-client / env import — so it is unit-testable without
+ * a database connection (importing handoff-queries pulls in the Postgres client
+ * + env validation, which the test environment does not have).
+ */
+
+/**
+ * Build a contiguous N-day window (oldest→newest) from sparse per-day maps.
+ * Uses UTC day strings so it lines up with `date_trunc('day', …)` in SQL.
+ */
+export function densifyDailyBuckets(
+  pushedByDay: Map<string, number>,
+  completedByDay: Map<string, number>,
+  now: Date = new Date(),
+  days = 14,
+): Array<{ date: string; pushed: number; completed: number }> {
+  const out: Array<{ date: string; pushed: number; completed: number }> = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    out.push({
+      date: key,
+      pushed: pushedByDay.get(key) ?? 0,
+      completed: completedByDay.get(key) ?? 0,
+    });
+  }
+  return out;
+}

--- a/apps/broomva/lib/db/handoff-queries.ts
+++ b/apps/broomva/lib/db/handoff-queries.ts
@@ -282,7 +282,9 @@ const TRANSITIONS: Record<
 export type HandoffAction = keyof typeof TRANSITIONS;
 
 export function isHandoffAction(value: unknown): value is HandoffAction {
-  return typeof value === "string" && value in TRANSITIONS;
+  // Object.hasOwn (not `in`) — `in` walks the prototype chain, so a payload of
+  // `{ action: "constructor" }` would otherwise pass the guard and 500 later.
+  return typeof value === "string" && Object.hasOwn(TRANSITIONS, value);
 }
 
 /**
@@ -442,16 +444,14 @@ export async function getQueueAnalytics(
   let specSum = 0;
   for (const r of statusRows) {
     if (r.status in statusCounts) statusCounts[r.status] = r.count;
-    // "active" total excludes superseded (history), like the queue board.
-    if (r.status !== "superseded") total += r.count;
-    specSum += r.specSum;
+    // Exclude superseded (version history) from BOTH the total and the
+    // specs-per-handoff numerator, so re-pushing an arc N times doesn't dilute
+    // the metric — consistent with every other metric on the page.
+    if (r.status !== "superseded") {
+      total += r.count;
+      specSum += r.specSum;
+    }
   }
-  const activeForSpecs =
-    statusCounts.queued +
-    statusCounts.in_progress +
-    statusCounts.done +
-    statusCounts.archived +
-    statusCounts.superseded;
 
   const [windowed] = await db
     .select({
@@ -511,8 +511,7 @@ export async function getQueueAnalytics(
     pushed7d: windowed?.pushed7d ?? 0,
     medianPickupMinutes:
       windowed?.medianPickup != null ? Math.round(windowed.medianPickup) : null,
-    avgSpecsPerHandoff:
-      activeForSpecs > 0 ? Math.round((specSum / activeForSpecs) * 10) / 10 : 0,
+    avgSpecsPerHandoff: total > 0 ? Math.round((specSum / total) * 10) / 10 : 0,
     daily: densifyDailyBuckets(pushedByDay, completedByDay),
   };
 }

--- a/apps/broomva/lib/db/handoff-queries.ts
+++ b/apps/broomva/lib/db/handoff-queries.ts
@@ -1,0 +1,518 @@
+/**
+ * Handoff queue queries (BRO-1415) — the narrative bridge that triggers the
+ * next session. A handoff is pushed (`broomva handoff push`), queued, related
+ * to specs, and run via Copy/Continue. Mirrors the SpecDoc lifecycle model:
+ * stable `slug`, append a `version` per push, supersede the prior active one.
+ *
+ * Every read/mutation is scoped to `ownerId` — ownership is enforced at the
+ * query layer (defense in depth), independent of the route-level auth gate.
+ *
+ * Each mutation emits a {@link handoffEvent} row in the SAME transaction, so
+ * the realtime timeline on /maestro/queue is an exact, gap-free projection of
+ * the queue's history.
+ */
+
+import { and, desc, eq, gt, inArray, isNull, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db } from "@/lib/db/client";
+import { densifyDailyBuckets } from "@/lib/db/handoff-buckets";
+import {
+  type Handoff,
+  type HandoffEventType,
+  type HandoffStatus,
+  handoff,
+  handoffEvent,
+} from "@/lib/db/schema";
+
+export { densifyDailyBuckets } from "@/lib/db/handoff-buckets";
+
+/** Statuses still "in the queue" (not superseded, not deleted). */
+const ACTIVE_STATUSES: HandoffStatus[] = [
+  "queued",
+  "in_progress",
+  "done",
+  "archived",
+];
+
+/** Statuses superseded on re-push of the same slug. */
+const SUPERSEDABLE_STATUSES: HandoffStatus[] = ["queued", "in_progress"];
+
+/** Max rows returned by list endpoints — bounds the response. */
+const LIST_LIMIT = 200;
+
+/** Max events returned by the timeline endpoint per poll. */
+const EVENT_LIMIT = 100;
+
+/** Normalize a string into a URL-safe slug (≤64 chars). */
+export function slugifyHandoff(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+/**
+ * Resolve the slug for a push:
+ *   explicit `slug` → slug of it
+ *   else `sourcePath` basename (e.g. 2026-06-05-handoff-queue.md) → slug
+ *   else the new row's `id` (standalone).
+ */
+export function deriveHandoffSlug(params: {
+  slug?: string | null;
+  sourcePath?: string | null;
+  id: string;
+}): string {
+  if (params.slug) {
+    const s = slugifyHandoff(params.slug);
+    if (s) return s;
+  }
+  if (params.sourcePath) {
+    const base = params.sourcePath.split("/").pop() ?? "";
+    const s = slugifyHandoff(base.replace(/\.[a-z0-9]+$/i, ""));
+    if (s) return s;
+  }
+  return params.id;
+}
+
+export interface PushHandoffParams {
+  id: string;
+  ownerId: string;
+  title: string;
+  body: string;
+  slug?: string | null;
+  tldr?: string | null;
+  firstAction?: string | null;
+  specRefs?: string[] | null;
+  priority?: number | null;
+  sourceRepo?: string | null;
+  sourcePath?: string | null;
+  sourceCommit?: string | null;
+  branch?: string | null;
+  ticketId?: string | null;
+  prNumber?: number | null;
+  sessionId?: string | null;
+  /** Who pushed it — "cli" | "web" | "agent". Defaults to "cli". */
+  actor?: string;
+}
+
+/**
+ * Push a handoff onto the queue. The prior active version(s) of the same slug
+ * become `superseded`; the new row is `queued`. Emits a `pushed` event (plus a
+ * `superseded` event for any replaced version). Atomic + advisory-locked per
+ * (owner, slug), exactly like {@link publishSpecDoc}.
+ */
+export async function pushHandoff(params: PushHandoffParams): Promise<Handoff> {
+  const slug = deriveHandoffSlug(params);
+  const actor = params.actor ?? "cli";
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${`${params.ownerId}/handoff/${slug}`}, 0))`,
+    );
+    const [agg] = await tx
+      .select({ maxV: sql<number>`coalesce(max(${handoff.version}), 0)` })
+      .from(handoff)
+      .where(and(eq(handoff.ownerId, params.ownerId), eq(handoff.slug, slug)));
+    const version = (agg?.maxV ?? 0) + 1;
+
+    if (version > 1) {
+      const superseded = await tx
+        .update(handoff)
+        .set({ status: "superseded" })
+        .where(
+          and(
+            eq(handoff.ownerId, params.ownerId),
+            eq(handoff.slug, slug),
+            inArray(handoff.status, SUPERSEDABLE_STATUSES),
+            isNull(handoff.deletedAt),
+          ),
+        )
+        .returning({ id: handoff.id });
+      for (const row of superseded) {
+        await tx.insert(handoffEvent).values({
+          id: nanoid(16),
+          handoffId: row.id,
+          ownerId: params.ownerId,
+          type: "superseded",
+          actor,
+          message: `Superseded by v${version}`,
+        });
+      }
+    }
+
+    const [row] = await tx
+      .insert(handoff)
+      .values({
+        id: params.id,
+        ownerId: params.ownerId,
+        slug,
+        version,
+        status: "queued",
+        priority: params.priority ?? 0,
+        title: params.title,
+        tldr: params.tldr ?? null,
+        body: params.body,
+        firstAction: params.firstAction ?? null,
+        specRefs: params.specRefs ?? [],
+        sourceRepo: params.sourceRepo ?? null,
+        sourcePath: params.sourcePath ?? null,
+        sourceCommit: params.sourceCommit ?? null,
+        branch: params.branch ?? null,
+        ticketId: params.ticketId ?? null,
+        prNumber: params.prNumber ?? null,
+        sessionId: params.sessionId ?? null,
+      })
+      .returning();
+    if (!row) throw new Error("pushHandoff: insert returned no row");
+
+    await tx.insert(handoffEvent).values({
+      id: nanoid(16),
+      handoffId: row.id,
+      ownerId: params.ownerId,
+      type: "pushed",
+      actor,
+      message:
+        version > 1
+          ? `Queued ${row.title} (v${version})`
+          : `Queued ${row.title}`,
+      metadata: {
+        specRefs: params.specRefs ?? [],
+        ticketId: params.ticketId ?? null,
+      },
+    });
+
+    // A spec-link is a first-class timeline event so the "relate specs with
+    // handoffs" linkage is visible on the stream.
+    for (const ref of params.specRefs ?? []) {
+      await tx.insert(handoffEvent).values({
+        id: nanoid(16),
+        handoffId: row.id,
+        ownerId: params.ownerId,
+        type: "linked",
+        actor,
+        message: `Linked spec /d/${ref}`,
+        metadata: { specRef: ref },
+      });
+    }
+
+    return row;
+  });
+}
+
+/** Metadata view — excludes the (potentially large) markdown body. */
+export type HandoffSummary = Omit<Handoff, "body">;
+
+const SUMMARY_COLUMNS = {
+  id: handoff.id,
+  ownerId: handoff.ownerId,
+  slug: handoff.slug,
+  version: handoff.version,
+  status: handoff.status,
+  priority: handoff.priority,
+  title: handoff.title,
+  tldr: handoff.tldr,
+  firstAction: handoff.firstAction,
+  specRefs: handoff.specRefs,
+  sourceRepo: handoff.sourceRepo,
+  sourcePath: handoff.sourcePath,
+  sourceCommit: handoff.sourceCommit,
+  branch: handoff.branch,
+  ticketId: handoff.ticketId,
+  prNumber: handoff.prNumber,
+  sessionId: handoff.sessionId,
+  pickedUpAt: handoff.pickedUpAt,
+  completedAt: handoff.completedAt,
+  expiresAt: handoff.expiresAt,
+  deletedAt: handoff.deletedAt,
+  createdAt: handoff.createdAt,
+  updatedAt: handoff.updatedAt,
+} as const;
+
+/**
+ * The queue board view — the owner's active handoffs (queued/in_progress/done/
+ * archived), highest priority then newest first. Superseded + deleted excluded.
+ */
+export async function listQueueHandoffs(
+  ownerId: string,
+): Promise<HandoffSummary[]> {
+  return db
+    .select(SUMMARY_COLUMNS)
+    .from(handoff)
+    .where(
+      and(
+        eq(handoff.ownerId, ownerId),
+        inArray(handoff.status, ACTIVE_STATUSES),
+        isNull(handoff.deletedAt),
+      ),
+    )
+    .orderBy(desc(handoff.priority), desc(handoff.createdAt))
+    .limit(LIST_LIMIT);
+}
+
+/** Fetch one handoff by id (full body), owner-scoped. Excludes soft-deleted. */
+export async function getHandoffForOwner(
+  id: string,
+  ownerId: string,
+): Promise<Handoff | null> {
+  const [row] = await db
+    .select()
+    .from(handoff)
+    .where(
+      and(
+        eq(handoff.id, id),
+        eq(handoff.ownerId, ownerId),
+        isNull(handoff.deletedAt),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+/** The status transition a PATCH requests → its target status + event type. */
+const TRANSITIONS: Record<
+  string,
+  { status: HandoffStatus; event: HandoffEventType; verb: string }
+> = {
+  pick_up: { status: "in_progress", event: "picked_up", verb: "Picked up" },
+  complete: { status: "done", event: "completed", verb: "Completed" },
+  archive: { status: "archived", event: "archived", verb: "Archived" },
+  requeue: { status: "queued", event: "restored", verb: "Re-queued" },
+};
+
+export type HandoffAction = keyof typeof TRANSITIONS;
+
+export function isHandoffAction(value: unknown): value is HandoffAction {
+  return typeof value === "string" && value in TRANSITIONS;
+}
+
+/**
+ * Apply a queue transition to a handoff (owner-scoped, non-deleted), setting
+ * the lifecycle timestamps and emitting the matching timeline event. Atomic.
+ * Returns the new status, or null when the row is missing.
+ */
+export async function transitionHandoff(
+  id: string,
+  ownerId: string,
+  action: HandoffAction,
+  actor = "web",
+): Promise<HandoffStatus | null> {
+  const t = TRANSITIONS[action];
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ id: handoff.id, title: handoff.title })
+      .from(handoff)
+      .where(
+        and(
+          eq(handoff.id, id),
+          eq(handoff.ownerId, ownerId),
+          isNull(handoff.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!row) return null;
+
+    const patch: Partial<typeof handoff.$inferInsert> = { status: t.status };
+    if (action === "pick_up") patch.pickedUpAt = sql`now()` as never;
+    if (action === "complete") patch.completedAt = sql`now()` as never;
+
+    await tx
+      .update(handoff)
+      .set(patch)
+      .where(and(eq(handoff.id, id), eq(handoff.ownerId, ownerId)));
+
+    await tx.insert(handoffEvent).values({
+      id: nanoid(16),
+      handoffId: id,
+      ownerId,
+      type: t.event,
+      actor,
+      message: `${t.verb} ${row.title}`,
+    });
+    return t.status;
+  });
+}
+
+/** Soft-delete a handoff by id (sets `deletedAt`). Owner-scoped. */
+export async function softDeleteHandoff(
+  id: string,
+  ownerId: string,
+): Promise<boolean> {
+  const updated = await db
+    .update(handoff)
+    .set({ deletedAt: sql`now()` })
+    .where(
+      and(
+        eq(handoff.id, id),
+        eq(handoff.ownerId, ownerId),
+        isNull(handoff.deletedAt),
+      ),
+    )
+    .returning({ id: handoff.id });
+  return updated.length > 0;
+}
+
+export type HandoffEventRow = {
+  id: string;
+  handoffId: string;
+  type: HandoffEventType;
+  actor: string;
+  message: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+};
+
+/**
+ * The realtime timeline feed — the owner's recent events, newest first. When
+ * `since` (an event id cursor's createdAt) is supplied, returns only events
+ * strictly newer than it (the SSE tail). Owner-scoped.
+ */
+export async function listHandoffEvents(
+  ownerId: string,
+  opts: { since?: Date; limit?: number } = {},
+): Promise<HandoffEventRow[]> {
+  const limit = opts.limit ?? EVENT_LIMIT;
+  const rows = await db
+    .select({
+      id: handoffEvent.id,
+      handoffId: handoffEvent.handoffId,
+      type: handoffEvent.type,
+      actor: handoffEvent.actor,
+      message: handoffEvent.message,
+      metadata: handoffEvent.metadata,
+      createdAt: handoffEvent.createdAt,
+    })
+    .from(handoffEvent)
+    .where(
+      opts.since
+        ? and(
+            eq(handoffEvent.ownerId, ownerId),
+            gt(handoffEvent.createdAt, opts.since),
+          )
+        : eq(handoffEvent.ownerId, ownerId),
+    )
+    .orderBy(desc(handoffEvent.createdAt))
+    .limit(limit);
+  return rows as HandoffEventRow[];
+}
+
+export interface QueueAnalytics {
+  /** Per-status counts of active (non-superseded/deleted) handoffs. */
+  statusCounts: Record<HandoffStatus, number>;
+  total: number;
+  /** Handoffs completed in the last 7 days. */
+  completed7d: number;
+  /** Handoffs pushed in the last 7 days. */
+  pushed7d: number;
+  /** Median pickup latency (queued→in_progress), in minutes, last 30d. Null if none. */
+  medianPickupMinutes: number | null;
+  /** Average related specs per handoff. */
+  avgSpecsPerHandoff: number;
+  /** Daily push/complete buckets for the last 14 days (oldest→newest). */
+  daily: Array<{ date: string; pushed: number; completed: number }>;
+}
+
+/**
+ * Aggregate the queue for /maestro/analytics. One round-trip per metric; all
+ * owner-scoped. Pickup latency uses `pickedUpAt - createdAt` over rows that
+ * have been picked up. Daily buckets are computed in SQL (date_trunc) and
+ * densified to a contiguous 14-day window in {@link densifyDailyBuckets}.
+ */
+export async function getQueueAnalytics(
+  ownerId: string,
+): Promise<QueueAnalytics> {
+  const statusRows = await db
+    .select({
+      status: handoff.status,
+      count: sql<number>`count(*)::int`,
+      // `specRefs` is a `json` (not `jsonb`) column → json_array_length.
+      specSum: sql<number>`coalesce(sum(coalesce(json_array_length(${handoff.specRefs}), 0)), 0)::int`,
+    })
+    .from(handoff)
+    .where(and(eq(handoff.ownerId, ownerId), isNull(handoff.deletedAt)))
+    .groupBy(handoff.status);
+
+  const statusCounts: Record<HandoffStatus, number> = {
+    queued: 0,
+    in_progress: 0,
+    done: 0,
+    archived: 0,
+    superseded: 0,
+  };
+  let total = 0;
+  let specSum = 0;
+  for (const r of statusRows) {
+    if (r.status in statusCounts) statusCounts[r.status] = r.count;
+    // "active" total excludes superseded (history), like the queue board.
+    if (r.status !== "superseded") total += r.count;
+    specSum += r.specSum;
+  }
+  const activeForSpecs =
+    statusCounts.queued +
+    statusCounts.in_progress +
+    statusCounts.done +
+    statusCounts.archived +
+    statusCounts.superseded;
+
+  const [windowed] = await db
+    .select({
+      pushed7d: sql<number>`count(*) filter (where ${handoff.createdAt} > now() - interval '7 days')::int`,
+      completed7d: sql<number>`count(*) filter (where ${handoff.completedAt} > now() - interval '7 days')::int`,
+      medianPickup: sql<number | null>`
+        percentile_cont(0.5) within group (
+          order by extract(epoch from (${handoff.pickedUpAt} - ${handoff.createdAt})) / 60.0
+        ) filter (where ${handoff.pickedUpAt} is not null and ${handoff.createdAt} > now() - interval '30 days')
+      `,
+    })
+    .from(handoff)
+    .where(and(eq(handoff.ownerId, ownerId), isNull(handoff.deletedAt)));
+
+  const dailyRows = await db
+    .select({
+      day: sql<string>`to_char(date_trunc('day', ${handoff.createdAt}), 'YYYY-MM-DD')`,
+      pushed: sql<number>`count(*)::int`,
+    })
+    .from(handoff)
+    .where(
+      and(
+        eq(handoff.ownerId, ownerId),
+        isNull(handoff.deletedAt),
+        gt(handoff.createdAt, sql`now() - interval '14 days'`),
+      ),
+    )
+    .groupBy(sql`date_trunc('day', ${handoff.createdAt})`);
+
+  // Completions are keyed on `completedAt` (a handoff can complete on a
+  // different day than it was pushed), so they get their own pass.
+  const completedRows = await db
+    .select({
+      day: sql<string>`to_char(date_trunc('day', ${handoff.completedAt}), 'YYYY-MM-DD')`,
+      completed: sql<number>`count(*)::int`,
+    })
+    .from(handoff)
+    .where(
+      and(
+        eq(handoff.ownerId, ownerId),
+        isNull(handoff.deletedAt),
+        sql`${handoff.completedAt} is not null`,
+        gt(handoff.completedAt, sql`now() - interval '14 days'`),
+      ),
+    )
+    .groupBy(sql`date_trunc('day', ${handoff.completedAt})`);
+
+  const pushedByDay = new Map(dailyRows.map((r) => [r.day, r.pushed]));
+  const completedByDay = new Map(
+    completedRows.map((r) => [r.day, r.completed]),
+  );
+
+  return {
+    statusCounts,
+    total,
+    completed7d: windowed?.completed7d ?? 0,
+    pushed7d: windowed?.pushed7d ?? 0,
+    medianPickupMinutes:
+      windowed?.medianPickup != null ? Math.round(windowed.medianPickup) : null,
+    avgSpecsPerHandoff:
+      activeForSpecs > 0 ? Math.round((specSum / activeForSpecs) * 10) / 10 : 0,
+    daily: densifyDailyBuckets(pushedByDay, completedByDay),
+  };
+}

--- a/apps/broomva/lib/db/migrations/0075_pretty_toad_men.sql
+++ b/apps/broomva/lib/db/migrations/0075_pretty_toad_men.sql
@@ -1,0 +1,48 @@
+CREATE TYPE "public"."handoff_event_type" AS ENUM('pushed', 'picked_up', 'completed', 'archived', 'restored', 'superseded', 'linked', 'note');--> statement-breakpoint
+CREATE TYPE "public"."handoff_status" AS ENUM('queued', 'in_progress', 'done', 'archived', 'superseded');--> statement-breakpoint
+CREATE TABLE "Handoff" (
+	"id" text PRIMARY KEY NOT NULL,
+	"ownerId" text NOT NULL,
+	"slug" text,
+	"version" integer DEFAULT 1 NOT NULL,
+	"status" "handoff_status" DEFAULT 'queued' NOT NULL,
+	"priority" integer DEFAULT 0 NOT NULL,
+	"title" text NOT NULL,
+	"tldr" text,
+	"body" text NOT NULL,
+	"firstAction" text,
+	"specRefs" json DEFAULT '[]'::json NOT NULL,
+	"sourceRepo" text,
+	"sourcePath" text,
+	"sourceCommit" varchar(64),
+	"branch" text,
+	"ticketId" text,
+	"prNumber" integer,
+	"sessionId" text,
+	"pickedUpAt" timestamp,
+	"completedAt" timestamp,
+	"expiresAt" timestamp,
+	"deletedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "HandoffEvent" (
+	"id" text PRIMARY KEY NOT NULL,
+	"handoffId" text NOT NULL,
+	"ownerId" text NOT NULL,
+	"type" "handoff_event_type" NOT NULL,
+	"actor" varchar(32) DEFAULT 'system' NOT NULL,
+	"message" text,
+	"metadata" json,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "Handoff" ADD CONSTRAINT "Handoff_ownerId_user_id_fk" FOREIGN KEY ("ownerId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "HandoffEvent" ADD CONSTRAINT "HandoffEvent_handoffId_Handoff_id_fk" FOREIGN KEY ("handoffId") REFERENCES "public"."Handoff"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "HandoffEvent" ADD CONSTRAINT "HandoffEvent_ownerId_user_id_fk" FOREIGN KEY ("ownerId") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "Handoff_owner_created_idx" ON "Handoff" USING btree ("ownerId","createdAt");--> statement-breakpoint
+CREATE INDEX "Handoff_owner_status_idx" ON "Handoff" USING btree ("ownerId","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "Handoff_owner_slug_version_uq" ON "Handoff" USING btree ("ownerId","slug","version");--> statement-breakpoint
+CREATE INDEX "HandoffEvent_owner_created_idx" ON "HandoffEvent" USING btree ("ownerId","createdAt");--> statement-breakpoint
+CREATE INDEX "HandoffEvent_handoff_idx" ON "HandoffEvent" USING btree ("handoffId");

--- a/apps/broomva/lib/db/migrations/meta/0075_snapshot.json
+++ b/apps/broomva/lib/db/migrations/meta/0075_snapshot.json
@@ -1,0 +1,7839 @@
+{
+  "id": "94bcde74-22b5-405b-b6e1-354781376ed5",
+  "prevId": "c92dc07d-2414-4820-a2df-ea10669fe5b9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Agent": {
+      "name": "Agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentKeyId": {
+          "name": "agentKeyId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Agent_user_id_idx": {
+          "name": "Agent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_status_idx": {
+          "name": "Agent_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_agent_key_id_unique": {
+          "name": "Agent_agent_key_id_unique",
+          "columns": [
+            {
+              "expression": "agentKeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Agent_public_key_unique": {
+          "name": "Agent_public_key_unique",
+          "columns": [
+            {
+              "expression": "publicKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Agent_userId_user_id_fk": {
+          "name": "Agent_userId_user_id_fk",
+          "tableFrom": "Agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentRegistration": {
+      "name": "AgentRegistration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustLevel": {
+          "name": "trustLevel",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unrated'"
+        },
+        "lastEvaluatedAt": {
+          "name": "lastEvaluatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentialId": {
+          "name": "credentialId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentRegistration_org_id_idx": {
+          "name": "AgentRegistration_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_trust_level_idx": {
+          "name": "AgentRegistration_trust_level_idx",
+          "columns": [
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistration_status_idx": {
+          "name": "AgentRegistration_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentRegistration_organizationId_Organization_id_fk": {
+          "name": "AgentRegistration_organizationId_Organization_id_fk",
+          "tableFrom": "AgentRegistration",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentService": {
+      "name": "AgentService",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "trustMinimum": {
+          "name": "trustMinimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "callCount": {
+          "name": "callCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalRevenue": {
+          "name": "totalRevenue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentService_agent_id_idx": {
+          "name": "AgentService_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_user_id_idx": {
+          "name": "AgentService_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_category_idx": {
+          "name": "AgentService_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentService_status_idx": {
+          "name": "AgentService_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AgentService_userId_user_id_fk": {
+          "name": "AgentService_userId_user_id_fk",
+          "tableFrom": "AgentService",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AudioPlaybackState": {
+      "name": "AudioPlaybackState",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "audioSrc": {
+          "name": "audioSrc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentTime": {
+          "name": "currentTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "AudioPlaybackState_userId_user_id_fk": {
+          "name": "AudioPlaybackState_userId_user_id_fk",
+          "tableFrom": "AudioPlaybackState",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AuditLog": {
+      "name": "AuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AuditLog_org_id_idx": {
+          "name": "AuditLog_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_actor_id_idx": {
+          "name": "AuditLog_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_action_idx": {
+          "name": "AuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_created_at_idx": {
+          "name": "AuditLog_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AuditLog_agent_id_idx": {
+          "name": "AuditLog_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AuditLog_organizationId_Organization_id_fk": {
+          "name": "AuditLog_organizationId_Organization_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "AuditLog_actorId_user_id_fk": {
+          "name": "AuditLog_actorId_user_id_fk",
+          "tableFrom": "AuditLog",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_account": {
+      "name": "base_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_anima_did": {
+          "name": "linked_anima_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_link_verified_at": {
+          "name": "cross_link_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_account_user_id_user_id_fk": {
+          "name": "base_account_user_id_user_id_fk",
+          "tableFrom": "base_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "base_account_user_id_unique": {
+          "name": "base_account_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.base_auth_nonce": {
+      "name": "base_auth_nonce",
+      "schema": "",
+      "columns": {
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "base_auth_nonce_user_id_user_id_fk": {
+          "name": "base_auth_nonce_user_id_user_id_fk",
+          "tableFrom": "base_auth_nonce",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Chat_userId_user_id_fk": {
+          "name": "Chat_userId_user_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Chat_projectId_Project_id_fk": {
+          "name": "Chat_projectId_Project_id_fk",
+          "tableFrom": "Chat",
+          "tableTo": "Project",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DeviceAuthCode": {
+      "name": "DeviceAuthCode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deviceCode": {
+          "name": "deviceCode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCode": {
+          "name": "userCode",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cli'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pollingInterval": {
+          "name": "pollingInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "DeviceAuthCode_device_code_idx": {
+          "name": "DeviceAuthCode_device_code_idx",
+          "columns": [
+            {
+              "expression": "deviceCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DeviceAuthCode_user_code_idx": {
+          "name": "DeviceAuthCode_user_code_idx",
+          "columns": [
+            {
+              "expression": "userCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "DeviceAuthCode_userId_user_id_fk": {
+          "name": "DeviceAuthCode_userId_user_id_fk",
+          "tableFrom": "DeviceAuthCode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DeviceAuthCode_deviceCode_unique": {
+          "name": "DeviceAuthCode_deviceCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCode"
+          ]
+        },
+        "DeviceAuthCode_userCode_unique": {
+          "name": "DeviceAuthCode_userCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Document": {
+      "name": "Document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Document_message_id_idx": {
+          "name": "Document_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Document_userId_user_id_fk": {
+          "name": "Document_userId_user_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Document_messageId_Message_id_fk": {
+          "name": "Document_messageId_Message_id_fk",
+          "tableFrom": "Document",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Document_id_createdAt_pk": {
+          "name": "Document_id_createdAt_pk",
+          "columns": [
+            "id",
+            "createdAt"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EscrowTransaction": {
+      "name": "EscrowTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerOrgId": {
+          "name": "buyerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerOrgId": {
+          "name": "sellerOrgId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCredits": {
+          "name": "amountCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commissionCredits": {
+          "name": "commissionCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'held'"
+        },
+        "heldAt": {
+          "name": "heldAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "releasedAt": {
+          "name": "releasedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disputeReason": {
+          "name": "disputeReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "EscrowTransaction_task_id_idx": {
+          "name": "EscrowTransaction_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_buyer_idx": {
+          "name": "EscrowTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_seller_idx": {
+          "name": "EscrowTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerOrgId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EscrowTransaction_status_idx": {
+          "name": "EscrowTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EscrowTransaction_taskId_MarketplaceTask_id_fk": {
+          "name": "EscrowTransaction_taskId_MarketplaceTask_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "MarketplaceTask",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_buyerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_buyerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "buyerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "EscrowTransaction_sellerOrgId_Organization_id_fk": {
+          "name": "EscrowTransaction_sellerOrgId_Organization_id_fk",
+          "tableFrom": "EscrowTransaction",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "sellerOrgId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Handoff": {
+      "name": "Handoff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "handoff_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tldr": {
+          "name": "tldr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstAction": {
+          "name": "firstAction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specRefs": {
+          "name": "specRefs",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "sourceRepo": {
+          "name": "sourceRepo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourcePath": {
+          "name": "sourcePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceCommit": {
+          "name": "sourceCommit",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticketId": {
+          "name": "ticketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prNumber": {
+          "name": "prNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickedUpAt": {
+          "name": "pickedUpAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Handoff_owner_created_idx": {
+          "name": "Handoff_owner_created_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Handoff_owner_status_idx": {
+          "name": "Handoff_owner_status_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Handoff_owner_slug_version_uq": {
+          "name": "Handoff_owner_slug_version_uq",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Handoff_ownerId_user_id_fk": {
+          "name": "Handoff_ownerId_user_id_fk",
+          "tableFrom": "Handoff",
+          "tableTo": "user",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.HandoffEvent": {
+      "name": "HandoffEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handoffId": {
+          "name": "handoffId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "handoff_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "HandoffEvent_owner_created_idx": {
+          "name": "HandoffEvent_owner_created_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "HandoffEvent_handoff_idx": {
+          "name": "HandoffEvent_handoff_idx",
+          "columns": [
+            {
+              "expression": "handoffId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "HandoffEvent_handoffId_Handoff_id_fk": {
+          "name": "HandoffEvent_handoffId_Handoff_id_fk",
+          "tableFrom": "HandoffEvent",
+          "tableTo": "Handoff",
+          "columnsFrom": [
+            "handoffId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "HandoffEvent_ownerId_user_id_fk": {
+          "name": "HandoffEvent_ownerId_user_id_fk",
+          "tableFrom": "HandoffEvent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeByokKey": {
+      "name": "LifeByokKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ownerKind": {
+          "name": "ownerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedPayload": {
+          "name": "encryptedPayload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHint": {
+          "name": "keyHint",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeByokKey_owner_idx": {
+          "name": "LifeByokKey_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeModuleType": {
+      "name": "LifeModuleType",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runnerRef": {
+          "name": "runnerRef",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputSchema": {
+          "name": "inputSchema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputSchema": {
+          "name": "outputSchema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requiredTools": {
+          "name": "requiredTools",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "defaultUi": {
+          "name": "defaultUi",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'life-interface-classic'"
+        },
+        "costEstimateCents": {
+          "name": "costEstimateCents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"avg\":10,\"p95\":30}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeProject": {
+      "name": "LifeProject",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownerKind": {
+          "name": "ownerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moduleTypeId": {
+          "name": "moduleTypeId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentRulesVersionId": {
+          "name": "currentRulesVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secretsMode": {
+          "name": "secretsMode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "safetyFlags": {
+          "name": "safetyFlags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeProject_owner_idx": {
+          "name": "LifeProject_owner_idx",
+          "columns": [
+            {
+              "expression": "ownerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProject_visibility_idx": {
+          "name": "LifeProject_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProject_module_idx": {
+          "name": "LifeProject_module_idx",
+          "columns": [
+            {
+              "expression": "moduleTypeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeProject_moduleTypeId_LifeModuleType_id_fk": {
+          "name": "LifeProject_moduleTypeId_LifeModuleType_id_fk",
+          "tableFrom": "LifeProject",
+          "tableTo": "LifeModuleType",
+          "columnsFrom": [
+            "moduleTypeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "LifeProject_slug_unique": {
+          "name": "LifeProject_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeProjectFile": {
+      "name": "LifeProjectFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blobSha": {
+          "name": "blobSha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blobUrl": {
+          "name": "blobUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writtenBy": {
+          "name": "writtenBy",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeProjectFile_project_path_uq": {
+          "name": "LifeProjectFile_project_path_uq",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeProjectFile_written_by_idx": {
+          "name": "LifeProjectFile_written_by_idx",
+          "columns": [
+            {
+              "expression": "writtenBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeProjectFile_projectId_LifeProject_id_fk": {
+          "name": "LifeProjectFile_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeProjectFile",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeProjectFile_sessionId_LifeSession_id_fk": {
+          "name": "LifeProjectFile_sessionId_LifeSession_id_fk",
+          "tableFrom": "LifeProjectFile",
+          "tableTo": "LifeSession",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeReservedSlug": {
+      "name": "LifeReservedSlug",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform-reserved'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRulesVersion": {
+      "name": "LifeRulesVersion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rulesJson": {
+          "name": "rulesJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semver": {
+          "name": "semver",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRulesVersion_project_idx": {
+          "name": "LifeRulesVersion_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRulesVersion_projectId_LifeProject_id_fk": {
+          "name": "LifeRulesVersion_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeRulesVersion",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeRulesVersion_parentId_fk": {
+          "name": "LifeRulesVersion_parentId_fk",
+          "tableFrom": "LifeRulesVersion",
+          "tableTo": "LifeRulesVersion",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRun": {
+      "name": "LifeRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputText": {
+          "name": "inputText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rulesVersionId": {
+          "name": "rulesVersionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerKind": {
+          "name": "consumerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerId": {
+          "name": "consumerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "errorReason": {
+          "name": "errorReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llmCostCents": {
+          "name": "llmCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "platformFeeCents": {
+          "name": "platformFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "creatorFeeCents": {
+          "name": "creatorFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "consumerPaidCents": {
+          "name": "consumerPaidCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "paymentMode": {
+          "name": "paymentMode",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'credits'"
+        },
+        "paymentRail": {
+          "name": "paymentRail",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentTxId": {
+          "name": "paymentTxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byokKeyId": {
+          "name": "byokKeyId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishedAt": {
+          "name": "finishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRun_project_idx": {
+          "name": "LifeRun_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_consumer_idx": {
+          "name": "LifeRun_consumer_idx",
+          "columns": [
+            {
+              "expression": "consumerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_status_idx": {
+          "name": "LifeRun_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeRun_org_idx": {
+          "name": "LifeRun_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRun_projectId_LifeProject_id_fk": {
+          "name": "LifeRun_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "LifeRun_sessionId_LifeSession_id_fk": {
+          "name": "LifeRun_sessionId_LifeSession_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeSession",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeRun_rulesVersionId_LifeRulesVersion_id_fk": {
+          "name": "LifeRun_rulesVersionId_LifeRulesVersion_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeRulesVersion",
+          "columnsFrom": [
+            "rulesVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "LifeRun_organizationId_Organization_id_fk": {
+          "name": "LifeRun_organizationId_Organization_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "LifeRun_byokKeyId_LifeByokKey_id_fk": {
+          "name": "LifeRun_byokKeyId_LifeByokKey_id_fk",
+          "tableFrom": "LifeRun",
+          "tableTo": "LifeByokKey",
+          "columnsFrom": [
+            "byokKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRunEvent": {
+      "name": "LifeRunEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "LifeRunEvent_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "runId": {
+          "name": "runId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRunEvent_run_seq_uq": {
+          "name": "LifeRunEvent_run_seq_uq",
+          "columns": [
+            {
+              "expression": "runId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRunEvent_runId_LifeRun_id_fk": {
+          "name": "LifeRunEvent_runId_LifeRun_id_fk",
+          "tableFrom": "LifeRunEvent",
+          "tableTo": "LifeRun",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeRunSnapshot": {
+      "name": "LifeRunSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runId": {
+          "name": "runId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "atEventSeq": {
+          "name": "atEventSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sceneJson": {
+          "name": "sceneJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signalsJson": {
+          "name": "signalsJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeRunSnapshot_session_seq_idx": {
+          "name": "LifeRunSnapshot_session_seq_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "atEventSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeRunSnapshot_sessionId_LifeSession_id_fk": {
+          "name": "LifeRunSnapshot_sessionId_LifeSession_id_fk",
+          "tableFrom": "LifeRunSnapshot",
+          "tableTo": "LifeSession",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeRunSnapshot_runId_LifeRun_id_fk": {
+          "name": "LifeRunSnapshot_runId_LifeRun_id_fk",
+          "tableFrom": "LifeRunSnapshot",
+          "tableTo": "LifeRun",
+          "columnsFrom": [
+            "runId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeSession": {
+      "name": "LifeSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerKind": {
+          "name": "consumerKind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumerId": {
+          "name": "consumerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kernelVmHandleJson": {
+          "name": "kernelVmHandleJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeSession_project_idx": {
+          "name": "LifeSession_project_idx",
+          "columns": [
+            {
+              "expression": "projectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeSession_consumer_idx": {
+          "name": "LifeSession_consumer_idx",
+          "columns": [
+            {
+              "expression": "consumerKind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "LifeSession_chat_idx": {
+          "name": "LifeSession_chat_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeSession_projectId_LifeProject_id_fk": {
+          "name": "LifeSession_projectId_LifeProject_id_fk",
+          "tableFrom": "LifeSession",
+          "tableTo": "LifeProject",
+          "columnsFrom": [
+            "projectId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "LifeSession_organizationId_Organization_id_fk": {
+          "name": "LifeSession_organizationId_Organization_id_fk",
+          "tableFrom": "LifeSession",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "LifeSession_chatId_Chat_id_fk": {
+          "name": "LifeSession_chatId_Chat_id_fk",
+          "tableFrom": "LifeSession",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.LifeSessionFile": {
+      "name": "LifeSessionFile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blobSha": {
+          "name": "blobSha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blobUrl": {
+          "name": "blobUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "LifeSessionFile_session_path_uq": {
+          "name": "LifeSessionFile_session_path_uq",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "LifeSessionFile_sessionId_LifeSession_id_fk": {
+          "name": "LifeSessionFile_sessionId_LifeSession_id_fk",
+          "tableFrom": "LifeSessionFile",
+          "tableTo": "LifeSession",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTask": {
+      "name": "MarketplaceTask",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceCredits": {
+          "name": "priceCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "estimatedDurationMs": {
+          "name": "estimatedDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "MarketplaceTask_agent_id_idx": {
+          "name": "MarketplaceTask_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTask_status_idx": {
+          "name": "MarketplaceTask_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "MarketplaceTask_agentId_AgentRegistration_id_fk": {
+          "name": "MarketplaceTask_agentId_AgentRegistration_id_fk",
+          "tableFrom": "MarketplaceTask",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.MarketplaceTransaction": {
+      "name": "MarketplaceTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "serviceId": {
+          "name": "serviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "buyerAgentId": {
+          "name": "buyerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sellerAgentId": {
+          "name": "sellerAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountMicroUsd": {
+          "name": "amountMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facilitatorFeeMicroUsd": {
+          "name": "facilitatorFeeMicroUsd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "MarketplaceTransaction_service_id_idx": {
+          "name": "MarketplaceTransaction_service_id_idx",
+          "columns": [
+            {
+              "expression": "serviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_buyer_idx": {
+          "name": "MarketplaceTransaction_buyer_idx",
+          "columns": [
+            {
+              "expression": "buyerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_seller_idx": {
+          "name": "MarketplaceTransaction_seller_idx",
+          "columns": [
+            {
+              "expression": "sellerAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "MarketplaceTransaction_status_idx": {
+          "name": "MarketplaceTransaction_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpConnector": {
+      "name": "McpConnector",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameId": {
+          "name": "nameId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'http'"
+        },
+        "oauthClientId": {
+          "name": "oauthClientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauthClientSecret": {
+          "name": "oauthClientSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpConnector_user_id_idx": {
+          "name": "McpConnector_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_idx": {
+          "name": "McpConnector_user_name_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpConnector_user_name_id_unique": {
+          "name": "McpConnector_user_name_id_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpConnector_userId_user_id_fk": {
+          "name": "McpConnector_userId_user_id_fk",
+          "tableFrom": "McpConnector",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.McpOAuthSession": {
+      "name": "McpOAuthSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mcpConnectorId": {
+          "name": "mcpConnectorId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serverUrl": {
+          "name": "serverUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientInfo": {
+          "name": "clientInfo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "McpOAuthSession_connector_idx": {
+          "name": "McpOAuthSession_connector_idx",
+          "columns": [
+            {
+              "expression": "mcpConnectorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "McpOAuthSession_state_idx": {
+          "name": "McpOAuthSession_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "McpOAuthSession_mcpConnectorId_McpConnector_id_fk": {
+          "name": "McpOAuthSession_mcpConnectorId_McpConnector_id_fk",
+          "tableFrom": "McpOAuthSession",
+          "tableTo": "McpConnector",
+          "columnsFrom": [
+            "mcpConnectorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "McpOAuthSession_state_unique": {
+          "name": "McpOAuthSession_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedModel": {
+          "name": "selectedModel",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "selectedTool": {
+          "name": "selectedTool",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "lastContext": {
+          "name": "lastContext",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeStreamId": {
+          "name": "activeStreamId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceledAt": {
+          "name": "canceledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Message_chatId_Chat_id_fk": {
+          "name": "Message_chatId_Chat_id_fk",
+          "tableFrom": "Message",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planCreditsMonthly": {
+          "name": "planCreditsMonthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "planCreditsRemaining": {
+          "name": "planCreditsRemaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "billingPeriodStart": {
+          "name": "billingPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neonBranchId": {
+          "name": "neonBranchId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Organization_slug_idx": {
+          "name": "Organization_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_stripe_customer_idx": {
+          "name": "Organization_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripeCustomerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_unique": {
+          "name": "Organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationApiKey": {
+      "name": "OrganizationApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdByUserId": {
+          "name": "createdByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'*'"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationApiKey_org_id_idx": {
+          "name": "OrganizationApiKey_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationApiKey_key_prefix_idx": {
+          "name": "OrganizationApiKey_key_prefix_idx",
+          "columns": [
+            {
+              "expression": "keyPrefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationApiKey_organizationId_Organization_id_fk": {
+          "name": "OrganizationApiKey_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationApiKey_createdByUserId_user_id_fk": {
+          "name": "OrganizationApiKey_createdByUserId_user_id_fk",
+          "tableFrom": "OrganizationApiKey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "createdByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationArcanRole": {
+      "name": "OrganizationArcanRole",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleName": {
+          "name": "roleName",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowCapabilities": {
+          "name": "allowCapabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "maxEventsPerTurn": {
+          "name": "maxEventsPerTurn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgArcanRole_org_idx": {
+          "name": "OrgArcanRole_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgArcanRole_org_role_unique": {
+          "name": "OrgArcanRole_org_role_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roleName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationArcanRole_organizationId_Organization_id_fk": {
+          "name": "OrganizationArcanRole_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationArcanRole",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationCustomSkill": {
+      "name": "OrganizationCustomSkill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifestToml": {
+          "name": "manifestToml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgCustomSkill_org_idx": {
+          "name": "OrgCustomSkill_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgCustomSkill_org_name_unique": {
+          "name": "OrgCustomSkill_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationCustomSkill_organizationId_Organization_id_fk": {
+          "name": "OrganizationCustomSkill_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationCustomSkill",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationLifeInstance": {
+      "name": "OrganizationLifeInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "railwayProjectId": {
+          "name": "railwayProjectId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "railwayEnvironmentId": {
+          "name": "railwayEnvironmentId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "arcanUrl": {
+          "name": "arcanUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lagoUrl": {
+          "name": "lagoUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autonomicUrl": {
+          "name": "autonomicUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "haimaUrl": {
+          "name": "haimaUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthCheck": {
+          "name": "lastHealthCheck",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastHealthStatus": {
+          "name": "lastHealthStatus",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationLifeInstance_org_id_idx": {
+          "name": "OrganizationLifeInstance_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationLifeInstance_organizationId_Organization_id_fk": {
+          "name": "OrganizationLifeInstance_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationLifeInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMcpServer": {
+      "name": "OrganizationMcpServer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearerToken": {
+          "name": "bearerToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedRoles": {
+          "name": "assignedRoles",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrgMcpServer_org_idx": {
+          "name": "OrgMcpServer_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMcpServer_org_name_unique": {
+          "name": "OrgMcpServer_org_name_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMcpServer_organizationId_Organization_id_fk": {
+          "name": "OrganizationMcpServer_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMcpServer",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationMember": {
+      "name": "OrganizationMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OrganizationMember_org_id_idx": {
+          "name": "OrganizationMember_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_user_id_idx": {
+          "name": "OrganizationMember_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationMember_org_user_unique": {
+          "name": "OrganizationMember_org_user_unique",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrganizationMember_organizationId_Organization_id_fk": {
+          "name": "OrganizationMember_organizationId_Organization_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "OrganizationMember_userId_user_id_fk": {
+          "name": "OrganizationMember_userId_user_id_fk",
+          "tableFrom": "OrganizationMember",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Part": {
+      "name": "Part",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_text": {
+          "name": "text_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_text": {
+          "name": "reasoning_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mediaType": {
+          "name": "file_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_filename": {
+          "name": "file_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_sourceId": {
+          "name": "source_url_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_url": {
+          "name": "source_url_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url_title": {
+          "name": "source_url_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_sourceId": {
+          "name": "source_document_sourceId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_mediaType": {
+          "name": "source_document_mediaType",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_title": {
+          "name": "source_document_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_document_filename": {
+          "name": "source_document_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_toolCallId": {
+          "name": "tool_toolCallId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_state": {
+          "name": "tool_state",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_errorText": {
+          "name": "tool_errorText",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_blob": {
+          "name": "data_blob",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Part_message_id_idx": {
+          "name": "Part_message_id_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Part_message_id_order_idx": {
+          "name": "Part_message_id_order_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Part_messageId_Message_id_fk": {
+          "name": "Part_messageId_Message_id_fk",
+          "tableFrom": "Part",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "Part_text_required_if_type_text": {
+          "name": "Part_text_required_if_type_text",
+          "value": "CASE WHEN \"Part\".\"type\" = 'text' THEN \"Part\".\"text_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_reasoning_required_if_type_reasoning": {
+          "name": "Part_reasoning_required_if_type_reasoning",
+          "value": "CASE WHEN \"Part\".\"type\" = 'reasoning' THEN \"Part\".\"reasoning_text\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_file_required_if_type_file": {
+          "name": "Part_file_required_if_type_file",
+          "value": "CASE WHEN \"Part\".\"type\" = 'file' THEN \"Part\".\"file_mediaType\" IS NOT NULL AND \"Part\".\"file_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_url_required_if_type_source_url": {
+          "name": "Part_source_url_required_if_type_source_url",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-url' THEN \"Part\".\"source_url_sourceId\" IS NOT NULL AND \"Part\".\"source_url_url\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_source_document_required_if_type_source_document": {
+          "name": "Part_source_document_required_if_type_source_document",
+          "value": "CASE WHEN \"Part\".\"type\" = 'source-document' THEN \"Part\".\"source_document_sourceId\" IS NOT NULL AND \"Part\".\"source_document_mediaType\" IS NOT NULL AND \"Part\".\"source_document_title\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_tool_required_if_type_tool": {
+          "name": "Part_tool_required_if_type_tool",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'tool-%' THEN \"Part\".\"tool_toolCallId\" IS NOT NULL AND \"Part\".\"tool_state\" IS NOT NULL ELSE TRUE END"
+        },
+        "Part_data_required_if_type_data": {
+          "name": "Part_data_required_if_type_data",
+          "value": "CASE WHEN \"Part\".\"type\" LIKE 'data-%' THEN \"Part\".\"data_type\" IS NOT NULL ELSE TRUE END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.Project": {
+      "name": "Project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder'"
+        },
+        "iconColor": {
+          "name": "iconColor",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gray'"
+        }
+      },
+      "indexes": {
+        "Project_user_id_idx": {
+          "name": "Project_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Project_userId_user_id_fk": {
+          "name": "Project_userId_user_id_fk",
+          "tableFrom": "Project",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptFeedback": {
+      "name": "PromptFeedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invocationId": {
+          "name": "invocationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptSlug": {
+          "name": "promptSlug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptVersion": {
+          "name": "promptVersion",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signal": {
+          "name": "signal",
+          "type": "prompt_feedback_signal",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "prompt_invocation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PromptFeedback_slug_created_idx": {
+          "name": "PromptFeedback_slug_created_idx",
+          "columns": [
+            {
+              "expression": "promptSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptFeedback_invocation_idx": {
+          "name": "PromptFeedback_invocation_idx",
+          "columns": [
+            {
+              "expression": "invocationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PromptFeedback_invocationId_PromptInvocation_id_fk": {
+          "name": "PromptFeedback_invocationId_PromptInvocation_id_fk",
+          "tableFrom": "PromptFeedback",
+          "tableTo": "PromptInvocation",
+          "columnsFrom": [
+            "invocationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "PromptFeedback_userId_user_id_fk": {
+          "name": "PromptFeedback_userId_user_id_fk",
+          "tableFrom": "PromptFeedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PromptInvocation": {
+      "name": "PromptInvocation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "promptSlug": {
+          "name": "promptSlug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptVersion": {
+          "name": "promptVersion",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "prompt_invocation_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caller": {
+          "name": "caller",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clientIpHash": {
+          "name": "clientIpHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prompt_invocation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pulled'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latencyMs": {
+          "name": "latencyMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokensIn": {
+          "name": "tokensIn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokensOut": {
+          "name": "tokensOut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costUsd": {
+          "name": "costUsd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalTraceId": {
+          "name": "externalTraceId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalSpanId": {
+          "name": "externalSpanId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PromptInvocation_slug_created_idx": {
+          "name": "PromptInvocation_slug_created_idx",
+          "columns": [
+            {
+              "expression": "promptSlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptInvocation_created_idx": {
+          "name": "PromptInvocation_created_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptInvocation_source_created_idx": {
+          "name": "PromptInvocation_source_created_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptInvocation_user_created_idx": {
+          "name": "PromptInvocation_user_created_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PromptInvocation_status_idx": {
+          "name": "PromptInvocation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "PromptInvocation_userId_user_id_fk": {
+          "name": "PromptInvocation_userId_user_id_fk",
+          "tableFrom": "PromptInvocation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RefreshToken": {
+      "name": "RefreshToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RefreshToken_user_id_idx": {
+          "name": "RefreshToken_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_token_hash_idx": {
+          "name": "RefreshToken_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RefreshToken_expires_at_idx": {
+          "name": "RefreshToken_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RefreshToken_userId_user_id_fk": {
+          "name": "RefreshToken_userId_user_id_fk",
+          "tableFrom": "RefreshToken",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "RefreshToken_tokenHash_unique": {
+          "name": "RefreshToken_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelayNode": {
+      "name": "RelayNode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'offline'"
+        },
+        "lastSeenAt": {
+          "name": "lastSeenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelayNode_user_idx": {
+          "name": "RelayNode_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelayNode_status_idx": {
+          "name": "RelayNode_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelayNode_userId_user_id_fk": {
+          "name": "RelayNode_userId_user_id_fk",
+          "tableFrom": "RelayNode",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RelaySession": {
+      "name": "RelaySession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "nodeId": {
+          "name": "nodeId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionType": {
+          "name": "sessionType",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workdir": {
+          "name": "workdir",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remoteSessionId": {
+          "name": "remoteSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSequence": {
+          "name": "lastSequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claudeSessionId": {
+          "name": "claudeSessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "RelaySession_node_idx": {
+          "name": "RelaySession_node_idx",
+          "columns": [
+            {
+              "expression": "nodeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_user_idx": {
+          "name": "RelaySession_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RelaySession_status_idx": {
+          "name": "RelaySession_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "RelaySession_nodeId_RelayNode_id_fk": {
+          "name": "RelaySession_nodeId_RelayNode_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "RelayNode",
+          "columnsFrom": [
+            "nodeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "RelaySession_userId_user_id_fk": {
+          "name": "RelaySession_userId_user_id_fk",
+          "tableFrom": "RelaySession",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxInstance": {
+      "name": "SandboxInstance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'starting'"
+        },
+        "vcpus": {
+          "name": "vcpus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memoryMb": {
+          "name": "memoryMb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persistent": {
+          "name": "persistent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastExecAt": {
+          "name": "lastExecAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execCount": {
+          "name": "execCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxInstance_org_idx": {
+          "name": "SandboxInstance_org_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_agent_idx": {
+          "name": "SandboxInstance_agent_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_status_idx": {
+          "name": "SandboxInstance_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SandboxInstance_provider_idx": {
+          "name": "SandboxInstance_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxInstance_organizationId_Organization_id_fk": {
+          "name": "SandboxInstance_organizationId_Organization_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SandboxInstance_agentId_AgentRegistration_id_fk": {
+          "name": "SandboxInstance_agentId_AgentRegistration_id_fk",
+          "tableFrom": "SandboxInstance",
+          "tableTo": "AgentRegistration",
+          "columnsFrom": [
+            "agentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "SandboxInstance_sandboxId_unique": {
+          "name": "SandboxInstance_sandboxId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sandboxId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SandboxSnapshot": {
+      "name": "SandboxSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sandboxInstanceId": {
+          "name": "sandboxInstanceId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotId": {
+          "name": "snapshotId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SandboxSnapshot_instance_idx": {
+          "name": "SandboxSnapshot_instance_idx",
+          "columns": [
+            {
+              "expression": "sandboxInstanceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk": {
+          "name": "SandboxSnapshot_sandboxInstanceId_SandboxInstance_id_fk",
+          "tableFrom": "SandboxSnapshot",
+          "tableTo": "SandboxInstance",
+          "columnsFrom": [
+            "sandboxInstanceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SpecDoc": {
+      "name": "SpecDoc",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "state": {
+          "name": "state",
+          "type": "spec_doc_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceRepo": {
+          "name": "sourceRepo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourcePath": {
+          "name": "sourcePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceCommit": {
+          "name": "sourceCommit",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticketId": {
+          "name": "ticketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prNumber": {
+          "name": "prNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orchState": {
+          "name": "orchState",
+          "type": "spec_doc_orch_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "altitude": {
+          "name": "altitude",
+          "type": "spec_doc_altitude",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'task'"
+        },
+        "dispatchCount": {
+          "name": "dispatchCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SpecDoc_owner_created_idx": {
+          "name": "SpecDoc_owner_created_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SpecDoc_owner_handle_version_uq": {
+          "name": "SpecDoc_owner_handle_version_uq",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SpecDoc_ownerId_user_id_fk": {
+          "name": "SpecDoc_ownerId_user_id_fk",
+          "tableFrom": "SpecDoc",
+          "tableTo": "user",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SpecDocRun": {
+      "name": "SpecDocRun",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "specDocId": {
+          "name": "specDocId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specVersion": {
+          "name": "specVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "spec_doc_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "runRef": {
+          "name": "runRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "maxAttempts": {
+          "name": "maxAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "lastSeq": {
+          "name": "lastSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt": {
+          "name": "receipt",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotencyKey": {
+          "name": "idempotencyKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SpecDocRun_owner_created_idx": {
+          "name": "SpecDocRun_owner_created_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SpecDocRun_specDoc_idx": {
+          "name": "SpecDocRun_specDoc_idx",
+          "columns": [
+            {
+              "expression": "specDocId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SpecDocRun_idempotency_uq": {
+          "name": "SpecDocRun_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotencyKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SpecDocRun_specDocId_SpecDoc_id_fk": {
+          "name": "SpecDocRun_specDocId_SpecDoc_id_fk",
+          "tableFrom": "SpecDocRun",
+          "tableTo": "SpecDoc",
+          "columnsFrom": [
+            "specDocId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SpecDocRun_ownerId_user_id_fk": {
+          "name": "SpecDocRun_ownerId_user_id_fk",
+          "tableFrom": "SpecDocRun",
+          "tableTo": "user",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Suggestion": {
+      "name": "Suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "documentId": {
+          "name": "documentId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "documentCreatedAt": {
+          "name": "documentCreatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalText": {
+          "name": "originalText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedText": {
+          "name": "suggestedText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Suggestion_userId_user_id_fk": {
+          "name": "Suggestion_userId_user_id_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk": {
+          "name": "Suggestion_documentId_documentCreatedAt_Document_id_createdAt_fk",
+          "tableFrom": "Suggestion",
+          "tableTo": "Document",
+          "columnsFrom": [
+            "documentId",
+            "documentCreatedAt"
+          ],
+          "columnsTo": [
+            "id",
+            "createdAt"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Suggestion_id_pk": {
+          "name": "Suggestion_id_pk",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UsageEvent": {
+      "name": "UsageEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costCents": {
+          "name": "costCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeMeterEventId": {
+          "name": "stripeMeterEventId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UsageEvent_org_id_idx": {
+          "name": "UsageEvent_org_id_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_user_id_idx": {
+          "name": "UsageEvent_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_created_at_idx": {
+          "name": "UsageEvent_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_org_created_idx": {
+          "name": "UsageEvent_org_created_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UsageEvent_agent_id_idx": {
+          "name": "UsageEvent_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UsageEvent_organizationId_Organization_id_fk": {
+          "name": "UsageEvent_organizationId_Organization_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "UsageEvent_userId_user_id_fk": {
+          "name": "UsageEvent_userId_user_id_fk",
+          "tableFrom": "UsageEvent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserCredit": {
+      "name": "UserCredit",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "UserCredit_userId_user_id_fk": {
+          "name": "UserCredit_userId_user_id_fk",
+          "tableFrom": "UserCredit",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserModelPreference": {
+      "name": "UserModelPreference",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserModelPreference_user_id_idx": {
+          "name": "UserModelPreference_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserModelPreference_userId_user_id_fk": {
+          "name": "UserModelPreference_userId_user_id_fk",
+          "tableFrom": "UserModelPreference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "UserModelPreference_userId_modelId_pk": {
+          "name": "UserModelPreference_userId_modelId_pk",
+          "columns": [
+            "userId",
+            "modelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserPrompt": {
+      "name": "UserPrompt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::json"
+        },
+        "variables": {
+          "name": "variables",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "copyCount": {
+          "name": "copyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isHighlighted": {
+          "name": "isHighlighted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserPrompt_user_id_idx": {
+          "name": "UserPrompt_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_visibility_idx": {
+          "name": "UserPrompt_visibility_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPrompt_slug_unique": {
+          "name": "UserPrompt_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserPrompt_userId_user_id_fk": {
+          "name": "UserPrompt_userId_user_id_fk",
+          "tableFrom": "UserPrompt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserVault": {
+      "name": "UserVault",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lagoSessionId": {
+          "name": "lagoSessionId",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserVault_user_id_idx": {
+          "name": "UserVault_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserVault_lago_session_unique": {
+          "name": "UserVault_lago_session_unique",
+          "columns": [
+            {
+              "expression": "lagoSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserVault_userId_user_id_fk": {
+          "name": "UserVault_userId_user_id_fk",
+          "tableFrom": "UserVault",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Vote": {
+      "name": "Vote",
+      "schema": "",
+      "columns": {
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUpvoted": {
+          "name": "isUpvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "Vote_chatId_Chat_id_fk": {
+          "name": "Vote_chatId_Chat_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Vote_messageId_Message_id_fk": {
+          "name": "Vote_messageId_Message_id_fk",
+          "tableFrom": "Vote",
+          "tableTo": "Message",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "Vote_chatId_messageId_pk": {
+          "name": "Vote_chatId_messageId_pk",
+          "columns": [
+            "chatId",
+            "messageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.handoff_event_type": {
+      "name": "handoff_event_type",
+      "schema": "public",
+      "values": [
+        "pushed",
+        "picked_up",
+        "completed",
+        "archived",
+        "restored",
+        "superseded",
+        "linked",
+        "note"
+      ]
+    },
+    "public.handoff_status": {
+      "name": "handoff_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "in_progress",
+        "done",
+        "archived",
+        "superseded"
+      ]
+    },
+    "public.prompt_feedback_signal": {
+      "name": "prompt_feedback_signal",
+      "schema": "public",
+      "values": [
+        "thumbs_up",
+        "thumbs_down"
+      ]
+    },
+    "public.prompt_invocation_source": {
+      "name": "prompt_invocation_source",
+      "schema": "public",
+      "values": [
+        "web",
+        "cli",
+        "skill",
+        "api"
+      ]
+    },
+    "public.prompt_invocation_status": {
+      "name": "prompt_invocation_status",
+      "schema": "public",
+      "values": [
+        "pulled",
+        "completed",
+        "failed",
+        "abandoned"
+      ]
+    },
+    "public.spec_doc_altitude": {
+      "name": "spec_doc_altitude",
+      "schema": "public",
+      "values": [
+        "task",
+        "feature",
+        "project",
+        "initiative"
+      ]
+    },
+    "public.spec_doc_orch_state": {
+      "name": "spec_doc_orch_state",
+      "schema": "public",
+      "values": [
+        "proposed",
+        "reviewing",
+        "triggered",
+        "running",
+        "blocked",
+        "review",
+        "done",
+        "canceled"
+      ]
+    },
+    "public.spec_doc_run_status": {
+      "name": "spec_doc_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.spec_doc_state": {
+      "name": "spec_doc_state",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published",
+        "superseded",
+        "archived",
+        "expired"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/broomva/lib/db/migrations/meta/_journal.json
+++ b/apps/broomva/lib/db/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1780512540208,
       "tag": "0074_minor_satana",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1780697010456,
+      "tag": "0075_pretty_toad_men",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/broomva/lib/db/schema.ts
+++ b/apps/broomva/lib/db/schema.ts
@@ -2226,6 +2226,138 @@ export const specDocRun = pgTable(
 export type SpecDocRun = InferSelectModel<typeof specDocRun>;
 export type SpecDocRunStatus = (typeof specDocRunStatusEnum.enumValues)[number];
 
+// ---------------------------------------------------------------------------
+// Handoff Queue (BRO-1415) — the narrative bridge that triggers the NEXT
+// session. Where SpecDoc orchestrates HTML *specs* served at /d/<handle>,
+// Handoff orchestrates the human-readable *handoff docs* the `/handoff` skill
+// writes (TL;DR + P15 snapshot + PR table + first action). Pushed via
+// `broomva handoff push`, queued, related to specs, and run by Copy/Continue —
+// the same fresh-session trigger the Maestro spec board uses (BRO-1399). The
+// queue lives at /maestro/queue; HandoffEvent drives its realtime timeline.
+// ---------------------------------------------------------------------------
+
+/**
+ * Handoff queue lifecycle. One handoff moves queued → in_progress (a fresh
+ * session picked it up via Copy/Continue) → done. `archived` = set aside;
+ * `superseded` = replaced by a newer version of the same slug (re-push).
+ */
+export const handoffStatusEnum = pgEnum("handoff_status", [
+  "queued",
+  "in_progress",
+  "done",
+  "archived",
+  "superseded",
+]);
+
+export const handoff = pgTable(
+  "Handoff",
+  {
+    id: text("id").primaryKey(),
+    ownerId: text("ownerId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    // Stable arc identity; re-pushing the same slug appends a version and
+    // supersedes the prior active one (mirrors SpecDoc handle/version).
+    slug: text("slug"),
+    version: integer("version").notNull().default(1),
+    status: handoffStatusEnum("status").notNull().default("queued"),
+    // Queue ordering — higher first, then createdAt desc.
+    priority: integer("priority").notNull().default(0),
+    title: text("title").notNull(),
+    // One-sentence queue headline (the handoff's TL;DR).
+    tldr: text("tldr"),
+    // Full markdown narrative (P18: agent-loaded → markdown). Capped server-side.
+    body: text("body").notNull(),
+    // The Copy-button payload — the continue-prompt / first action handed to a
+    // fresh session. Null → derived from a default continue-prompt at render.
+    firstAction: text("firstAction"),
+    // Related spec handles (the HTML specs at /d/<handle> this handoff relates
+    // to) — the "articulate + relate specs with handoffs" linkage.
+    specRefs: json("specRefs").$type<string[]>().notNull().default([]),
+    // Provenance (git archival + work linkage).
+    sourceRepo: text("sourceRepo"),
+    sourcePath: text("sourcePath"),
+    sourceCommit: varchar("sourceCommit", { length: 64 }),
+    branch: text("branch"),
+    ticketId: text("ticketId"),
+    prNumber: integer("prNumber"),
+    sessionId: text("sessionId"),
+    // Lifecycle timestamps (drive analytics: pickup latency, throughput).
+    pickedUpAt: timestamp("pickedUpAt"),
+    completedAt: timestamp("completedAt"),
+    expiresAt: timestamp("expiresAt"),
+    deletedAt: timestamp("deletedAt"),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+    updatedAt: timestamp("updatedAt")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date()),
+  },
+  (t) => ({
+    Handoff_owner_created_idx: index("Handoff_owner_created_idx").on(
+      t.ownerId,
+      t.createdAt,
+    ),
+    Handoff_owner_status_idx: index("Handoff_owner_status_idx").on(
+      t.ownerId,
+      t.status,
+    ),
+    Handoff_owner_slug_version_uq: uniqueIndex(
+      "Handoff_owner_slug_version_uq",
+    ).on(t.ownerId, t.slug, t.version),
+  }),
+);
+
+export type Handoff = InferSelectModel<typeof handoff>;
+export type HandoffStatus = (typeof handoffStatusEnum.enumValues)[number];
+
+/**
+ * Handoff timeline event types — the append-only stream behind the realtime
+ * card on /maestro/queue. Each push / status transition / spec-link emits one
+ * row; the SSE endpoint tails this table.
+ */
+export const handoffEventTypeEnum = pgEnum("handoff_event_type", [
+  "pushed",
+  "picked_up",
+  "completed",
+  "archived",
+  "restored",
+  "superseded",
+  "linked",
+  "note",
+]);
+
+export const handoffEvent = pgTable(
+  "HandoffEvent",
+  {
+    id: text("id").primaryKey(),
+    handoffId: text("handoffId")
+      .notNull()
+      .references(() => handoff.id, { onDelete: "cascade" }),
+    ownerId: text("ownerId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    type: handoffEventTypeEnum("type").notNull(),
+    // Who/what drove it: "cli" | "web" | "agent" | "system".
+    actor: varchar("actor", { length: 32 }).notNull().default("system"),
+    // Human-readable timeline line.
+    message: text("message"),
+    metadata: json("metadata").$type<Record<string, unknown>>(),
+    createdAt: timestamp("createdAt").notNull().defaultNow(),
+  },
+  (t) => ({
+    HandoffEvent_owner_created_idx: index("HandoffEvent_owner_created_idx").on(
+      t.ownerId,
+      t.createdAt,
+    ),
+    HandoffEvent_handoff_idx: index("HandoffEvent_handoff_idx").on(t.handoffId),
+  }),
+);
+
+export type HandoffEvent = InferSelectModel<typeof handoffEvent>;
+export type HandoffEventType =
+  (typeof handoffEventTypeEnum.enumValues)[number];
+
 export const schema = { user, session, account, verification };
 
 export const baseAccount = pgTable("base_account", {

--- a/crates/broomva-cli/src/api/mod.rs
+++ b/crates/broomva-cli/src/api/mod.rs
@@ -258,6 +258,51 @@ impl BroomvaClient {
         Ok(())
     }
 
+    // ── Handoff Queue (BRO-1415) ──
+
+    /// Push a handoff onto the queue. Returns `{ id, slug, url, … }`; `url` is
+    /// the queue board (`<base>/maestro/queue`).
+    pub async fn push_handoff(
+        &self,
+        req: PushHandoffRequest,
+    ) -> BroomvaResult<PushHandoffResponse> {
+        let resp = self
+            .request(Method::POST, "/api/handoffs")
+            .json(&req)
+            .send()
+            .await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    /// List the authenticated owner's active queue (metadata only).
+    pub async fn list_handoffs(&self) -> BroomvaResult<Vec<HandoffSummary>> {
+        let resp = self.request(Method::GET, "/api/handoffs").send().await?;
+        let resp = self.check_response(resp).await?;
+        Ok(resp.json().await?)
+    }
+
+    /// Apply a queue transition (`pick_up` | `complete` | `archive` | `requeue`).
+    pub async fn set_handoff_status(&self, id: &str, action: &str) -> BroomvaResult<()> {
+        let resp = self
+            .request(Method::PATCH, &format!("/api/handoffs/{id}"))
+            .json(&serde_json::json!({ "action": action }))
+            .send()
+            .await?;
+        self.check_response(resp).await?;
+        Ok(())
+    }
+
+    /// Delete an owned handoff by id.
+    pub async fn delete_handoff(&self, id: &str) -> BroomvaResult<()> {
+        let resp = self
+            .request(Method::DELETE, &format!("/api/handoffs/{id}"))
+            .send()
+            .await?;
+        self.check_response(resp).await?;
+        Ok(())
+    }
+
     // ── Skills ──
 
     pub async fn list_skills(&self, layer: Option<&str>) -> BroomvaResult<Vec<SkillSummary>> {

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -557,6 +557,107 @@ pub struct DocContentResponse {
     pub html: String,
 }
 
+// ── Handoff Queue (BRO-1415) ──
+//
+// `broomva handoff push <file.md>` pushes a narrative handoff onto the queue
+// at `<base>/maestro/queue`, related to the HTML specs it references, run by
+// the same Copy/Continue fresh-session trigger the Maestro spec board uses.
+
+/// Git provenance + work-linkage for a pushed handoff.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffSource {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ticket: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+}
+
+impl HandoffSource {
+    pub fn is_empty(&self) -> bool {
+        self.repo.is_none()
+            && self.path.is_none()
+            && self.commit.is_none()
+            && self.branch.is_none()
+            && self.ticket.is_none()
+            && self.pr.is_none()
+            && self.session.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushHandoffRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub body: String,
+    /// Stable arc slug; re-pushing the same slug appends a version.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tldr: Option<String>,
+    /// The Copy-button payload (continue-prompt / first action).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_action: Option<String>,
+    /// Related spec handles (the HTML specs at /d/<handle>).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub spec_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<HandoffSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushHandoffResponse {
+    pub id: String,
+    #[serde(default)]
+    pub slug: Option<String>,
+    #[serde(default = "default_doc_version")]
+    pub version: i64,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub spec_refs: Vec<String>,
+    pub url: String,
+}
+
+/// One row of `GET /api/handoffs` (metadata only — excludes the body).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffSummary {
+    pub id: String,
+    #[serde(default)]
+    pub slug: Option<String>,
+    #[serde(default = "default_doc_version")]
+    pub version: i64,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub tldr: Option<String>,
+    #[serde(default)]
+    pub spec_refs: Vec<String>,
+    #[serde(default)]
+    pub ticket_id: Option<String>,
+    #[serde(default)]
+    pub created_at: String,
+}
+
 #[cfg(test)]
 mod telemetry_types_tests {
     use super::*;

--- a/crates/broomva-cli/src/cli/handoff.rs
+++ b/crates/broomva-cli/src/cli/handoff.rs
@@ -163,6 +163,12 @@ fn extract_tldr(md: &str) -> Option<String> {
         let Some(idx) = line.find("TL;DR") else {
             continue;
         };
+        // Require the bold lead marker (`**TL;DR`) so a prose mention of "TL;DR"
+        // mid-narrative isn't mistaken for the lead line (matches the server's
+        // `**TL;DR**` matcher).
+        if !line[..idx].trim_end().ends_with("**") {
+            continue;
+        }
         // Everything after the TL;DR label; drop closing `**` and punctuation.
         let after = &line[idx + "TL;DR".len()..];
         let after = after.trim_start_matches(['*', '.', ':', ' ']);
@@ -320,6 +326,13 @@ mod tests {
     fn extracts_tldr_with_colon() {
         let md = "**TL;DR:** Do the thing.";
         assert_eq!(extract_tldr(md).as_deref(), Some("Do the thing."));
+    }
+
+    #[test]
+    fn ignores_prose_tldr_without_bold_marker() {
+        // A narrative mention of TL;DR is not the lead line.
+        let md = "I'll write the TL;DR after the snapshot.\n\n**TL;DR.** Real one.";
+        assert_eq!(extract_tldr(md).as_deref(), Some("Real one."));
     }
 
     #[test]

--- a/crates/broomva-cli/src/cli/handoff.rs
+++ b/crates/broomva-cli/src/cli/handoff.rs
@@ -1,0 +1,349 @@
+//! `broomva handoff` — push narrative handoff docs onto the Maestro queue
+//! (BRO-1415). Where `broomva docs publish` uploads an HTML *spec* to
+//! `/d/<handle>`, `broomva handoff push <file.md>` pushes the *handoff* the
+//! `/handoff` skill writes (TL;DR + P15 snapshot + first action) onto the queue
+//! at `/maestro/queue`, related to the specs it references and run by the same
+//! Copy/Continue fresh-session trigger.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+
+use crate::api::BroomvaClient;
+use crate::api::types::{HandoffSource, PushHandoffRequest};
+use crate::cli::output::{OutputFormat, print_json, print_kv, print_table};
+use crate::error::{BroomvaError, BroomvaResult};
+
+/// Push a local markdown handoff → prints the queue URL.
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_push(
+    client: &BroomvaClient,
+    file: &str,
+    title: Option<String>,
+    slug: Option<String>,
+    specs: Vec<String>,
+    ticket: Option<String>,
+    priority: Option<i64>,
+    commit: bool,
+    format: OutputFormat,
+) -> BroomvaResult<()> {
+    let path = Path::new(file);
+    if !path.exists() {
+        return Err(BroomvaError::User(format!("file not found: {file}")));
+    }
+    // Fail fast on oversize before reading/uploading (server caps at ~1 MB).
+    const MAX_BYTES: u64 = 1_000_000;
+    if let Ok(meta) = fs::metadata(path)
+        && meta.len() > MAX_BYTES
+    {
+        return Err(BroomvaError::User(format!(
+            "file too large: {} bytes (max {MAX_BYTES}). The server rejects handoffs over ~1 MB.",
+            meta.len()
+        )));
+    }
+    let body = fs::read_to_string(path)?;
+
+    // Title precedence: explicit --title → first `# ` heading → file stem.
+    let resolved_title = title
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .or_else(|| extract_h1_title(&body))
+        .or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()));
+
+    let tldr = extract_tldr(&body);
+    let first_action = extract_section(&body, "First action");
+
+    // git archival: --commit stages + commits the file first.
+    if commit {
+        commit_file(path)?;
+    }
+
+    let mut source = detect_git_source(path).unwrap_or_default();
+    if let Some(t) = ticket.map(|t| t.trim().to_string()).filter(|t| !t.is_empty()) {
+        source.ticket = Some(t);
+    }
+    let source = if source.is_empty() { None } else { Some(source) };
+
+    let req = PushHandoffRequest {
+        title: resolved_title,
+        body,
+        slug: slug.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
+        tldr,
+        first_action,
+        spec_refs: specs
+            .into_iter()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        priority,
+        source,
+    };
+    let resp = client.push_handoff(req).await?;
+
+    if format == OutputFormat::Json {
+        print_json(&resp);
+    } else {
+        print_kv("Queued", &resp.title);
+        if resp.version > 1 {
+            print_kv("Version", &format!("v{}", resp.version));
+        }
+        if !resp.spec_refs.is_empty() {
+            print_kv("Specs", &resp.spec_refs.join(", "));
+        }
+        print_kv("Queue", &resp.url);
+    }
+    Ok(())
+}
+
+/// List the owner's active queue.
+pub async fn handle_list(client: &BroomvaClient, format: OutputFormat) -> BroomvaResult<()> {
+    let rows = client.list_handoffs().await?;
+
+    if format == OutputFormat::Json {
+        print_json(&rows);
+        return Ok(());
+    }
+    if rows.is_empty() {
+        println!("Queue is empty. Push one with `broomva handoff push file.md`.");
+        return Ok(());
+    }
+
+    let rows: Vec<Vec<String>> = rows
+        .iter()
+        .map(|h| {
+            vec![
+                h.slug.clone().unwrap_or_else(|| h.id.clone()),
+                h.status.clone(),
+                format!("{}", h.spec_refs.len()),
+                h.ticket_id.clone().unwrap_or_default(),
+                h.title.clone(),
+            ]
+        })
+        .collect();
+    print_table(&["SLUG", "STATUS", "SPECS", "TICKET", "TITLE"], &rows, format);
+    Ok(())
+}
+
+/// Mark a handoff done (queue transition `complete`).
+pub async fn handle_done(client: &BroomvaClient, id: &str) -> BroomvaResult<()> {
+    client.set_handoff_status(id, "complete").await?;
+    println!("Completed {id}");
+    Ok(())
+}
+
+/// Delete a handoff by id.
+pub async fn handle_rm(client: &BroomvaClient, id: &str) -> BroomvaResult<()> {
+    client.delete_handoff(id).await?;
+    println!("Deleted {id}");
+    Ok(())
+}
+
+// ── Markdown extraction ──
+
+/// First `# ` heading (single hash), trimmed. None when absent.
+fn extract_h1_title(md: &str) -> Option<String> {
+    md.lines().find_map(|line| {
+        let t = line.trim_start();
+        if let Some(rest) = t.strip_prefix("# ") {
+            let title = rest.trim();
+            if title.is_empty() {
+                None
+            } else {
+                Some(title.chars().take(300).collect())
+            }
+        } else {
+            None
+        }
+    })
+}
+
+/// The `**TL;DR.**` lead-line content (markers + label stripped). None if absent.
+fn extract_tldr(md: &str) -> Option<String> {
+    for line in md.lines() {
+        let Some(idx) = line.find("TL;DR") else {
+            continue;
+        };
+        // Everything after the TL;DR label; drop closing `**` and punctuation.
+        let after = &line[idx + "TL;DR".len()..];
+        let after = after.trim_start_matches(['*', '.', ':', ' ']);
+        let cleaned = after.trim().trim_end_matches('*').trim();
+        if !cleaned.is_empty() {
+            return Some(cleaned.chars().take(600).collect());
+        }
+    }
+    None
+}
+
+/// The body of a `## <heading>` section (until the next `#`/`##` heading).
+/// Case-insensitive on the heading text. None when missing or empty.
+fn extract_section(md: &str, heading: &str) -> Option<String> {
+    let target = heading.to_ascii_lowercase();
+    let mut collecting = false;
+    let mut out: Vec<&str> = Vec::new();
+    for line in md.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix("## ") {
+            if collecting {
+                break; // next section starts
+            }
+            if rest.trim().to_ascii_lowercase() == target {
+                collecting = true;
+            }
+            continue;
+        }
+        // A top-level `# ` heading also ends a `## ` section.
+        if collecting && trimmed.starts_with("# ") {
+            break;
+        }
+        if collecting {
+            out.push(line);
+        }
+    }
+    if !collecting {
+        return None;
+    }
+    let text = out.join("\n").trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.chars().take(4000).collect())
+    }
+}
+
+// ── git provenance ──
+
+fn parent_dir(path: &Path) -> PathBuf {
+    path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn git_capture(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = ProcessCommand::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Best-effort git provenance: origin remote, branch, repo-relative path, HEAD.
+fn detect_git_source(path: &Path) -> Option<HandoffSource> {
+    let dir = parent_dir(path);
+    let repo = git_capture(&dir, &["remote", "get-url", "origin"]);
+    let commit = git_capture(&dir, &["rev-parse", "HEAD"]);
+    let branch = git_capture(&dir, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    let toplevel = git_capture(&dir, &["rev-parse", "--show-toplevel"]);
+
+    let rel_path = match (toplevel, path.canonicalize().ok()) {
+        (Some(top), Some(abs)) => Path::new(&top).canonicalize().ok().and_then(|top_abs| {
+            abs.strip_prefix(&top_abs)
+                .ok()
+                .map(|p| p.to_string_lossy().into_owned())
+        }),
+        _ => None,
+    };
+
+    let source = HandoffSource {
+        repo,
+        path: rel_path,
+        commit,
+        branch,
+        ..Default::default()
+    };
+    if source.is_empty() {
+        None
+    } else {
+        Some(source)
+    }
+}
+
+/// Stage + commit a single file (git archival). Errors if git fails.
+fn commit_file(path: &Path) -> BroomvaResult<()> {
+    let dir = parent_dir(path);
+    let file_name = path
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .ok_or_else(|| BroomvaError::User("invalid file path".into()))?;
+
+    let added = ProcessCommand::new("git")
+        .args(["add", "--", &file_name])
+        .current_dir(&dir)
+        .status()?;
+    if !added.success() {
+        return Err(BroomvaError::User(format!("`git add {file_name}` failed")));
+    }
+
+    let message = format!("handoff: push {file_name}");
+    let committed = ProcessCommand::new("git")
+        .args(["commit", "-m", &message, "--", &file_name])
+        .current_dir(&dir)
+        .status()?;
+    if !committed.success() {
+        return Err(BroomvaError::User(
+            "`git commit` failed (nothing to commit, or not a git repo)".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_h1_title() {
+        let md = "# Handoff Queue — Phase 1\n\nbody";
+        assert_eq!(extract_h1_title(md).as_deref(), Some("Handoff Queue — Phase 1"));
+    }
+
+    #[test]
+    fn ignores_h2_for_title() {
+        assert_eq!(extract_h1_title("## Not a title\ntext"), None);
+    }
+
+    #[test]
+    fn extracts_tldr_line() {
+        let md = "# T\n\n**TL;DR.** Ship the queue today.\n\nmore";
+        assert_eq!(
+            extract_tldr(md).as_deref(),
+            Some("Ship the queue today."),
+        );
+    }
+
+    #[test]
+    fn extracts_tldr_with_colon() {
+        let md = "**TL;DR:** Do the thing.";
+        assert_eq!(extract_tldr(md).as_deref(), Some("Do the thing."));
+    }
+
+    #[test]
+    fn extracts_first_action_section() {
+        let md = "# T\n\n## State\n\nstuff\n\n## First action\n\nRun `make deploy`.\nThen verify.\n\n## Pickup\n\n- x";
+        assert_eq!(
+            extract_section(md, "First action").as_deref(),
+            Some("Run `make deploy`.\nThen verify."),
+        );
+    }
+
+    #[test]
+    fn missing_section_is_none() {
+        assert_eq!(extract_section("# T\n\ntext", "First action"), None);
+    }
+
+    #[test]
+    fn empty_handoff_source_detected() {
+        let src = HandoffSource::default();
+        assert!(src.is_empty());
+        let src = HandoffSource {
+            branch: Some("main".into()),
+            ..Default::default()
+        };
+        assert!(!src.is_empty());
+    }
+}

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod console;
 pub mod context;
 pub mod daemon_cmd;
 pub mod docs;
+pub mod handoff;
 pub mod output;
 pub mod prompts;
 pub mod relay;
@@ -76,6 +77,15 @@ pub enum Command {
     Docs {
         #[command(subcommand)]
         action: DocsCommand,
+    },
+    /// Push + manage handoff docs on the Maestro queue (/maestro/queue).
+    ///
+    /// `broomva handoff push docs/handoffs/<arc>.md --spec <handle>` pushes a
+    /// narrative handoff onto the queue, related to its specs and run by the
+    /// same Copy/Continue trigger the spec board uses. The fresh-session bridge.
+    Handoff {
+        #[command(subcommand)]
+        action: HandoffCommand,
     },
     /// Manage skills.
     Skills {
@@ -325,6 +335,43 @@ pub enum DocsCommand {
     /// Open a published document in the browser by handle or id.
     Open { id: String },
     /// Delete a published document by id.
+    Rm { id: String },
+}
+
+// ── Handoff Queue (BRO-1415) ──
+
+#[derive(Subcommand, Debug)]
+pub enum HandoffCommand {
+    /// Push a local markdown handoff → queues it at /maestro/queue.
+    Push {
+        /// Path to the .md handoff file to push.
+        file: String,
+        /// Title override (default: the first `# ` heading, else the file name).
+        #[arg(long)]
+        title: Option<String>,
+        /// Stable arc slug: re-pushing the same slug appends a version and
+        /// supersedes the prior one (default: derived from the file name).
+        #[arg(long = "as", value_name = "SLUG")]
+        as_slug: Option<String>,
+        /// Related spec handle (repeatable) — the HTML specs at /d/<handle>
+        /// this handoff relates to.
+        #[arg(long = "spec", value_name = "HANDLE")]
+        spec: Vec<String>,
+        /// Linear ticket id (e.g. BRO-1415).
+        #[arg(long)]
+        ticket: Option<String>,
+        /// Queue priority — higher floats up (default: 0).
+        #[arg(long)]
+        priority: Option<i64>,
+        /// Stage + commit the file before pushing (git archival).
+        #[arg(long)]
+        commit: bool,
+    },
+    /// List your active handoff queue.
+    List,
+    /// Mark a handoff done by id.
+    Done { id: String },
+    /// Delete a handoff by id.
     Rm { id: String },
 }
 
@@ -648,6 +695,25 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
             }
             DocsCommand::Open { id } => docs::handle_open(&client, &id).await,
             DocsCommand::Rm { id } => docs::handle_rm(&client, &id).await,
+        },
+        Command::Handoff { action } => match action {
+            HandoffCommand::Push {
+                file,
+                title,
+                as_slug,
+                spec,
+                ticket,
+                priority,
+                commit,
+            } => {
+                handoff::handle_push(
+                    &client, &file, title, as_slug, spec, ticket, priority, commit, format,
+                )
+                .await
+            }
+            HandoffCommand::List => handoff::handle_list(&client, format).await,
+            HandoffCommand::Done { id } => handoff::handle_done(&client, &id).await,
+            HandoffCommand::Rm { id } => handoff::handle_rm(&client, &id).await,
         },
         Command::Prompts { action } => match action {
             PromptsCommand::List {


### PR DESCRIPTION
## What

Builds the **handoff queue** — the human-readable layer that articulates *what to hand off next*. The `/handoff` skill wrote `docs/handoffs/*.md` to local disk only; the narrative bridge that triggers the next session never reached broomva.tech. Now it pushes into an explicit, realtime, owner-gated queue at **`/maestro/queue`**, relates each handoff to its HTML specs (`/d/<handle>`), and exposes the copy-to-continue trigger.

Closes BRO-1415.

## Surface

| Layer | Files |
|---|---|
| **Schema** | `Handoff` + `HandoffEvent` tables (migration `0075`). Handoff mirrors SpecDoc (owner-gated, slug+version, supersede-on-republish); HandoffEvent is the append-only log behind the realtime timeline + analytics. |
| **Queries** | `lib/db/handoff-queries.ts` — push (advisory-lock + supersede + emit events), list queue, status transitions, soft-delete, event tail (SSE cursor), `getQueueAnalytics`. `densifyDailyBuckets` split into env-free `handoff-buckets.ts` for testability. |
| **API** | `POST/GET /api/handoffs`, `GET/PATCH/DELETE /api/handoffs/[id]`, **SSE** `GET /api/handoffs/events`. `resolveAuth` (Bearer CLI + session cookie), owner-scoped — 404 on cross-owner (no existence leak). |
| **Pages** | `/maestro/queue` (realtime stream card + timeline on top, queue list with related-spec chips, Copy + Continue deep-link, status controls, lazy markdown body) · `/maestro/analytics` (KPI tiles, 14-day throughput SVG, status distribution — server-rendered inline SVG, no client charting lib). |
| **CLI** | `broomva handoff push <file.md> --as <slug> --spec <handle>… --ticket BRO-N` (+ `list`/`done`/`rm`). Auto-extracts title / TL;DR / first-action from the markdown; records git provenance. |

## How a handoff runs

Today the trigger is **Copy** (continue-prompt → clipboard) / **Continue** (`claude-cli://` deep link) — the same fresh-session bridge the Maestro spec board uses (BRO-1399). The `firstAction` the `/handoff` skill writes becomes the Copy payload. Wires to the relay runtime when BRO-1407 lands.

## Dep-chain (P14)

- **Upstream:** `specDoc`/`spec-doc-queries.ts` (lifecycle pattern), `resolveAuth`, `continuePrompt`/`claudeDeepLink` (maestro/lib.ts), `/api/docs` route, CLI `docs.rs` + `api/mod.rs` + `api/types.rs`, drizzle migrate-on-build (`tsx lib/db/migrate && next build`).
- **Downstream:** `/handoff` skill gains a "push to queue" step (separate `broomva/workspace` change — coupled), maestro board nav links to the queue, deploy build runs migration `0075`, CLI rebuild ships the `handoff` subcommand.

## Validation (P11)

- `cargo check -p broomva-cli` ✅ · `cargo test -p broomva-cli handoff::` ✅ (markdown extraction + provenance)
- `tsc --noEmit` → **0 errors** · `biome check` clean
- 18 TS unit tests (`queue/lib.test.ts` + `analytics/lib.test.ts`): grouping, continue-prompt synthesis, deep-link encoding, timeline merge/dedupe, relative-time, chart geometry, bucket densification.
- Owner-gating: routes 302→`/login` when logged out; queries owner-scoped.
- **Deploy preview** is the empirical check for the live SSE stream + migration apply.

## Notes for the reviewer

- Migration `0075` applies through the normal pipeline (build-time `migrate`) — no manual prod mutation.
- `specRefs` is a `json` column → analytics uses `json_array_length` (not `jsonb_…`).
- SSE route self-closes after ~55s; client `EventSource` reconnects with an updated `since` cursor; events deduped by id, so reconnect replay is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Handoff Queue API with CRUD operations (create, list, retrieve, update status, delete handoffs)
  * Built queue management dashboard with status board, real-time activity stream, and analytics
  * Implemented real-time event streaming for handoff activity updates
  * Added CLI commands for handoff management (push, list, mark complete, delete)
  * Added queue analytics dashboard displaying throughput charts and distribution metrics

* **Tests**
  * Added test coverage for analytics and queue logic utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->