### PR TITLE
fix(chat): emit message-metadata on lifegw stream — assistant turns no longer collapse into version siblings

### DIFF
--- a/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
+++ b/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
@@ -469,6 +469,42 @@ describe("POST /api/chat — anonymous flow", () => {
     expect(arcanGuard.resolveArcanEndpoints).not.toHaveBeenCalled();
   });
 
+  it("stamps assistant metadata on the stream (message-metadata chunks)", async () => {
+    __setSessionClientFactoryForTests(() => makeFakeClient({}));
+
+    const userMessage = makeChatMessage("Hello", ANON_MODEL);
+    const resp = await POST(
+      makeRequest({
+        id: "44444444-4444-4444-4444-444444444444",
+        message: userMessage,
+        prevMessages: [],
+      }),
+    );
+    expect(resp.status).toBe(200);
+
+    const body = await drainBody(resp);
+    const metadataChunks = body
+      .split("\n")
+      .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
+      .map((line) => JSON.parse(line.slice("data: ".length)))
+      .filter((chunk) => chunk.type === "message-metadata");
+
+    // The route wrapper owns message-metadata emission (the canonical
+    // translator deliberately does not) — without these chunks the
+    // client's live assistant message has no parentMessageId and
+    // lib/stores/with-threads.ts renders consecutive turns as version
+    // siblings.
+    expect(metadataChunks.length).toBeGreaterThanOrEqual(2);
+
+    const first = metadataChunks[0].messageMetadata;
+    expect(first.parentMessageId).toBe(userMessage.id);
+    expect(first.selectedModel).toBe(ANON_MODEL);
+
+    const last = metadataChunks.at(-1).messageMetadata;
+    expect(last.parentMessageId).toBe(userMessage.id);
+    expect(last.activeStreamId).toBeNull();
+  });
+
   it("prepends recent conversation context to the lifegw user message (multi-turn)", async () => {
     const streamCalls: FakeOpts["streamCalls"] = [];
     __setSessionClientFactoryForTests(() => makeFakeClient({ streamCalls }));

--- a/apps/broomva/app/(chat)/api/chat/route.ts
+++ b/apps/broomva/app/(chat)/api/chat/route.ts
@@ -840,6 +840,19 @@ async function createLifegwBackedChatStream({
         });
       }
 
+      // Stamp the live assistant message's metadata up front. The
+      // canonical translator deliberately does NOT emit
+      // `message-metadata` chunks (see canonical-to-vercel-ai-sse.ts
+      // header — they're owned by this wrapper). Without this chunk the
+      // client's streaming message has no `parentMessageId`, so
+      // lib/stores/with-threads.ts parents every live assistant turn at
+      // `null` and consecutive replies render as version siblings
+      // ("1/2" / "2/2" arrows across different turns).
+      dataStream.write({
+        type: "message-metadata",
+        messageMetadata: initialMetadata,
+      });
+
       // Open the lifegw dispatch. createSession failures surface here
       // as a thrown error → caught by `createUIMessageStream`'s onError.
       let dispatch: Awaited<ReturnType<typeof dispatchViaLifegw>>;
@@ -910,6 +923,21 @@ async function createLifegwBackedChatStream({
           "main-chat",
         );
       }
+
+      // Converge the live message with what stitchAssistantMessage
+      // persists: clear activeStreamId and attach usage (when lifegw
+      // reported it). The SDK deep-merges repeated message-metadata
+      // chunks into message.metadata (processUIMessageStream →
+      // mergeObjects), so this overlays the up-front chunk above.
+      const finalUsage = buildUsageMetadata(consumeState);
+      dataStream.write({
+        type: "message-metadata",
+        messageMetadata: {
+          ...initialMetadata,
+          activeStreamId: null,
+          ...(finalUsage ? { usage: finalUsage } : {}),
+        },
+      });
     },
     generateId: () => messageId,
     onFinish: async ({ responseMessage }) => {
@@ -961,16 +989,45 @@ async function createLifegwBackedChatStream({
 }
 
 /**
- * Synthesize a `ChatMessage` to persist as the assistant turn. The
- * Vercel-AI-SDK `responseMessage` passed to onFinish already carries
- * the parts the client saw (text + tool + data); we just need to
- * stamp the finalized metadata (usage, activeStreamId: null).
+ * Build the `usage` metadata field from lifegw's reported counts.
  *
  * Lifegw reports plain token counts (`{ inputTokens, outputTokens }`)
  * but the SDK's `LanguageModelUsage` shape carries per-provider
  * detail (cache reads, reasoning tokens). We pad the missing detail
- * fields with `undefined` so the persisted metadata typecheck-passes
- * without inventing data we don't actually have.
+ * fields with `undefined` so the metadata typecheck-passes without
+ * inventing data we don't actually have. Shared by the final
+ * `message-metadata` stream chunk and the persisted assistant message
+ * (stitchAssistantMessage) so the live and stored shapes never drift.
+ */
+function buildUsageMetadata(
+  consumeState: CanonicalConsumeState,
+): ChatMessage["metadata"]["usage"] {
+  if (!consumeState.usage) {
+    return undefined;
+  }
+  return {
+    inputTokens: consumeState.usage.inputTokens,
+    outputTokens: consumeState.usage.outputTokens,
+    totalTokens:
+      (consumeState.usage.inputTokens ?? 0) +
+      (consumeState.usage.outputTokens ?? 0),
+    inputTokenDetails: {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokenDetails: {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+    },
+  };
+}
+
+/**
+ * Synthesize a `ChatMessage` to persist as the assistant turn. The
+ * Vercel-AI-SDK `responseMessage` passed to onFinish already carries
+ * the parts the client saw (text + tool + data); we just need to
+ * stamp the finalized metadata (usage, activeStreamId: null).
  */
 function stitchAssistantMessage({
   responseMessage,
@@ -981,24 +1038,7 @@ function stitchAssistantMessage({
   consumeState: CanonicalConsumeState;
   initialMetadata: ChatMessage["metadata"];
 }): ChatMessage {
-  const usage = consumeState.usage
-    ? {
-        inputTokens: consumeState.usage.inputTokens,
-        outputTokens: consumeState.usage.outputTokens,
-        totalTokens:
-          (consumeState.usage.inputTokens ?? 0) +
-          (consumeState.usage.outputTokens ?? 0),
-        inputTokenDetails: {
-          noCacheTokens: undefined,
-          cacheReadTokens: undefined,
-          cacheWriteTokens: undefined,
-        },
-        outputTokenDetails: {
-          textTokens: undefined,
-          reasoningTokens: undefined,
-        },
-      }
-    : undefined;
+  const usage = buildUsageMetadata(consumeState);
 
   return {
     ...responseMessage,


### PR DESCRIPTION
## Problem

The lifegw-backed chat stream never emits `message-metadata` chunks, so the client's **live** assistant message carries no metadata at all — no `parentMessageId`, no `selectedModel`, no `activeStreamId`.

The contract gap: `lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse.ts` (header, ~line 44) deliberately does **not** emit `start`/`message-metadata` chunks — "those are owned by the `createUIMessageStream` wrapper in the route" — but `createLifegwBackedChatStream` in `app/(chat)/api/chat/route.ts` never wrote one. `initialMetadata` was built and then used **only** for persistence (`onFinish` → `stitchAssistantMessage` → `finalizeMessageAndCredits`).

**User-visible consequence (reproduced on production today, anon and authed):** with `metadata.parentMessageId` undefined, `lib/stores/with-threads.ts` (`childrenMap`/`getMessageSiblingInfo`) parents every live assistant message at `null`, so consecutive assistant replies render as version **siblings** — the "1/2" / "2/2" prev/next-version arrows appear across *different turns*. Live repro: anon chat `019eb230-4dfd-736c-aca5-b21967ff5599` showed `1/2`, `2/2`, then `3/3` across three sequential turns. Authed chats self-heal on reload (the DB row has correct metadata); anonymous chats never heal.

## Fix

In `createLifegwBackedChatStream.execute()`:

1. **Up-front chunk** — right after the `data-chatConfirmed` block, write `{ type: "message-metadata", messageMetadata: initialMetadata }` so the streaming message is parented/stamped from its first frame.
2. **Convergence chunk** — after the translator loop and usage accounting, write a second `message-metadata` chunk: `{ ...initialMetadata, activeStreamId: null, usage }` so the live message converges with exactly what `stitchAssistantMessage` persists.
3. **Shared shape** — factored the usage construction out of `stitchAssistantMessage` into `buildUsageMetadata()`, shared by both consumers so live and stored shapes can't drift.

Merge semantics verified against installed `ai@6.0.184`: `processUIMessageStream` deep-merges repeated `message-metadata` chunks into `message.metadata` via `mergeObjects` (dist/index.mjs ~5500), so the final chunk overlays the first.

## Dep-Chain (P14)

**Upstream (this depends on):**
- `ai@6.0.184` — `UIMessageChunk` member `{ type: 'message-metadata'; messageMetadata: METADATA }` (dist/index.d.ts); `processUIMessageStream` merge semantics (`mergeObjects`)
- `apps/broomva/lib/ai/types.ts` — `MessageMetadata` schema (`createdAt`, `parentMessageId`, `selectedModel`, `activeStreamId`, `usage?`)
- `apps/broomva/lib/life-runtime/edge-adapter/canonical-to-vercel-ai-sse.ts` — translator ownership comment (the contract this fulfills)
- `CanonicalConsumeState.usage` (lifegw terminal `finish` event counts)

**Downstream (consumers of this):**
- `apps/broomva/components/chat-sync.tsx` — `useChat.onFinish` → `addMessageToTree(message)` now receives parented metadata
- `apps/broomva/lib/stores/with-threads.ts` — `childrenMap`/`getMessageSiblingInfo`/`switchToSibling` (version arrows now only appear for true regenerate siblings)
- `apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts` — new assertion (`stamps assistant metadata on the stream`)
- Persistence path unchanged: `stitchAssistantMessage` output is byte-identical (helper refactor only)

## Dogfood / validation

- `bunx biome lint app/(chat)/api/chat/route.ts app/(chat)/api/chat/__tests__/route.test.ts` → clean
- `bunx vitest run app/(chat)/api/chat/__tests__/route.test.ts` → 12/12 pass (incl. new `stamps assistant metadata on the stream (message-metadata chunks)`)
- `bun run test:unit` → 79 files, 652 pass / 1 skipped
- `bun run test:types` → clean
- Live prod repro evidence captured during the dogfood session that motivated this PR (lifegw Railway logs correlated per-turn; UI version arrows accumulating per turn)

## Cross-refs

- chat-multiturn arc: #243, #244, #245
- `canonical-to-vercel-ai-sse.ts` ownership comment (lines ~44-48)
- Post-merge follow-up: verify on prod that consecutive anon turns no longer grow the version counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Improvements
* Chat streaming responses now include detailed metadata emitted at the start and completion of each message, providing visibility into message creation time, selected AI model, and token usage statistics
* Standardized usage metadata formatting across chat interactions for improved consistency
* Enhanced metadata tracking support for anonymous user conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->