### PR TITLE
fix(chat): make anon credits cookie client-readable — banner now tracks real count

### DIFF
--- a/apps/broomva/lib/__tests__/anonymous-session-server.test.ts
+++ b/apps/broomva/lib/__tests__/anonymous-session-server.test.ts
@@ -1,0 +1,43 @@
+// Pins the anonymous-session cookie contract (#249): the server-set
+// cookie MUST be client-readable (httpOnly: false) because the
+// remaining-credits banner reads it via document.cookie
+// (anonymous-session-client.ts getAnonymousSession → useGetCredits).
+// With httpOnly: true the per-message decrement was invisible to the
+// client and the banner stuck at the default credit count.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const cookieSet = vi.fn();
+const cookieGet = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ set: cookieSet, get: cookieGet })),
+}));
+
+import { setAnonymousSession } from "@/lib/anonymous-session-server";
+import { ANONYMOUS_SESSION_COOKIES_KEY } from "@/lib/constants";
+
+describe("setAnonymousSession cookie contract", () => {
+  beforeEach(() => {
+    cookieSet.mockClear();
+  });
+
+  it("writes a client-readable (non-httpOnly) cookie with the session JSON", async () => {
+    const session = {
+      id: "anon-test",
+      remainingCredits: 46,
+      createdAt: new Date("2026-06-10T00:00:00Z"),
+    };
+
+    await setAnonymousSession(session);
+
+    expect(cookieSet).toHaveBeenCalledTimes(1);
+    const [name, value, options] = cookieSet.mock.calls[0];
+    expect(name).toBe(ANONYMOUS_SESSION_COOKIES_KEY);
+    expect(JSON.parse(value).remainingCredits).toBe(46);
+    expect(options).toMatchObject({
+      path: "/",
+      sameSite: "lax",
+      httpOnly: false,
+    });
+  });
+});

--- a/apps/broomva/lib/anonymous-session-server.ts
+++ b/apps/broomva/lib/anonymous-session-server.ts
@@ -42,6 +42,16 @@ export async function setAnonymousSession(
     maxAge: ANONYMOUS_LIMITS.SESSION_DURATION,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",
-    httpOnly: true,
+    // Deliberately NOT httpOnly: the client reads this cookie via
+    // document.cookie (anonymous-session-client.ts getAnonymousSession →
+    // useGetCredits) to render the remaining-credits banner, and the
+    // client created it non-httpOnly in the first place
+    // (AnonymousSessionInit). With httpOnly the server's per-message
+    // decrement became invisible to the client and the banner stuck at
+    // the default credit count (#249). This is the user's own counter,
+    // not a secret — enforcement is server-side (pre-deduct, 402 on
+    // exhaustion, per-IP rate limits), and httpOnly never stopped the
+    // user from editing their own cookie anyway.
+    httpOnly: false,
   });
 }


### PR DESCRIPTION
## Problem

Fixes #249. After N anonymous turns the credit banner still reads "You only have **50** credits left" — the per-message decrement never reaches the UI.

Root cause is a cookie-visibility contract break:

- `lib/anonymous-session-server.ts` `setAnonymousSession()` (called by `/api/chat` to pre-deduct each anon message) wrote the `anonymous-session` cookie with **`httpOnly: true`**.
- The banner reads the count client-side: `components/upgrade-cta/limit-display.tsx` → `useGetCredits()` (`hooks/chat-sync-hooks.ts:515`) → client `getAnonymousSession()` (`lib/anonymous-session-client.ts`) → `document.cookie`.
- An httpOnly cookie is invisible to `document.cookie`, so the client read returns `null` and the hook falls back to `ANONYMOUS_LIMITS.CREDITS` (50) forever. The per-message `ANONYMOUS_CREDITS_KEY` invalidation (`chat-sync-hooks.ts:385`) re-reads the same invisible cookie.

The decrement itself works — the server-side read (`next/headers` cookies) sees the updated value and 402s on exhaustion. Only the client display lies.

## Fix

`httpOnly: false` on the server-set cookie, restoring the contract the client already assumes — `AnonymousSessionInit` *creates* this cookie non-httpOnly via `document.cookie`/CookieStore in the first place; the server's first overwrite was what hid it.

**Security note:** this is the visitor's own credit counter, not a secret. httpOnly was never a protection here — users can edit their own cookies in devtools regardless; enforcement is and remains server-side (pre-deduct, `ANONYMOUS_LIMIT_EXCEEDED` 402, per-IP rate limits).

## Dep-Chain (P14)

**Upstream:** `next/headers` `cookies().set` options; `lib/types/anonymous.ts` `ANONYMOUS_LIMITS`; `lib/constants.ts` `ANONYMOUS_SESSION_COOKIES_KEY`.
**Downstream:** `app/(chat)/api/chat/route.ts` (pre-deduct call site, unchanged); `lib/anonymous-session-client.ts` `getAnonymousSession` (now sees server updates); `hooks/chat-sync-hooks.ts` `useGetCredits` + `ANONYMOUS_CREDITS_KEY` invalidation (now refreshes with real values); `components/upgrade-cta/limit-display.tsx` banner copy; new test `lib/__tests__/anonymous-session-server.test.ts` pins the contract.

## Dogfood / validation

- `bunx vitest run lib/__tests__/anonymous-session-server.test.ts` → 1/1 (new contract test: non-httpOnly + session JSON)
- `bun run test:unit` → 653 pass / 1 skipped
- `bun run test:types` → clean · biome lint clean
- Post-merge prod check: fresh anon session, send 2 messages, banner must read 48 (will verify in the same dogfood loop as #248's version-counter check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
