### PR TITLE
fix(proxy): allow public artifact pages

### DIFF
--- a/apps/broomva/proxy.test.ts
+++ b/apps/broomva/proxy.test.ts
@@ -37,8 +37,6 @@ describe("proxy public artifact routes", () => {
     const response = await proxy(req("/maestro"));
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe(
-      "https://broomva.tech/login",
-    );
+    expect(response.headers.get("location")).toBe("https://broomva.tech/login");
   });
 });

--- a/apps/broomva/proxy.test.ts
+++ b/apps/broomva/proxy.test.ts
@@ -1,0 +1,44 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { getSafeSession } from "@/lib/auth";
+import { proxy } from "./proxy";
+
+vi.mock("@/lib/auth", () => ({ getSafeSession: vi.fn() }));
+
+const mockGetSafeSession = vi.mocked(getSafeSession);
+
+function req(pathname: string) {
+  return new NextRequest(`https://broomva.tech${pathname}`);
+}
+
+beforeEach(() => {
+  mockGetSafeSession.mockReset();
+  mockGetSafeSession.mockResolvedValue({ data: { session: null, user: null } });
+});
+
+describe("proxy public artifact routes", () => {
+  test("allows anonymous public spec pages through to the route handler", async () => {
+    const response = await proxy(req("/d/hackathon-fork-inventory"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockGetSafeSession).not.toHaveBeenCalled();
+  });
+
+  test("allows anonymous public handoff pages through to the route handler", async () => {
+    const response = await proxy(req("/h/demo-handoff"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockGetSafeSession).not.toHaveBeenCalled();
+  });
+
+  test("still redirects private app pages for anonymous visitors", async () => {
+    const response = await proxy(req("/maestro"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://broomva.tech/login",
+    );
+  });
+});

--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -24,6 +24,10 @@ const PUBLIC_PAGE_PREFIXES = [
   "/links",
   "/ingest",
   "/life",
+  // Public artifact sharing: route handlers still enforce row-level
+  // visibility. The proxy must let anonymous viewers reach them.
+  "/d/",
+  "/h/",
   "/.well-known",
 ] as const;
 

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -9,6 +9,13 @@ import {
 import { notFound } from "next/navigation";
 import type { ComponentType } from "react";
 
+type RuntimePageData = {
+  body: ComponentType<Record<string, unknown>>;
+  toc: Parameters<typeof DocsPage>[0]["toc"];
+  title: string;
+  description?: string;
+};
+
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
 }) {
@@ -16,12 +23,13 @@ export default async function Page(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
-  const MDX = page.data.body as unknown as ComponentType<Record<string, unknown>>;
+  const data = page.data as unknown as RuntimePageData;
+  const MDX = data.body;
 
   return (
-    <DocsPage toc={page.data.toc}>
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
+    <DocsPage toc={data.toc}>
+      <DocsTitle>{data.title}</DocsTitle>
+      <DocsDescription>{data.description}</DocsDescription>
       <DocsBody>
         <MDX components={{ ...defaultMdxComponents }} />
       </DocsBody>
@@ -39,9 +47,10 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
+  const data = page.data as unknown as RuntimePageData;
 
   return {
-    title: page.data.title,
-    description: page.data.description,
+    title: data.title,
+    description: data.description,
   };
 }


### PR DESCRIPTION
## Summary
- allow anonymous requests to reach /d/* and /h/* public artifact route handlers
- keep row-level public/private enforcement inside the route/database resolver
- add proxy regression tests for public artifact pages and private Maestro redirects

## Verification
- bunx vitest run proxy.test.ts
- bun run test:types
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended public page access to additional route prefixes, enabling more content to be viewed without authentication.

* **Tests**
  * Added comprehensive test suite verifying proper authentication handling for public and private pages, including redirect behavior for unauthenticated private access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->