### PR TITLE
fix(profile): remove unconcluded Life Runtime tenant engagement card [BRO-1487]

### DIFF
--- a/apps/broomva/app/(site)/profile/page.tsx
+++ b/apps/broomva/app/(site)/profile/page.tsx
@@ -139,12 +139,6 @@ const engagements = [
       "Anchor customer of the Time Series Engine. Production medallion-style lakehouse since 2021 with anomaly detection, alarm threshold estimation, and digital-twin integration.",
   },
   {
-    metric: "$250M+ AUM · 3,000+ bedrooms",
-    label: "Canadian property-management group",
-    blurb:
-      "First paying tenant of Broomva Life Runtime — Sentinel work-order audit module. Pro-tier SLA, USDC-on-Base billing rail.",
-  },
-  {
     metric: "FIFA 2026 + Olympics Committee scale",
     label: "Tier-1 sports + procurement enterprise",
     blurb:


### PR DESCRIPTION
## Summary
Removes the **"$250M+ AUM · 3,000+ bedrooms — Canadian property-management group / first paying tenant"** engagement card from `/profile`. That engagement (and the Colombian constructora materiales-intel one) was a **prospect that never concluded** — no contract, no paying tenant. Companion workspace commit `437c7988` removes the same claims from all CVs and archives the prospect records + 8 knowledge-graph entities.

Linear: BRO-1487

## Dep-chain (P14)
- Upstream: `apps/broomva/app/(site)/profile/page.tsx` — `engagements` const only (6-line deletion, no component/schema changes).
- Downstream: `/profile` engagements grid renders 3 cards instead of 4; no other consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the profile page engagements section with three new case study examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->