### PR TITLE
fix(chat): emit start chunk with server messageId — authed turns no longer grow phantom version siblings

### DIFF
--- a/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
+++ b/apps/broomva/app/(chat)/api/chat/__tests__/route.test.ts
@@ -483,11 +483,22 @@ describe("POST /api/chat — anonymous flow", () => {
     expect(resp.status).toBe(200);
 
     const body = await drainBody(resp);
-    const metadataChunks = body
+    const chunks = body
       .split("\n")
       .filter((line) => line.startsWith("data: ") && !line.includes("[DONE]"))
-      .map((line) => JSON.parse(line.slice("data: ".length)))
-      .filter((chunk) => chunk.type === "message-metadata");
+      .map((line) => JSON.parse(line.slice("data: ".length)));
+    const metadataChunks = chunks.filter(
+      (chunk) => chunk.type === "message-metadata",
+    );
+
+    // The route wrapper owns `start` emission too: without a `start`
+    // chunk carrying the server's messageId, the client invents its own
+    // assistant id and (for authenticated users) the DB-synced row
+    // becomes a phantom version sibling of the live message.
+    const startChunks = chunks.filter((chunk) => chunk.type === "start");
+    expect(startChunks.length).toBeGreaterThanOrEqual(1);
+    expect(typeof startChunks[0].messageId).toBe("string");
+    expect(startChunks[0].messageId.length).toBeGreaterThan(0);
 
     // The route wrapper owns message-metadata emission (the canonical
     // translator deliberately does not) — without these chunks the

--- a/apps/broomva/app/(chat)/api/chat/route.ts
+++ b/apps/broomva/app/(chat)/api/chat/route.ts
@@ -828,6 +828,20 @@ async function createLifegwBackedChatStream({
 
   const stream = createUIMessageStream<ChatMessage>({
     execute: async ({ writer: dataStream }) => {
+      // Adopt the server's assistant message id on the client. Without a
+      // `start` chunk carrying `messageId`, the client's useChat invents
+      // its own id while persistence writes under `messageId` — so for
+      // authenticated users the DB-synced row and the live streamed
+      // message become two siblings of the same user message and the UI
+      // shows phantom version arrows on every turn. Like
+      // `message-metadata` below, `start` is owned by this wrapper (the
+      // canonical translator deliberately emits neither — see
+      // canonical-to-vercel-ai-sse.ts header).
+      dataStream.write({
+        type: "start",
+        messageId,
+      });
+
       // Confirm chat persistence on first message (chat + user message
       // are persisted before streaming begins — this just signals the
       // UI to update its sidebar)


### PR DESCRIPTION
## Problem

Authenticated turns still showed version arrows after #248 — e.g. a brand-new authed chat's first reply rendered "2/2" (observed on prod tonight in chat `019eb428-ee88-…`, and retroactively explains this morning's "1/2" on the pong test). Anonymous chats are clean.

Wire evidence: the lifegw-backed SSE stream emits **no `start` chunk** (first chunk is `message-metadata`, then `text-start`). Per `ai@6.0.184` `processUIMessageStream`, the client adopts the server's assistant message id only from `start.messageId` — absent that, the client invents its own uuid. Persistence writes the assistant row under the route's `messageId` (`createUIMessageStream`'s `generateId`). For authed users, `MessageTreeSync`'s `getChatMessages` sync then brings the server-id row into `allMessages` alongside the live client-id message — two assistant nodes under the same user message → `lib/stores/with-threads.ts` renders them as version siblings. Anon users never DB-sync, hence clean.

This is the unfulfilled second half of the translator's ownership contract: `canonical-to-vercel-ai-sse.ts` (header ~line 44) declares it emits **neither `start` nor `message-metadata`** — "those are owned by the `createUIMessageStream` wrapper in the route". #248 fulfilled the metadata half; this PR fulfills the `start` half.

## Fix

`createLifegwBackedChatStream.execute()` now writes `{ type: "start", messageId }` as the first chunk, before `data-chatConfirmed`/`message-metadata`. The client's `case "start"` sets `state.message.id = chunk.messageId`, so live and persisted assistant messages share one id and the DB sync replaces instead of fork-siblings.

## Dep-Chain (P14)

**Upstream:** `ai@6.0.184` `processUIMessageStream` `case "start"` (`state.message.id = chunk.messageId`); route's `messageId` (also used by `generateId`, `finalizeMessageAndCredits` persistence, and `prepareReconnectToStreamRequest`'s `?messageId=` resume path — ids now consistent end-to-end).
**Downstream:** `components/message-tree-sync.tsx` (DB sync upserts same-id message), `lib/stores/with-threads.ts` `addMessageToTree` (id match → replace, not append), `components/chat-sync.tsx` `onFinish`/`saveChatMessage` (same id), `__tests__/route.test.ts` (start-chunk assertions added).

## Dogfood / validation

- Prod wire probe before fix: first SSE chunks = `message-metadata` → `text-start` (no `start`).
- `bunx vitest run app/(chat)/api/chat/__tests__/route.test.ts` → 12/12 (start-chunk + metadata assertions) · `bun run test:unit` full suite pass · `bun run test:types` clean · biome clean.
- Post-merge prod check: new authed chat turn must render with **no** version arrows; anon flow re-checked unchanged.

Same dogfood arc as #246/#247/#248/#251/#252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
