### PR TITLE
feat(cli): frontmatter-driven handoff publish + lifecycle [BRO-1418]

### DIFF
--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -45,6 +45,14 @@ const PUBLIC_API_PREFIXES = [
   // resolveAuth (Bearer Life JWT OR session cookie). It returns 401 when
   // neither is present, so it is not actually public.
   "/api/docs",
+  // Handoff queue (BRO-1415/BRO-1418): like /api/docs, the broomva CLI pushes
+  // handoffs and drives their lifecycle with a Bearer token and no session
+  // cookie. The proxy must let /api/handoffs, /api/handoffs/[id], and the SSE
+  // /api/handoffs/events through so the handler can self-authenticate via
+  // resolveAuth (Bearer Life JWT OR session cookie); it returns 401 when
+  // neither is present, so it is not actually public. (Missing this entry made
+  // every CLI push 307→/login — the redirect external SDK callers can't follow.)
+  "/api/handoffs",
   "/api/discovery",
   "/api/trust",
   "/api/marketplace",
@@ -213,10 +221,7 @@ function withSecurityHeaders(
   // origins get no CORS headers — the browser silently fails its end, which
   // is the standard posture.
   const origin = req.headers.get("origin");
-  if (
-    req.nextUrl.pathname.startsWith("/api/") &&
-    isAllowedOrigin(origin)
-  ) {
+  if (req.nextUrl.pathname.startsWith("/api/") && isAllowedOrigin(origin)) {
     applyCorsHeaders(res.headers, origin as string);
   }
 
@@ -255,9 +260,7 @@ function extractTenantSlug(req: NextRequest): string | null {
   const hostname = host.split(":")[0];
 
   // Match `<slug>.broomva.tech` or `<slug>.localhost`
-  const match = hostname.match(
-    /^([a-z0-9-]+)\.(broomva\.tech|localhost)$/i,
-  );
+  const match = hostname.match(/^([a-z0-9-]+)\.(broomva\.tech|localhost)$/i);
   if (!match) return null;
 
   const slug = match[1].toLowerCase();

--- a/crates/broomva-cli/src/api/types.rs
+++ b/crates/broomva-cli/src/api/types.rs
@@ -633,6 +633,9 @@ pub struct PushHandoffResponse {
     #[serde(default)]
     pub spec_refs: Vec<String>,
     pub url: String,
+    /// Server-side createdAt — used as `pushed_at` in the file's frontmatter.
+    #[serde(default)]
+    pub created_at: Option<String>,
 }
 
 /// One row of `GET /api/handoffs` (metadata only — excludes the body).

--- a/crates/broomva-cli/src/cli/handoff.rs
+++ b/crates/broomva-cli/src/cli/handoff.rs
@@ -11,10 +11,14 @@ use std::process::Command as ProcessCommand;
 
 use crate::api::BroomvaClient;
 use crate::api::types::{HandoffSource, PushHandoffRequest};
+use crate::cli::handoff_frontmatter as fm;
 use crate::cli::output::{OutputFormat, print_json, print_kv, print_table};
 use crate::error::{BroomvaError, BroomvaResult};
 
-/// Push a local markdown handoff → prints the queue URL.
+/// Push a local markdown handoff → queues it, then writes the queue reference
+/// back into the file's frontmatter (BRO-1418). Frontmatter supplies defaults
+/// (`arc` / `specs` / `ticket` / `priority`); CLI flags override. The body sent
+/// to the server is the narrative with any frontmatter stripped.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_push(
     client: &BroomvaClient,
@@ -25,6 +29,7 @@ pub async fn handle_push(
     ticket: Option<String>,
     priority: Option<i64>,
     commit: bool,
+    no_write_back: bool,
     format: OutputFormat,
 ) -> BroomvaResult<()> {
     let path = Path::new(file);
@@ -41,7 +46,11 @@ pub async fn handle_push(
             meta.len()
         )));
     }
-    let body = fs::read_to_string(path)?;
+
+    let raw = fs::read_to_string(path)?;
+    let parsed = fm::parse(&raw);
+    let body = parsed.body.clone();
+    let mut front = parsed.frontmatter;
 
     // Title precedence: explicit --title → first `# ` heading → file stem.
     let resolved_title = title
@@ -49,6 +58,31 @@ pub async fn handle_push(
         .filter(|t| !t.is_empty())
         .or_else(|| extract_h1_title(&body))
         .or_else(|| path.file_stem().map(|s| s.to_string_lossy().into_owned()));
+
+    // Slug / specs / ticket / priority: CLI flag → frontmatter → derived.
+    let resolved_slug = slug
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| fm::get_str(&front, "arc"))
+        .or_else(|| fm::get_str(&front, "slug"));
+
+    let mut spec_refs: Vec<String> = Vec::new();
+    for s in specs
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .chain(fm::get_seq_str(&front, "specs"))
+    {
+        if !s.is_empty() && !spec_refs.contains(&s) {
+            spec_refs.push(s);
+        }
+    }
+
+    let resolved_ticket = ticket
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .or_else(|| fm::get_str(&front, "ticket"));
+
+    let resolved_priority = priority.or_else(|| fm::get_i64(&front, "priority"));
 
     let tldr = extract_tldr(&body);
     let first_action = extract_section(&body, "First action");
@@ -59,26 +93,54 @@ pub async fn handle_push(
     }
 
     let mut source = detect_git_source(path).unwrap_or_default();
-    if let Some(t) = ticket.map(|t| t.trim().to_string()).filter(|t| !t.is_empty()) {
+    if let Some(t) = resolved_ticket.clone() {
         source.ticket = Some(t);
     }
-    let source = if source.is_empty() { None } else { Some(source) };
+    let source = if source.is_empty() {
+        None
+    } else {
+        Some(source)
+    };
 
     let req = PushHandoffRequest {
         title: resolved_title,
-        body,
-        slug: slug.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
+        body, // narrative only (frontmatter stripped)
+        slug: resolved_slug.clone(),
         tldr,
         first_action,
-        spec_refs: specs
-            .into_iter()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect(),
-        priority,
+        spec_refs: spec_refs.clone(),
+        priority: resolved_priority,
         source,
     };
     let resp = client.push_handoff(req).await?;
+
+    // Write the queue reference back into the file's frontmatter — the `.md`
+    // becomes self-referential to its queue entry (re-push updates it).
+    if !no_write_back {
+        if let Some(s) = resp.slug.clone().or(resolved_slug) {
+            fm::set_str(&mut front, "arc", &s);
+        }
+        if !spec_refs.is_empty() {
+            fm::set_seq_str(&mut front, "specs", &spec_refs);
+        }
+        if let Some(t) = resolved_ticket {
+            fm::set_str(&mut front, "ticket", &t);
+        }
+        if let Some(p) = resolved_priority {
+            fm::set_i64(&mut front, "priority", p);
+        }
+        fm::set_str(&mut front, "queue_id", &resp.id);
+        if let Some(s) = resp.slug.clone() {
+            fm::set_str(&mut front, "queue_slug", &s);
+        }
+        fm::set_i64(&mut front, "queue_version", resp.version);
+        fm::set_str(&mut front, "queue_status", &resp.status);
+        fm::set_str(&mut front, "queue_url", &resp.url);
+        if let Some(ts) = resp.created_at.clone() {
+            fm::set_str(&mut front, "pushed_at", &ts);
+        }
+        fs::write(path, fm::render(&front, &parsed.body))?;
+    }
 
     if format == OutputFormat::Json {
         print_json(&resp);
@@ -89,6 +151,9 @@ pub async fn handle_push(
         }
         if !resp.spec_refs.is_empty() {
             print_kv("Specs", &resp.spec_refs.join(", "));
+        }
+        if !no_write_back {
+            print_kv("Frontmatter", "updated (queue_id, queue_status, …)");
         }
         print_kv("Queue", &resp.url);
     }
@@ -120,20 +185,98 @@ pub async fn handle_list(client: &BroomvaClient, format: OutputFormat) -> Broomv
             ]
         })
         .collect();
