### PR TITLE
fix(chat): gate auto-submit on transport registration — landing handoff no longer sends into the void

### DIFF
--- a/apps/broomva/components/chat-system.tsx
+++ b/apps/broomva/components/chat-system.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useChatActions, useChatStatus } from "@ai-sdk-tools/store";
+import {
+  useChatActions,
+  useChatStatus,
+  useChatStore,
+} from "@ai-sdk-tools/store";
 import { memo, useEffect, useRef } from "react";
 import { Chat } from "@/components/chat";
 import { ChatSync } from "@/components/chat-sync";
@@ -11,15 +15,28 @@ import { ArtifactProvider } from "@/hooks/use-artifact";
 import type { AppModelId } from "@/lib/ai/app-models";
 import type { ChatMessage, UiToolName } from "@/lib/ai/types";
 import { CustomStoreProvider } from "@/lib/stores/custom-store-provider";
-import { useAddMessageToTree } from "@/lib/stores/hooks-threads";
-import { useThreadEpoch } from "@/lib/stores/hooks-threads";
+import {
+  useAddMessageToTree,
+  useThreadEpoch,
+} from "@/lib/stores/hooks-threads";
 import { generateUUID } from "@/lib/utils";
-import { ChatInputProvider } from "@/providers/chat-input-provider";
-import { useChatInput } from "@/providers/chat-input-provider";
+import {
+  ChatInputProvider,
+  useChatInput,
+} from "@/providers/chat-input-provider";
 
 function AutoSubmitTrigger({ chatId }: { chatId: string }) {
   const status = useChatStatus();
   const { sendMessage } = useChatActions<ChatMessage>();
+  // useChatActions falls back to a silent no-op until ChatSync's useChat
+  // registers the real transport-bound sendMessage into the store — and
+  // that registration is deferred (rAF-batched state sync). On a heavy
+  // navigation (authed landing → /chat?q= handoff: RSC refetch + session
+  // + sidebar queries) the 100ms timer below can win that race, consume
+  // the auto-submit, and "send" into the void: message rendered in the
+  // tree, no POST /api/chat ever issued (#250). Gate on the real
+  // function being present; the effect re-runs when it registers.
+  const transportReady = useChatStore((state) => Boolean(state.sendMessage));
   const addMessageToTree = useAddMessageToTree();
   const {
     tryConsumeAutoSubmit,
@@ -31,7 +48,7 @@ function AutoSubmitTrigger({ chatId }: { chatId: string }) {
   const firedRef = useRef(false);
 
   useEffect(() => {
-    if (firedRef.current || status !== "ready") return;
+    if (firedRef.current || status !== "ready" || !transportReady) return;
 
     const timer = setTimeout(() => {
       if (firedRef.current) return;
@@ -62,6 +79,7 @@ function AutoSubmitTrigger({ chatId }: { chatId: string }) {
     return () => clearTimeout(timer);
   }, [
     status,
+    transportReady,
     chatId,
     sendMessage,
     addMessageToTree,


### PR DESCRIPTION
## Problem

Fixes #250. Sending from the landing hero as an **authenticated** user (`/` → `/chat?q=…`) rendered the message and pushed `/chat/<id>`, but **no `POST /api/chat` was ever issued** — the chat wedged with the message sitting unanswered. Reproduced twice today in production (authed profile), including *after* the #246 hydration fix shipped, which killed the earlier hydration-recovery theory. The anonymous flow never reproduced it.

## Root cause

`@ai-sdk-tools/store@1.2.0`'s `useChatActions()` returns `state.sendMessage || fallbackSendMessage`, where the fallback is a **silent no-op** (`debug.warn` only — invisible in prod). The real transport-bound `sendMessage` is registered into the store by `ChatSync`'s `useChat` via a **deferred, rAF-batched state sync** (`dist/index.js` ~730-760: `requestAnimationFrame(() => syncState(chatState))`).

`AutoSubmitTrigger` (components/chat-system.tsx) fired on `status === "ready"` + a 100ms timer. But the store's *initial* status is already `"ready"` before any helpers register — so on a heavy navigation (authed landing handoff: RSC refetch of `/chat?q=`, session fetch, sidebar queries), the timer wins the race:

1. `tryConsumeAutoSubmit()` consumes the one-shot,
2. `pushState`/`addMessageToTree` run (message visible, URL changes),
3. `sendMessage(message)` hits the **fallback no-op** → no request, no error, no retry. Wedge.

Why authed-only in practice: the authed `/chat?q=` navigation does strictly more work before hydration settles (session, chat list, RSC payloads), widening the registration gap past 100ms; the anon page settles faster.

## Fix

Gate the trigger on the real transport being registered, reactively:

```ts
const transportReady = useChatStore((state) => Boolean(state.sendMessage));
// effect: if (firedRef.current || status !== "ready" || !transportReady) return;
```

`useChatStore` is a public export and subscribes through the same `CustomStoreProvider` store, so the effect re-runs the moment ChatSync's helper sync lands — the auto-submit is never consumed before a real `sendMessage` exists. No behavior change for the already-working paths (timer and guards otherwise identical).

## Dep-Chain (P14)

**Upstream:** `@ai-sdk-tools/store@1.2.0` — `useChatStore` export, `StoreState.sendMessage` registration lifecycle (rAF-batched `syncState`), silent `fallbackSendMessage`; `providers/chat-input-provider.tsx` `tryConsumeAutoSubmit` one-shot semantics; `components/chat-sync.tsx` `useChat` mount (registrar).
**Downstream:** `app/(chat)/chat-home.tsx` (`?q=` capture → `autoSubmit`), `components/chat-system.tsx` `ChatSystem`/`ChatThreadSync` (remount keys `chat-sync:${id}:${threadEpoch}` — any remount window re-clears helpers, also covered by the reactive gate), issue #250.

**Known residual (documented, out of scope):** a *manual* submit (multimodal-input `coreSubmitLogic`) hitting the same unregistered-transport window would still silently drop; it's a far narrower window (human typing time). Follow-up candidate: disable the Submit button on `!transportReady`.

## Dogfood / validation

- Repro before fix (prod, authed Chrome): landing send → `/chat/019eb3b9-7f08-…` → message rendered, passive network log shows **zero** `api/chat` requests, no lifegw dispatch server-side (Railway logs checked at 22:49Z).
- `bunx biome check components/chat-system.tsx` → clean · `bun run test:unit` → 653 pass · `bun run test:types` → clean.
- Post-merge prod verification planned: repeat the authed landing handoff; expect POST /api/chat + streamed reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where messages could be auto-submitted before the chat transport system was fully initialized, ensuring messages are only sent when the chat system is ready to handle them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->