### PR TITLE
fix(chat): mark tool inventory as not-yet-active on the lifegw surface

### DIFF
--- a/apps/broomva/components/context-sidebar.tsx
+++ b/apps/broomva/components/context-sidebar.tsx
@@ -139,6 +139,21 @@ function ModelSection() {
   );
 }
 
+/**
+ * Tool inventory — PREVIEW state, not live capability.
+ *
+ * Chat streams via lifegw, which dispatches a bare [system, user]
+ * completion with no tool definitions — see the "lifegw owns
+ * server-side tool dispatch" note in app/(chat)/api/chat/route.ts.
+ * The execution harness lands with the life-side arcand Phase-2 arc
+ * (TOOL_CALL_PENDING / TOOL_RESULT proto events; life repo
+ * docs/handoffs/2026-06-10-chat-agent-grounding-shipped.md) — that
+ * ship is the trigger to remove this preview framing.
+ *
+ * Per-tier filtering (chat.config.ts `anonymous.availableTools`) is
+ * deliberately deferred to the tool-wiring arc — do NOT import server
+ * config into this client component.
+ */
 function ToolsSection() {
   const tools = useMemo(() => {
     return Object.values(toolsDefinitions).map((tool) => ({
@@ -149,8 +164,13 @@ function ToolsSection() {
   }, []);
 
   return (
-    <SectionHeader icon={WrenchIcon} title={`Tools (${tools.length})`}>
-      <div className="space-y-1">
+    <SectionHeader icon={WrenchIcon} title={`Tools (${tools.length} · preview)`}>
+      <p className="mb-2 text-[11px] text-muted-foreground">
+        Tool execution isn&apos;t wired into the live agent runtime yet — the
+        agent answers from its grounded knowledge. The inventory below is the
+        roadmap surface, arriving with the runtime tool harness.
+      </p>
+      <div className="space-y-1 opacity-60">
         {tools.map((tool) => (
           <div
             key={tool.name}


### PR DESCRIPTION
## Problem

The chat Context sidebar advertises **"Tools (20)"** as if they were callable, on a surface where tool execution is not wired. Empirical evidence (verified 2026-06-10, in production), per Empirical (P11):

- The in-app chat stream is 100% dispatched via lifegw — `apps/broomva/app/(chat)/api/chat/route.ts` (line ~409): *"lifegw owns server-side tool dispatch — the in-app route no longer constructs `getTools()` / `streamText`"*.
- lifegw's arcan dispatch sends a bare `[system, user]` chat/completions request with **no tool definitions** (Railway lifegw logs: `arcan.dispatch_message` to `ai-gateway.vercel.sh`, no `tools` field).
- The grounded persona shipped in life#1676 explicitly discloses that tools are not wired; the live agent, when asked to use `searchKnowledge`, **fabricated** a quoted `ToolCallError`.
- The execution harness arrives with the life-side arcand Phase-2 arc (`TOOL_CALL_PENDING` / `TOOL_RESULT` proto events) — not yet shipped.

The sidebar's claim was the only surface still presenting the inventory as live capability.

## Fix

Scope-tight, honest, not alarming — in `ToolsSection` (`apps/broomva/components/context-sidebar.tsx`):

1. **Caption above the list** (muted, `text-[11px] text-muted-foreground`, consistent with the file): "Tool execution isn't wired into the live agent runtime yet — the agent answers from its grounded knowledge. The inventory below is the roadmap surface, arriving with the runtime tool harness." Keeps the two facts: not executing today; coming via the runtime harness.
2. **De-emphasized rows**: `opacity-60` on the list container.
3. **Title** now reads `Tools (N · preview)` via template string (`Tools (${tools.length} · preview)`).
4. **Code comment** above `ToolsSection` cross-referencing the route.ts dispatch note and the life repo handoff (`docs/handoffs/2026-06-10-chat-agent-grounding-shipped.md`); arcand Phase-2 ship is the explicit removal trigger for this preview state. The comment also records that per-tier filtering (`chat.config.ts` `anonymous.availableTools`) is deliberately deferred to the tool-wiring arc — no server config imported into this client component.

The inventory list itself is kept: it is a genuine roadmap surface.

## Dep-Chain (P14)

**Upstream (this change depends on):**
- `apps/broomva/lib/ai/tools/tools-definitions.ts` — `toolsDefinitions` map (source of `tools.length`; the `N · preview` title stays correct as the inventory grows).
- `apps/broomva/app/(chat)/api/chat/route.ts` — `determineAllowedTools()` JSDoc (line ~409), the "lifegw owns server-side tool dispatch" ground truth this preview framing is anchored to.
- `apps/broomva/components/ui/collapsible.tsx` (via local `SectionHeader`), `apps/broomva/lib/utils.ts` `cn()` — unchanged render scaffolding.
- life repo: `docs/handoffs/2026-06-10-chat-agent-grounding-shipped.md` + arcand Phase-2 arc (`TOOL_CALL_PENDING` / `TOOL_RESULT` proto events) — the removal trigger for the preview state.

**Downstream (consumers of this change):**
- `ContextSidebar()` in the same file — sole renderer of `ToolsSection` (mounted from the chat layout); copy/opacity change is presentational only, no prop or export surface changed.
- `apps/broomva/lib/config/chat.config.ts` `anonymous.availableTools` — deliberately NOT consumed here; per-tier filtering deferred to the tool-wiring arc (noted in the code comment).
- No tests reference `ToolsSection` (no `context-sidebar` matches under `apps/broomva` test files); no other component imports it.
- Future arcand Phase-2 wiring PR — must remove the caption, the `opacity-60`, and the `· preview` suffix (comment marks the trigger).

## Dogfood / validation

Run from `apps/broomva/` in the worktree:

| Command | Result |
|---|---|
| `bunx biome lint components/context-sidebar.tsx` | exit 0 — 1 pre-existing warning (`lint/correctness/noUnusedImports`: `ImageIcon`, line 8), present on main baseline, unrelated to this diff, left untouched for scope-tightness |
| `bun run test:unit` | 79 test files passed, 651 tests passed / 1 skipped |
| `bun run test:types` (`next typegen` + `tsc --noEmit`) | "Types generated successfully", tsc clean, exit 0 |

## Cross-references

- `apps/broomva/app/(chat)/api/chat/route.ts` ~line 409 — "lifegw owns server-side tool dispatch" note.
- life#1676 — grounded persona that discloses tools are not wired.
- life repo `docs/handoffs/2026-06-10-chat-agent-grounding-shipped.md` — chat-agent grounding handoff; arcand Phase-2 = removal trigger.
- Railway lifegw logs — `arcan.dispatch_message`, no `tools` field in the upstream request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