-    print_table(&["SLUG", "STATUS", "SPECS", "TICKET", "TITLE"], &rows, format);
+    print_table(
+        &["SLUG", "STATUS", "SPECS", "TICKET", "TITLE"],
+        &rows,
+        format,
+    );
     Ok(())
 }
 
-/// Mark a handoff done (queue transition `complete`).
-pub async fn handle_done(client: &BroomvaClient, id: &str) -> BroomvaResult<()> {
-    client.set_handoff_status(id, "complete").await?;
-    println!("Completed {id}");
+/// Resolve a lifecycle target that is either a handoff id or a path to a
+/// handoff file (whose frontmatter carries `queue_id`). Returns (id, file).
+fn resolve_target(target: &str) -> BroomvaResult<(String, Option<PathBuf>)> {
+    let path = Path::new(target);
+    if path.is_file() {
+        let parsed = fm::parse(&fs::read_to_string(path)?);
+        let id = fm::get_str(&parsed.frontmatter, "queue_id").ok_or_else(|| {
+            BroomvaError::User(format!(
+                "{target} has no `queue_id` in its frontmatter — run `broomva handoff push` first"
+            ))
+        })?;
+        Ok((id, Some(path.to_path_buf())))
+    } else {
+        Ok((target.to_string(), None))
+    }
+}
+
+/// Write a new `queue_status` into a handoff file's frontmatter.
+fn write_back_status(path: &Path, status: &str) -> BroomvaResult<()> {
+    let parsed = fm::parse(&fs::read_to_string(path)?);
+    let mut front = parsed.frontmatter;
+    fm::set_str(&mut front, "queue_status", status);
+    fs::write(path, fm::render(&front, &parsed.body))?;
     Ok(())
 }
 
-/// Delete a handoff by id.
-pub async fn handle_rm(client: &BroomvaClient, id: &str) -> BroomvaResult<()> {
-    client.delete_handoff(id).await?;
+/// Apply a queue transition by `<file|id>`, mirroring the new status into the
+/// file's frontmatter when a file is given (the file is the control surface).
+async fn transition(
+    client: &BroomvaClient,
+    target: &str,
+    action: &str,
+    status: &str,
+    verb: &str,
+) -> BroomvaResult<()> {
+    let (id, file) = resolve_target(target)?;
+    client.set_handoff_status(&id, action).await?;
+    if let Some(p) = file {
+        write_back_status(&p, status)?;
+    }
+    println!("{verb} {id}");
+    Ok(())
+}
+
+/// Mark a handoff in-progress (a fresh session picked it up).
+pub async fn handle_pickup(client: &BroomvaClient, target: &str) -> BroomvaResult<()> {
+    transition(client, target, "pick_up", "in_progress", "Picked up").await
+}
+
+/// Mark a handoff done.
+pub async fn handle_done(client: &BroomvaClient, target: &str) -> BroomvaResult<()> {
+    transition(client, target, "complete", "done", "Completed").await
+}
+
+/// Archive a handoff (set aside, off the active queue).
+pub async fn handle_archive(client: &BroomvaClient, target: &str) -> BroomvaResult<()> {
+    transition(client, target, "archive", "archived", "Archived").await
+}
+
+/// Re-queue a handoff (back to the waiting queue).
+pub async fn handle_requeue(client: &BroomvaClient, target: &str) -> BroomvaResult<()> {
+    transition(client, target, "requeue", "queued", "Re-queued").await
+}
+
+/// Delete a handoff by `<file|id>`. When a file, clears the queue reference
+/// from its frontmatter (the row is gone; the local arc params stay).
+pub async fn handle_rm(client: &BroomvaClient, target: &str) -> BroomvaResult<()> {
+    let (id, file) = resolve_target(target)?;
+    client.delete_handoff(&id).await?;
+    if let Some(p) = file {
+        let parsed = fm::parse(&fs::read_to_string(&p)?);
+        let mut front = parsed.frontmatter;
+        for k in [
+            "queue_id",
+            "queue_slug",
+            "queue_version",
+            "queue_status",
+            "queue_url",
+            "pushed_at",
+        ] {
+            fm::remove(&mut front, k);
+        }
+        fs::write(&p, fm::render(&front, &parsed.body))?;
+    }
     println!("Deleted {id}");
     Ok(())
 }
@@ -305,7 +448,10 @@ mod tests {
     #[test]
     fn extracts_h1_title() {
         let md = "# Handoff Queue — Phase 1\n\nbody";
-        assert_eq!(extract_h1_title(md).as_deref(), Some("Handoff Queue — Phase 1"));
+        assert_eq!(
+            extract_h1_title(md).as_deref(),
+            Some("Handoff Queue — Phase 1")
+        );
     }
 
     #[test]
@@ -316,10 +462,7 @@ mod tests {
     #[test]
     fn extracts_tldr_line() {
         let md = "# T\n\n**TL;DR.** Ship the queue today.\n\nmore";
-        assert_eq!(
-            extract_tldr(md).as_deref(),
-            Some("Ship the queue today."),
-        );
+        assert_eq!(extract_tldr(md).as_deref(), Some("Ship the queue today."),);
     }
 
     #[test]

--- a/crates/broomva-cli/src/cli/handoff_frontmatter.rs
+++ b/crates/broomva-cli/src/cli/handoff_frontmatter.rs
@@ -1,0 +1,210 @@
+//! YAML frontmatter handling for handoff files (BRO-1418).
+//!
+//! A handoff `.md` carries a `---` frontmatter block that is BOTH the publish
+//! input (`arc` / `specs` / `ticket` / `priority`) and the queue reference
+//! written back on push (`queue_id` / `queue_slug` / `queue_version` /
+//! `queue_status` / `queue_url` / `pushed_at`). serde_yaml round-trips it,
+//! preserving any extra user keys and their order (Mapping is IndexMap-backed).
+
+use serde_yaml::{Mapping, Value};
+
+/// A handoff split into its frontmatter mapping + narrative body. `frontmatter`
+/// is an empty Mapping when the file has no `---` block (legacy handoffs); the
+/// `body` is always the narrative with any frontmatter stripped.
+pub struct Parsed {
+    pub frontmatter: Mapping,
+    pub had_frontmatter: bool,
+    pub body: String,
+}
+
+/// Split a raw file into (frontmatter, body). A leading `---\n … \n---\n` block
+/// is parsed as YAML; everything after is the body. A malformed or non-mapping
+/// block is treated as "no frontmatter" (the whole file is the body) — never an
+/// error, so a stray `---` in prose can't break a push.
+pub fn parse(raw: &str) -> Parsed {
+    if let Some(after_open) = raw.strip_prefix("---\n") {
+        if let Some(close) = after_open.find("\n---\n") {
+            let yaml = &after_open[..close];
+            // Body starts after the closing delimiter; drop the conventional
+            // blank line(s) so the narrative begins at its first content line.
+            let body = after_open[close + 5..].trim_start_matches(['\n', '\r']);
+            if let Ok(Value::Mapping(m)) = serde_yaml::from_str::<Value>(yaml) {
+                return Parsed {
+                    frontmatter: m,
+                    had_frontmatter: true,
+                    body: body.to_string(),
+                };
+            }
+        } else if let Some(yaml) = after_open
+            .strip_suffix("\n---\n")
+            .or_else(|| after_open.strip_suffix("\n---"))
+        {
+            // Frontmatter block with no body after it.
+            if let Ok(Value::Mapping(m)) = serde_yaml::from_str::<Value>(yaml) {
+                return Parsed {
+                    frontmatter: m,
+                    had_frontmatter: true,
+                    body: String::new(),
+                };
+            }
+        }
+    }
+    Parsed {
+        frontmatter: Mapping::new(),
+        had_frontmatter: false,
+        body: raw.to_string(),
+    }
+}
+
+/// Read a string-ish scalar (string or number coerced to string).
+pub fn get_str(m: &Mapping, key: &str) -> Option<String> {
+    match m.get(key)? {
+        Value::String(s) if !s.trim().is_empty() => Some(s.clone()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Read an integer scalar.
+pub fn get_i64(m: &Mapping, key: &str) -> Option<i64> {
+    match m.get(key)? {
+        Value::Number(n) => n.as_i64(),
+        Value::String(s) => s.trim().parse().ok(),
+        _ => None,
+    }
+}
+
+/// Read a sequence of strings (also accepts a single bare string).
+pub fn get_seq_str(m: &Mapping, key: &str) -> Vec<String> {
+    match m.get(key) {
+        Some(Value::Sequence(seq)) => seq
+            .iter()
+            .filter_map(|v| match v {
+                Value::String(s) if !s.trim().is_empty() => Some(s.trim().to_string()),
+                Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .collect(),
+        Some(Value::String(s)) if !s.trim().is_empty() => vec![s.trim().to_string()],
+        _ => Vec::new(),
+    }
+}
+
+/// Insert/update a string key, preserving its position when it already exists.
+pub fn set_str(m: &mut Mapping, key: &str, val: &str) {
+    m.insert(
+        Value::String(key.to_string()),
+        Value::String(val.to_string()),
+    );
+}
+
+/// Insert/update an integer key.
+pub fn set_i64(m: &mut Mapping, key: &str, val: i64) {
+    m.insert(Value::String(key.to_string()), Value::Number(val.into()));
+}
+
+/// Insert/update a string-sequence key.
+pub fn set_seq_str(m: &mut Mapping, key: &str, vals: &[String]) {
+    let seq = vals
+        .iter()
+        .map(|s| Value::String(s.clone()))
+        .collect::<Vec<_>>();
+    m.insert(Value::String(key.to_string()), Value::Sequence(seq));
+}
+
+/// Remove a key if present.
+pub fn remove(m: &mut Mapping, key: &str) {
+    m.remove(key);
+}
+
+/// Re-render a file from frontmatter + body: `---\n{yaml}---\n\n{body}\n`. An
+/// empty mapping yields the bare body (no `---` block). Leading newlines on the
+/// body are normalized to a single blank line after the frontmatter.
+pub fn render(m: &Mapping, body: &str) -> String {
+    if m.is_empty() {
+        return body.to_string();
+    }
+    let yaml = serde_yaml::to_string(m).unwrap_or_default();
+    let trimmed_body = body.trim_start_matches(['\n', '\r']);
+    let mut out = format!("---\n{yaml}---\n\n{trimmed_body}");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_no_frontmatter() {
+        let p = parse("# Title\n\nbody");
+        assert!(!p.had_frontmatter);
+        assert!(p.frontmatter.is_empty());
+        assert_eq!(p.body, "# Title\n\nbody");
+    }
+
+    #[test]
+    fn parses_frontmatter_and_body() {
+        let raw = "---\narc: my-arc\nticket: BRO-1\nspecs:\n  - a\n  - b\n---\n\n# Title\n\nbody";
+        let p = parse(raw);
+        assert!(p.had_frontmatter);
+        assert_eq!(get_str(&p.frontmatter, "arc").as_deref(), Some("my-arc"));
+        assert_eq!(get_str(&p.frontmatter, "ticket").as_deref(), Some("BRO-1"));
+        assert_eq!(get_seq_str(&p.frontmatter, "specs"), vec!["a", "b"]);
+        assert_eq!(p.body, "# Title\n\nbody");
+    }
+
+    #[test]
+    fn malformed_block_is_treated_as_body() {
+        // A stray `---` rule in prose must not be mistaken for frontmatter.
+        let raw = "# Title\n\n---\n\nmore";
+        let p = parse(raw);
+        assert!(!p.had_frontmatter);
+        assert_eq!(p.body, raw);
+    }
+
+    #[test]
+    fn round_trips_with_added_queue_keys() {
+        let raw = "# Title\n\nbody text";
+        let mut p = parse(raw);
+        set_str(&mut p.frontmatter, "arc", "my-arc");
+        set_seq_str(&mut p.frontmatter, "specs", &["spec-a".to_string()]);
+        set_str(&mut p.frontmatter, "queue_id", "abc123");
+        set_i64(&mut p.frontmatter, "queue_version", 1);
+        let out = render(&p.frontmatter, &p.body);
+        // Re-parse the rendered output: frontmatter + identical body.
+        let re = parse(&out);
+        assert!(re.had_frontmatter);
+        assert_eq!(get_str(&re.frontmatter, "arc").as_deref(), Some("my-arc"));
+        assert_eq!(
+            get_str(&re.frontmatter, "queue_id").as_deref(),
+            Some("abc123")
+        );
+        assert_eq!(get_i64(&re.frontmatter, "queue_version"), Some(1));
+        assert_eq!(get_seq_str(&re.frontmatter, "specs"), vec!["spec-a"]);
+        // render() guarantees a trailing newline on the file; body content is
+        // otherwise preserved exactly.
+        assert_eq!(re.body.trim_end(), "# Title\n\nbody text");
+    }
+
+    #[test]
+    fn updates_preserve_position_and_other_keys() {
+        let raw = "---\narc: a\nqueue_status: queued\ncustom: keep-me\n---\n\nbody";
+        let mut p = parse(raw);
+        set_str(&mut p.frontmatter, "queue_status", "done");
+        let out = render(&p.frontmatter, &p.body);
+        let re = parse(&out);
+        assert_eq!(
+            get_str(&re.frontmatter, "queue_status").as_deref(),
+            Some("done")
+        );
+        assert_eq!(
+            get_str(&re.frontmatter, "custom").as_deref(),
+            Some("keep-me")
+        );
+        assert_eq!(get_str(&re.frontmatter, "arc").as_deref(), Some("a"));
+    }
+}

--- a/crates/broomva-cli/src/cli/mod.rs
+++ b/crates/broomva-cli/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod context;
 pub mod daemon_cmd;
 pub mod docs;
 pub mod handoff;
+pub mod handoff_frontmatter;
 pub mod output;
 pub mod prompts;
 pub mod relay;
@@ -366,13 +367,37 @@ pub enum HandoffCommand {
         /// Stage + commit the file before pushing (git archival).
         #[arg(long)]
         commit: bool,
+        /// Don't write the queue reference back into the file's frontmatter.
+        #[arg(long = "no-write-back")]
+        no_write_back: bool,
     },
     /// List your active handoff queue.
     List,
-    /// Mark a handoff done by id.
-    Done { id: String },
-    /// Delete a handoff by id.
-    Rm { id: String },
+    /// Mark a handoff in-progress by <file|id> (a fresh session took it).
+    PickUp {
+        /// Handoff file path or queue id.
+        target: String,
+    },
+    /// Mark a handoff done by <file|id>.
+    Done {
+        /// Handoff file path or queue id.
+        target: String,
+    },
+    /// Archive a handoff by <file|id> (off the active queue).
+    Archive {
+        /// Handoff file path or queue id.
+        target: String,
+    },
+    /// Re-queue a handoff by <file|id> (back to waiting).
+    Requeue {
+        /// Handoff file path or queue id.
+        target: String,
+    },
+    /// Delete a handoff by <file|id>.
+    Rm {
+        /// Handoff file path or queue id.
+        target: String,
+    },
 }
 
 // ── Prompts ──
@@ -689,10 +714,7 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                 reference,
                 output,
                 version,
-            } => {
-                docs::handle_get(&client, &reference, output.as_deref(), version, format)
-                    .await
-            }
+            } => docs::handle_get(&client, &reference, output.as_deref(), version, format).await,
             DocsCommand::Open { id } => docs::handle_open(&client, &id).await,
             DocsCommand::Rm { id } => docs::handle_rm(&client, &id).await,
         },
@@ -705,15 +727,28 @@ pub async fn run_command(cli: Cli) -> BroomvaResult<()> {
                 ticket,
                 priority,
                 commit,
+                no_write_back,
             } => {
                 handoff::handle_push(
-                    &client, &file, title, as_slug, spec, ticket, priority, commit, format,
+                    &client,
+                    &file,
+                    title,
+                    as_slug,
+                    spec,
+                    ticket,
+                    priority,
+                    commit,
+                    no_write_back,
+                    format,
                 )
                 .await
             }
             HandoffCommand::List => handoff::handle_list(&client, format).await,
-            HandoffCommand::Done { id } => handoff::handle_done(&client, &id).await,
-            HandoffCommand::Rm { id } => handoff::handle_rm(&client, &id).await,
+            HandoffCommand::PickUp { target } => handoff::handle_pickup(&client, &target).await,
+            HandoffCommand::Done { target } => handoff::handle_done(&client, &target).await,
+            HandoffCommand::Archive { target } => handoff::handle_archive(&client, &target).await,
+            HandoffCommand::Requeue { target } => handoff::handle_requeue(&client, &target).await,
+            HandoffCommand::Rm { target } => handoff::handle_rm(&client, &target).await,
         },
         Command::Prompts { action } => match action {
             PromptsCommand::List {


### PR DESCRIPTION
## What

Makes the handoff queue self-maintaining from the `.md` file (follow-up to #231 / BRO-1415).

**`broomva handoff push <file>`** now:
- **reads frontmatter** (`arc`/`specs`/`ticket`/`priority`) as publish defaults (CLI flags override), and
- **writes the queue reference back** into the file: `queue_id`, `queue_slug`, `queue_version`, `queue_status`, `queue_url`, `pushed_at`. The `.md` becomes self-referential to its queue entry; re-push updates it. The body sent to the server is the narrative with frontmatter stripped.

**Lifecycle from the file** — `pick-up` / `done` / `archive` / `requeue` / `rm` accept `<file|id>`. Given a file, they resolve `queue_id` from frontmatter and mirror the new `queue_status` back (`rm` clears the `queue_*` block). The file is the control surface.

## Files
| File | Change |
|---|---|
| `cli/handoff_frontmatter.rs` (new) | serde_yaml parse/get/set/render — order- + key-preserving; malformed `---` blocks treated as body (never errors). 5 round-trip tests. |
| `cli/handoff.rs` | `handle_push` frontmatter read + write-back; `pick-up`/`done`/`archive`/`requeue`/`rm` via shared `transition` + `resolve_target`. |
| `cli/mod.rs` | `HandoffCommand`: `--no-write-back` on push; lifecycle verbs take `<file|id>`. |
| `api/types.rs` | `PushHandoffResponse.created_at` → frontmatter `pushed_at`. |

## Dep-chain (P14)
- Upstream: the deployed `/api/handoffs*` (BRO-1415), `serde_yaml` (already a dep), `PushHandoffResponse`.
- Downstream: `broomva/skills` handoff SKILL.md + template (frontmatter block + lifecycle docs); the existing handoff `.md` files get `queue_*` frontmatter on backfill.

## Validation (P11)
`cargo test` 13 green (frontmatter round-trip + key preservation + markdown extractors); `clippy` clean; release binary builds. Backfill of the ~15 existing handoffs runs with the rebuilt binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)