### PR TITLE
fix(site): compute time greeting client-side — kill React #418 hydration mismatch on landing

### DIFF
--- a/apps/broomva/components/site/landing-sections.tsx
+++ b/apps/broomva/components/site/landing-sections.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { motion } from "motion/react";
 import { ScrollReveal } from "@/components/site/scroll-reveal";
 import ThermodynamicGrid from "@/components/ui/interactive-thermodynamic-grid";
@@ -57,7 +57,15 @@ export function HeroSection({ userName }: { userName?: string | null }) {
   const [chatInput, setChatInput] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  const greeting = useMemo(() => getTimeGreeting(), []);
+  // Two-pass render: the server can't know the visitor's local hour, so the
+  // greeting starts null (server HTML and first client render both say
+  // "Hello") and an effect swaps in the time-based greeting after hydration.
+  // Computing it during render trips React #418 (hydration text mismatch)
+  // whenever the server's UTC hour lands in a different bucket.
+  const [greeting, setGreeting] = useState<string | null>(null);
+  useEffect(() => {
+    setGreeting(getTimeGreeting());
+  }, []);
   const firstName = userName?.split(" ")[0] ?? null;
 
   const submitChat = useCallback(() => {
@@ -114,7 +122,7 @@ export function HeroSection({ userName }: { userName?: string | null }) {
         >
           {firstName ? (
             <>
-              {greeting},{" "}
+              {greeting ?? "Hello"},{" "}
               <span className="relative inline-block text-ai-blue">
                 {firstName}
                 <motion.span


### PR DESCRIPTION
## Problem

The landing hero (`HeroSection` in `apps/broomva/components/site/landing-sections.tsx`) computed the time-of-day greeting during render via `useMemo(() => getTimeGreeting(), [])`. `getTimeGreeting()` reads `new Date().getHours()`, so SSR on Vercel produces the UTC-hour bucket while the client hydrates with the local-hour bucket. Whenever the two buckets differ, the `<h1>` text mismatches and React throws minified error #418 (hydration text mismatch).

**Empirical evidence (prod, 2026-06-10):** on https://broomva.tech/ signed in, a client at 10:34 GMT-5 rendered "Good morning, Carlos" while the server (15:34 UTC) rendered "Good afternoon" — the browser console showed the minified React #418 exception (deployment `dpl_BBd2fRA3H1YBEebEiSVCKT9t1T3c`). The hydration failure forces a full client re-render and is the prime suspect for a separately-observed wedge where the landing chat handoff never dispatches.

## Fix

Two-pass render. The greeting is now state that starts `null` and is set by an effect after hydration:

- `const [greeting, setGreeting] = useState<string | null>(null)` + `useEffect(() => { setGreeting(getTimeGreeting()); }, [])`
- The signed-in branch renders `{greeting ?? "Hello"}` so server HTML and first client render agree ("Hello, Carlos"), then the effect swaps in the time-based greeting. The `<h1>` is already wrapped in a 0.7s motion fade-in, so the swap is invisible.
- Deliberately **not** using `suppressHydrationWarning` — that would freeze the stale server-computed text instead of correcting it.
- `useMemo` import dropped (no longer used), `useEffect` added.

**Nondeterminism scan of the rest of the file:** `navigator.clipboard` and `setTimeout` in `InstallSection.copy` run only in an event handler (never during render) — safe. No `Math.random`, no locale formatting (`toLocaleString`/`Intl`), no other `Date` construction in render paths. Motion `initial`/`animate` props are deterministic on first render. No other fixes needed.

## Dep-Chain (P14)

**Upstream (what this change depends on):**
- `apps/broomva/components/site/landing-sections.tsx` — `getTimeGreeting()` (unchanged), `HeroSection({ userName })` (modified)
- `react` — `useState`, `useEffect` (replacing `useMemo`)
- `motion/react` — `motion.h1` fade-in (unchanged) masks the post-hydration text swap
- Server render path on Vercel (UTC clock) vs. browser local clock — the divergence this change neutralizes

**Downstream (what depends on this):**
- `apps/broomva/app/(site)/page.tsx` — renders `HeroSection` with the session user's name (the signed-in greeting branch)
- Landing chat handoff (`submitChat` → `router.push("/chat?q=...")` in the same component) — suspected victim of the hydration-failure re-render; this fix removes that failure mode
- No tests import `landing-sections.tsx` (pure presentational); no type contracts change — `HeroSection`'s props are untouched
- CI gates: biome lint, vitest unit, `next typegen` + `tsc --noEmit` — all green (see below)

## Dogfood / validation

Commands run from `apps/broomva/` in the worktree:

| Command | Result |
|---|---|
| `bunx biome lint components/site/landing-sections.tsx` | exit 0 — 1 warning (`useExhaustiveDependencies` on `InstallSection.copy`, lines 320/328), **pre-existing**: reproduced verbatim on the unmodified file via `git stash` |
| `bun run test:unit` | 79 test files passed, 651 tests passed, 1 skipped |
| `bun run test:types` (`next typegen` + `tsc --noEmit`) | exit 0, types generated successfully, no errors |

## Cross-references

- React error #418 (hydration text mismatch): https://react.dev/errors/418
- Observed prod console exception: deployment `dpl_BBd2fRA3H1YBEebEiSVCKT9t1T3c` on https://broomva.tech/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
