### PR TITLE
fix(chat): make chat stream end-to-end — accept lifegw short-form agent_kind [chat-multiturn]

### DIFF
--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.test.ts
@@ -228,6 +228,45 @@ describe("decodeAgentEvent — ERROR", () => {
   });
 });
 
+// Regression: lifegw's `event_to_outbound_frame` emits the SHORT enum
+// form (`TOKEN`/`FINISH`/`ERROR`) while the proto canonical JSON form is
+// the prefixed `AGENT_EVENT_KIND_*`. Before normalization these short
+// frames fell through to the `unknown_kind` warning branch, so TOKEN text
+// never rendered and FINISH never terminated the stream — every turn
+// streamed nothing then died at the 30s frame-deadline. The decoder now
+// accepts both forms.
+describe("decodeAgentEvent — short-form wire kinds (lifegw compat)", () => {
+  it("decodes a short-form TOKEN frame", () => {
+    const f = frame("TOKEN", { text: "hi" });
+    expect(decodeAgentEvent(f, ctx)).toEqual({ kind: "token", delta: "hi" });
+  });
+
+  it("recognizes a short-form FINISH frame as terminal", () => {
+    const f = frame("FINISH", { reason: "stop" });
+    expect(decodeAgentEvent(f, ctx)).toMatchObject({
+      kind: "finish",
+      reason: "stop",
+    });
+  });
+
+  it("decodes a short-form ERROR frame", () => {
+    const f = frame("ERROR", { code: "lifed.x", message: "boom" });
+    expect(decodeAgentEvent(f, ctx)).toEqual({
+      kind: "error",
+      code: "lifed.x",
+      message: "boom",
+    });
+  });
+
+  it("still treats a genuinely unknown kind as a warning", () => {
+    const f = frame("NONSENSE", {});
+    expect(decodeAgentEvent(f, ctx)).toMatchObject({
+      kind: "warning",
+      code: "lifed-ws.unknown_kind",
+    });
+  });
+});
+
 describe("decodeAgentEvent — HIBERNATE", () => {
   it("decodes a HIBERNATE frame into a warning with code 'lifed.hibernate'", () => {
     const f = frame("AGENT_EVENT_KIND_HIBERNATE", {});

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -976,7 +976,21 @@ function decodeAgentEvent(
   frame: Extract<OutboundFrame, { kind: "agent_event" }>,
   ctx: AgentStreamInput,
 ): AgentEvent | null {
-  const kind = frame.agent_kind;
+  // Normalize the wire kind. The proto canonical JSON form is the
+  // fully-qualified enum name (`AGENT_EVENT_KIND_TOKEN`), which this
+  // switch matches. lifegw's `event_to_outbound_frame`, however, has
+  // historically emitted the short form (`TOKEN`, `FINISH`, `ERROR`).
+  // A short-form frame used to fall through to the `unknown_kind`
+  // `warning` branch below — which is silently collected onto message
+  // metadata and never recognized as terminal. The net effect: TOKEN
+  // text never rendered AND the FINISH frame never ended the stream, so
+  // every turn streamed nothing and then died at the 30s frame-deadline.
+  // Accept both forms (Postel's law) so a producer-side kind-format
+  // change can never again silently break rendering + termination.
+  const rawKind = frame.agent_kind ?? "";
+  const kind = rawKind.startsWith("AGENT_EVENT_KIND_")
+    ? rawKind
+    : `AGENT_EVENT_KIND_${rawKind}`;
   const payload = (frame.record.payload ?? {}) as Record<string, unknown>;
 
   switch (kind) {


### PR DESCRIPTION
## Problem

broomva.tech chat was **100% broken in production** — every message hung ~30s then errored:
\`\`\`
data: {"type":"error","errorText":"lifed.stream.no-first-frame: No first frame from lifegw within 30000ms"}
\`\`\`

## Root cause (two independent bugs, found via prod logs — P11)

The chat path is broomva.tech → lifegw (Railway) → lifed → arcan (Vercel AI Gateway). Diagnosis from `railway logs`:

1. **Provider 403 (lifed/Railway config):** lifed's `OPENAI_MODEL` was `anthropic/claude-sonnet-4-6` — a premium model the production free-tier AI-gateway key cannot serve (`403 "Free tier users do not have access to this model"`). Every turn failed before emitting a token. **Fixed out-of-band** by setting `OPENAI_MODEL=openai/gpt-5-mini` (broomva.tech's own default chat model) on the Railway `lifegw` service.

2. **Wire-kind mismatch (this PR):** once the model produced tokens, the stream *still* hung "after frame N". lifegw's `event_to_outbound_frame` emits the **short** enum form (`TOKEN`/`FINISH`/`ERROR`); broomva.tech's `decodeAgentEvent` matched only the **canonical proto** form (`AGENT_EVENT_KIND_*`). Every frame fell through to the `unknown_kind` warning branch → no text rendered **and** the terminal `FINISH` was never recognized → 30s frame-deadline.

## Fix (this PR — consumer side, Postel's law)

Normalize `agent_kind` in `decodeAgentEvent` to accept **both** the prefixed and short forms, so neither the missing text nor the non-terminating stream can recur if the producer's kind format shifts. Adds regression tests for short-form `TOKEN`/`FINISH`/`ERROR` plus a genuinely-unknown kind.

## Test plan

- [x] `vitest run lifed-ws-client.test.ts` — 34/34 pass (4 new short-form cases)
- [x] Reproduced the bug against prod lifegw; Railway logs confirmed TOKEN+FINISH emitted server-side
- [ ] E2E dogfood on Vercel preview / prod (multi-turn + complex task) — see PR comment

## Companion / follow-ups

- **lifed PR (broomva/life):** producer-side hardening — surface arcan dispatch failures as `ERROR`+`FINISH` frames instead of a silent hang (so the 403/429 class shows an immediate inline error, not a 30s timeout). Optionally emit canonical `AGENT_EVENT_KIND_*` on the wire.
- **Ops (account owner):** the production Vercel AI Gateway key is **free-tier** — premium models 403 and accessible models (gpt-5-mini/gemini-flash) are rate-limited (429) under load. Top up credits / add BYOK provider keys to serve premium models reliably for complex tasks.

> ⚠️ Linear ticket: not created — the Linear MCP is unauthenticated in this session. Please link the relevant BRO- ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced event decoding to accept and properly normalize both current and legacy event kind formats, improving backward compatibility and system robustness.

* **Tests**
  * Added regression tests verifying proper event decoding across format variations, including handling of unrecognized event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->