### PR TITLE
feat(chat): multi-turn context — prepend recent turns to lifegw dispatch [chat-multiturn]

### DIFF
--- a/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
+++ b/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
@@ -469,6 +469,62 @@ describe("POST /api/chat — anonymous flow", () => {
     expect(arcanGuard.resolveArcanEndpoints).not.toHaveBeenCalled();
   });
 
+  it("prepends recent conversation context to the lifegw user message (multi-turn)", async () => {
+    const streamCalls: FakeOpts["streamCalls"] = [];
+    __setSessionClientFactoryForTests(() => makeFakeClient({ streamCalls }));
+
+    const chatId = "22222222-2222-2222-2222-222222222222";
+    const priorUser = { ...makeChatMessage("My code word is ARCANGEL."), id: "prev-u" };
+    const priorAssistant = {
+      id: "prev-a",
+      role: "assistant" as const,
+      parts: [{ type: "text" as const, text: "Got it — ARCANGEL." }],
+      metadata: {
+        createdAt: new Date(),
+        parentMessageId: "prev-u",
+        selectedModel: ANON_MODEL,
+        activeStreamId: null,
+      },
+    };
+
+    const resp = await POST(
+      makeRequest({
+        id: chatId,
+        message: makeChatMessage("What is my code word?"),
+        prevMessages: [priorUser, priorAssistant],
+      }),
+    );
+    expect(resp.status).toBe(200);
+    await drainBody(resp);
+
+    // The content lifegw forwards to the LLM carries the prior turns as
+    // labelled context plus the current message — so the model can
+    // "remember" earlier turns despite lifed's per-turn dispatch.
+    expect(streamCalls).toHaveLength(1);
+    const sent = streamCalls![0].userMessage;
+    expect(sent).toContain("User: My code word is ARCANGEL.");
+    expect(sent).toContain("Assistant: Got it — ARCANGEL.");
+    expect(sent).toContain("What is my code word?");
+  });
+
+  it("sends only the current message when there is no prior context", async () => {
+    const streamCalls: FakeOpts["streamCalls"] = [];
+    __setSessionClientFactoryForTests(() => makeFakeClient({ streamCalls }));
+
+    const resp = await POST(
+      makeRequest({
+        id: "33333333-3333-3333-3333-333333333333",
+        message: makeChatMessage("Just one message"),
+        prevMessages: [],
+      }),
+    );
+    expect(resp.status).toBe(200);
+    await drainBody(resp);
+
+    // First turn: byte-for-byte the bare user text (no transcript wrapper).
+    expect(streamCalls![0].userMessage).toBe("Just one message");
+  });
+
   it("rejects anonymous request when model is not in ANONYMOUS_LIMITS", async () => {
     __setSessionClientFactoryForTests(() => makeFakeClient({}));
     const req = makeRequest({

--- a/apps/broomva/app/(chat)/api/chat/route.ts
+++ b/apps/broomva/app/(chat)/api/chat/route.ts
@@ -694,6 +694,60 @@ function extractUserMessageText(message: ChatMessage): string {
 }
 
 /**
+ * Build the single user-message string lifegw forwards to the LLM,
+ * including recent conversation context.
+ *
+ * Multi-turn (BRO-chat): lifed's arcan dispatch is per-turn and sends
+ * only this one `content` string to the model — it does NOT carry the
+ * conversation history (the LLM `messages` array is `[system, user]`).
+ * broomva.tech owns the thread (DB for authed users, client-supplied
+ * `prevMessages` for anonymous), so we are the right layer to supply
+ * context: we prepend a compact role-labelled transcript of the recent
+ * turns so the model can actually "remember" earlier messages.
+ *
+ * `previousMessages` is already trimmed to the last few turns upstream
+ * (`prepareRequestContext`). When empty (first turn) the output is just
+ * the current user text, byte-for-byte identical to the old behaviour.
+ *
+ * NOTE: this flattens roles into one message — a pragmatic adaptation to
+ * lifed's string-only dispatch interface. The ideal is structured
+ * history through the lifegw WS protocol (a lifed-side follow-up); until
+ * then this delivers working multi-turn without a critical-service
+ * protocol change.
+ */
+function buildLifegwUserText(
+  previousMessages: ChatMessage[],
+  currentMessage: ChatMessage,
+): string {
+  const current = extractUserMessageText(currentMessage);
+
+  const priorTurns: string[] = [];
+  for (const msg of previousMessages) {
+    if (msg.id === currentMessage.id) {
+      continue;
+    }
+    const text = extractUserMessageText(msg);
+    if (!text) {
+      continue;
+    }
+    const label = msg.role === "assistant" ? "Assistant" : "User";
+    priorTurns.push(`${label}: ${text}`);
+  }
+
+  if (priorTurns.length === 0) {
+    return current;
+  }
+
+  return [
+    "Conversation so far (most recent last):",
+    priorTurns.join("\n"),
+    "",
+    "Continue the conversation. The user's new message:",
+    current,
+  ].join("\n");
+}
+
+/**
  * Build the lifegw-routed response stream. Wraps the canonical iterator
  * from `dispatchViaLifegw` in a `createUIMessageStream` so we can:
  *
@@ -714,6 +768,7 @@ async function createLifegwBackedChatStream({
   messageId,
   chatId,
   userMessage,
+  previousMessages,
   selectedModelId,
   userId,
   anonymousSessionId,
@@ -728,6 +783,9 @@ async function createLifegwBackedChatStream({
   messageId: string;
   chatId: string;
   userMessage: ChatMessage;
+  /** Recent prior turns (trimmed upstream) — prepended as conversation
+   *  context so lifed's per-turn dispatch can "remember" earlier turns. */
+  previousMessages: ChatMessage[];
   selectedModelId: AppModelId;
   userId: string | null;
   /** Anonymous-session id — populated when `userId` is null. Used as the
@@ -766,7 +824,7 @@ async function createLifegwBackedChatStream({
     ? { kind: "user" as const, id: userId }
     : { kind: "anon" as const, id: anonymousSessionId ?? chatId };
 
-  const userMessageText = extractUserMessageText(userMessage);
+  const userMessageText = buildLifegwUserText(previousMessages, userMessage);
 
   const stream = createUIMessageStream<ChatMessage>({
     execute: async ({ writer: dataStream }) => {
@@ -980,6 +1038,7 @@ async function* wrapWithProgress(
 async function executeChatRequest({
   chatId,
   userMessage,
+  previousMessages,
   selectedModelId,
   userId,
   anonymousSessionId,
@@ -991,6 +1050,7 @@ async function executeChatRequest({
 }: {
   chatId: string;
   userMessage: ChatMessage;
+  previousMessages: ChatMessage[];
   selectedModelId: AppModelId;
   userId: string | null;
   anonymousSessionId: string | null;
@@ -1040,6 +1100,7 @@ async function executeChatRequest({
     messageId,
     chatId,
     userMessage,
+    previousMessages,
     selectedModelId,
     userId,
     anonymousSessionId,
@@ -1322,6 +1383,7 @@ export async function POST(request: NextRequest) {
     return await executeChatRequest({
       chatId,
       userMessage,
+      previousMessages: contextResult.previousMessages,
       selectedModelId,
       userId,
       anonymousSessionId: anonymousSession?.id ?? null,


### PR DESCRIPTION
## Problem (found by dogfooding prod)

After the streaming fixes (#243, #244) single-turn chat works — but **multi-turn doesn't**. Dogfood:
- Turn 1: "Remember this code word: ARCANGEL." → "Acknowledged: ARCANGEL."
- Turn 2 (same chatId): "What was the code word?" → **"none"**

## Root cause

lifed's arcan dispatch is per-turn and forwards only the **current message string** to the model — `build_request_body` produces `messages: [system, user]` with **no conversation history**. The LLM literally never sees prior turns. lifed has no session-history store either.

## Fix (broomva.tech-owned)

broomva.tech already owns the thread (DB for authed, client `prevMessages` for anon) and trims it to the last few turns in `prepareRequestContext`. Thread that `previousMessages` through `executeChatRequest` → `createLifegwBackedChatStream` and prepend a compact **role-labelled transcript** to the content lifegw forwards. The model now has context.

- First turn (no prior messages): output is **byte-for-byte unchanged** (bare user text).
- Bounded: uses the already-trimmed last-N turns.

## Test plan

- [x] New route tests: transcript reaches the lifed `stream()` call (`User: …` / `Assistant: …` + current); contextless turn sends only bare text. 11/11 route tests pass.
- [ ] Re-dogfood prod after deploy (turn-2 recall) — PR comment.

## Why here, not lifed

lifed's dispatch takes a content **string**; structured history would require changing the `ArcanCall` trait + the arcan-substrate gRPC proto + every impl — a high-blast-radius change to a critical service. broomva.tech owns the conversation state, so sending context is the sensible, low-risk layer. The structured-history WS protocol is the ideal lifed-side follow-up.

Chain: model-403 (Railway env) → #243 (decode kind) → #244 (terminate on FINISH) → **this** (multi-turn). Companion: broomva/life#1673 (error surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)