### PR TITLE
fix(chat): terminate per-turn stream on FINISH (no post-answer hang) [chat-multiturn]

### DIFF
--- a/apps/broomva/lib/life-runtime/agent-session/__tests__/lifed-ws-contract.test.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/__tests__/lifed-ws-contract.test.ts
@@ -341,3 +341,80 @@ describe("LifedWsAgentSessionClient — per-turn close-after-finish parity", () 
     expect(events[events.length - 1].event.kind).toBe("finish");
   });
 });
+
+/**
+ * A WS fake that emits TOKEN + FINISH and then NEVER closes the socket —
+ * modelling lifed's real per-turn behaviour (the fan-out sender stays
+ * attached after a single-turn FINISH, so the WS is not server-closed).
+ * The harness `FakeWebSocket` auto-closes on script exhaustion, which
+ * masked this; in production it caused the stream to hang ~30s after a
+ * complete answer and append a spurious `frame-deadline` error.
+ */
+class NeverClosesAfterFinishFake {
+  readyState = 0;
+  private handlers: FakeWsHandlers = {};
+
+  constructor() {
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.handlers.open?.();
+    });
+  }
+
+  addEventListener<K extends keyof FakeWsHandlers>(
+    event: K,
+    h: NonNullable<FakeWsHandlers[K]>,
+  ): void {
+    // biome-ignore lint/suspicious/noExplicitAny: handler union
+    (this.handlers as any)[event] = h;
+  }
+
+  send(_data: string): void {
+    queueMicrotask(() => {
+      if (this.readyState !== 1) return;
+      this.handlers.message?.({
+        data: JSON.stringify({
+          kind: "agent_event",
+          seq_no: "1",
+          record: { sequence: 1, at: new Date().toISOString(), kind: "TOKEN", payload: { text: "hi" } },
+          agent_kind: "AGENT_EVENT_KIND_TOKEN",
+        }),
+      });
+      this.handlers.message?.({
+        data: JSON.stringify({
+          kind: "agent_event",
+          seq_no: "2",
+          record: { sequence: 2, at: new Date().toISOString(), kind: "FINISH", payload: { finish_reason: "stop" } },
+          agent_kind: "AGENT_EVENT_KIND_FINISH",
+        }),
+      });
+      // Intentionally NO close() — the socket stays open forever.
+    });
+  }
+
+  close(_code = 1000, _reason = ""): void {
+    this.readyState = 3;
+  }
+}
+
+describe("LifedWsAgentSessionClient — per-turn terminates on FINISH without server close", () => {
+  it("completes the iterator on FINISH even when the WS never closes", async () => {
+    const wsFactory: WebSocketFactory = () =>
+      new NeverClosesAfterFinishFake() as unknown as ReturnType<WebSocketFactory>;
+    const client = new LifedWsAgentSessionClient({
+      baseUrl: "https://fake.lifegw.test",
+      webSocketFactory: wsFactory,
+      fetchFn: (async () => new Response("OK")) as typeof fetch,
+    });
+
+    // Without the per-turn break-on-finish fix this `for await` (inside
+    // drainStream) would never resolve — the test would hang to timeout.
+    const events = await drainStream(client, "never-closes-after-finish");
+
+    expect(events.some((e) => e.event.kind === "token")).toBe(true);
+    const finishes = events.filter((e) => e.event.kind === "finish");
+    expect(finishes).toHaveLength(1);
+    expect(events.filter((e) => e.event.kind === "error")).toHaveLength(0);
+    expect(events[events.length - 1].event.kind).toBe("finish");
+  });
+});

--- a/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
+++ b/apps/broomva/lib/life-runtime/agent-session/lifed-ws-client.ts
@@ -604,6 +604,15 @@ export class LifedWsAgentSessionClient implements AgentSessionClient {
               at: frame.record.at ?? new Date().toISOString(),
               event: decoded,
             };
+            // Per-turn contract (this method): FINISH is the
+            // terminal-and-last event. lifed does not reliably close the
+            // WS after a per-turn FINISH (the fan-out sender stays
+            // attached), so continuing to read would block until the
+            // client-side frame deadline (~30s) and append a spurious
+            // error AFTER a fully-delivered answer. Stop as soon as the
+            // terminal finish is delivered. (Multi-turn treats FINISH as a
+            // turn boundary and is handled separately in streamMultiTurn.)
+            if (decoded.kind === "finish") break;
           }
         } else if (frame.kind === "closing") {
           // server is about to close the stream (Spec C₃ §6.5). Don't


### PR DESCRIPTION
## Problem (found by dogfooding prod after #243)

With #243 deployed, chat finally **renders streamed text** — but a spurious error appears *after* a complete answer:
\`\`\`
text-start → 23×text-delta → text-end → error: "lifed.stream.frame-deadline: No frame from lifegw within 30000ms after frame 24"
\`\`\`

## Root cause

The per-turn `LifedWsAgentSessionClient.stream()` loop yields the terminal `finish` event but then **keeps reading the WS**. lifed does **not** close the socket after a single-turn FINISH (its fan-out sender stays attached), so the iterator blocks until the ~30s client frame-deadline fires and appends a trailing `error`. The `stream()` docstring already declares FINISH "the terminal-and-last event" on the per-turn path — the loop just wasn't honoring it.

## Fix

`break` the per-turn loop once the `finish` event is delivered. Multi-turn (FINISH = turn boundary) is unaffected — it lives in `streamMultiTurn`.

## Test plan

- [x] New contract regression test `NeverClosesAfterFinishFake` — asserts the iterator completes on FINISH even when the WS never closes (without the fix this hangs to timeout). The harness's other fakes auto-close on exhaustion, which masked the bug.
- [x] `vitest run` contract + decoder suites — 43 passed, 1 skipped
- [ ] Re-dogfood prod after deploy (clean stream, no trailing error) — see PR comment

## Context

Third and final layer of the chat outage chain: (1) model-403 on free-tier gateway → set `OPENAI_MODEL=gpt-5-mini` on Railway; (2) #243 short-form `agent_kind` decode; (3) **this** — per-turn iterator must self-terminate on FINISH. Companion lifed hardening: broomva/life#1673.

> ⚠️ Linear ticket: not created — Linear MCP unauthenticated in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)