### PR TITLE
feat(redis): per-env DB isolation + wiring tests + CI redis gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,19 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    services:
+      # Real Redis for the wiring integration test (redis-wiring.integration
+      # .test.ts). The test self-skips when REDIS_URL is unset, so this is what
+      # makes the "is the whole setup wired?" check actually gate PRs.
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -57,6 +70,15 @@ jobs:
 
       - name: Typecheck
         run: bun run test:types
+
+      # Runs the full vitest suite (previously not gated in CI) plus the Redis
+      # wiring integration test against the redis:8 service on db15 (isolated
+      # from the app's prod=0 / preview=1 / dev=2 logical DBs).
+      - name: Test (unit + Redis integration)
+        working-directory: apps/broomva
+        env:
+          REDIS_URL: redis://localhost:6379/15
+        run: bun run test:unit
 
       - name: Validate internal links
         run: bun run check:links

--- a/apps/broomva/app/api/health/redis/route.ts
+++ b/apps/broomva/app/api/health/redis/route.ts
@@ -12,13 +12,14 @@
  *   503 { status: "unavailable" }  — REDIS_URL set but unreachable (real fault)
  */
 
-import { NextResponse } from "next/server";
+import { connection, NextResponse } from "next/server";
 import { checkRedisHealth } from "@/lib/redis-health";
 
-// Always probe live — a cached health result is worse than useless.
-export const dynamic = "force-dynamic";
-
 export async function GET() {
+  // Opt out of static prerendering (the project runs `cacheComponents`, which
+  // forbids `export const dynamic`): always probe live — a build-time cached
+  // health result is worse than useless.
+  await connection();
   const health = await checkRedisHealth();
   const httpStatus = health.status === "unavailable" ? 503 : 200;
   return NextResponse.json(health, { status: httpStatus });

--- a/apps/broomva/app/api/health/redis/route.ts
+++ b/apps/broomva/app/api/health/redis/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/health/redis
+ *
+ * Status-only health probe for the Redis the chat surface uses for anonymous
+ * rate limiting + resumable streams. Returns `{ status, latency_ms, db }` —
+ * never the connection string. Public (status-only, no secrets) so dogfood /
+ * uptime checks can read it without a session cookie; registered in
+ * proxy.ts PUBLIC_API_PREFIXES under `/api/health`.
+ *
+ *   200 { status: "ok" }           — connected + PONG
+ *   200 { status: "unconfigured" } — no REDIS_URL (intentional in-memory mode)
+ *   503 { status: "unavailable" }  — REDIS_URL set but unreachable (real fault)
+ */
+
+import { NextResponse } from "next/server";
+import { checkRedisHealth } from "@/lib/redis-health";
+
+// Always probe live — a cached health result is worse than useless.
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const health = await checkRedisHealth();
+  const httpStatus = health.status === "unavailable" ? 503 : 200;
+  return NextResponse.json(health, { status: httpStatus });
+}

--- a/apps/broomva/lib/__tests__/redis-wiring.integration.test.ts
+++ b/apps/broomva/lib/__tests__/redis-wiring.integration.test.ts
@@ -1,0 +1,90 @@
+// End-to-end Redis wiring test — runs against a REAL Redis whenever REDIS_URL
+// is set (CI provides a `redis:8` service on db15; locally point it at the
+// Railway instance's db15). Skipped otherwise so the unit suite stays
+// hermetic. This is the test that "checks the whole setup is wired": env var
+// → client → connect → PING → per-environment logical-DB isolation.
+
+import { createClient } from "redis";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { checkRedisHealth, parseRedisDb } from "@/lib/redis-health";
+import { checkAnonymousRateLimit } from "@/lib/utils/rate-limit";
+
+// redis-health.ts / rate-limit.ts are server-only; neutralize the guard.
+vi.mock("server-only", () => ({}));
+
+const REDIS_URL = process.env.REDIS_URL;
+
+/** Rewrite the logical-DB segment of a redis:// URL (the isolation knob). */
+function withDb(url: string, db: number): string {
+  const u = new URL(url);
+  u.pathname = `/${db}`;
+  return u.toString();
+}
+
+type Client = ReturnType<typeof createClient>;
+
+// `describe.skipIf` keeps the unit run green with no Redis present.
+describe.skipIf(!REDIS_URL)("Redis wiring (integration)", () => {
+  const url = REDIS_URL as string;
+  const configuredDb = parseRedisDb(url) ?? 0;
+  const otherDb = configuredDb === 0 ? 1 : configuredDb - 1;
+  const stamp = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+  let primary: Client;
+  let neighbour: Client;
+
+  beforeAll(async () => {
+    primary = createClient({ url, socket: { reconnectStrategy: false } });
+    neighbour = createClient({
+      url: withDb(url, otherDb),
+      socket: { reconnectStrategy: false },
+    });
+    primary.on("error", () => undefined);
+    neighbour.on("error", () => undefined);
+    await Promise.all([primary.connect(), neighbour.connect()]);
+  });
+
+  afterAll(async () => {
+    await primary?.destroy();
+    await neighbour?.destroy();
+  });
+
+  it("connects and answers PING", async () => {
+    expect(await primary.ping()).toBe("PONG");
+  });
+
+  it("checkRedisHealth reports ok with the configured DB", async () => {
+    const health = await checkRedisHealth(url);
+    expect(health.status).toBe("ok");
+    expect(health.db).toBe(configuredDb);
+    expect(health.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("isolates keyspaces across logical DBs (per-environment isolation)", async () => {
+    const key = `wiringtest:iso:${stamp}`;
+    try {
+      await primary.set(key, "present", { EX: 30 });
+      // Same key, neighbouring DB index → must NOT see it.
+      expect(await neighbour.get(key)).toBeNull();
+      // Sanity: it IS visible in its own DB.
+      expect(await primary.get(key)).toBe("present");
+    } finally {
+      await primary.del(key);
+    }
+  });
+
+  it("writes a durable rate-limit counter through the real client", async () => {
+    const ip = `198.51.100.${Math.floor(Math.random() * 254) + 1}-${stamp}`;
+    const minuteKey = `broomva:rate-limit:minute:${ip}`;
+    const monthKey = `broomva:rate-limit:month:${ip}`;
+    try {
+      const result = await checkAnonymousRateLimit(ip, primary);
+      expect(result.success).toBe(true);
+      // The counter is in Redis — durable across serverless instances.
+      expect(await primary.get(minuteKey)).toBe("1");
+    } finally {
+      await primary.del(minuteKey);
+      await primary.del(monthKey);
+    }
+  });
+});

--- a/apps/broomva/lib/redis-health.ts
+++ b/apps/broomva/lib/redis-health.ts
@@ -1,0 +1,91 @@
+import "server-only";
+
+import { createClient } from "redis";
+
+export type RedisHealthStatus = "ok" | "unavailable" | "unconfigured";
+
+export type RedisHealth = {
+  status: RedisHealthStatus;
+  latency_ms: number;
+  /** Logical DB index parsed from the connection URL (0 when unspecified). */
+  db: number | null;
+  error?: string;
+};
+
+const CONNECT_TIMEOUT_MS = 3000;
+
+/**
+ * Parse the logical DB index from a redis:// URL path (e.g. `…:6379/2` → 2).
+ * Per-environment DB isolation (prod=0, preview=1, dev=2) rides on this path
+ * segment, so the health probe surfaces it for verification.
+ */
+export function parseRedisDb(url: string): number | null {
+  try {
+    const path = new URL(url).pathname.replace(/^\//, "");
+    if (path === "") {
+      return 0;
+    }
+    const n = Number.parseInt(path, 10);
+    return Number.isNaN(n) ? null : n;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probe the configured Redis: connect, PING, report status + latency + DB.
+ *
+ * Never throws and never leaks the connection string — safe to expose via a
+ * health route. `unconfigured` (no REDIS_URL) is a valid graceful mode (the
+ * app intentionally falls back to in-memory rate limiting); `unavailable`
+ * means a URL is set but unreachable — the real failure this guards against
+ * (it was masked for ~85 days by a stale URL pointing at a deleted store).
+ */
+export async function checkRedisHealth(
+  url: string | undefined = process.env.REDIS_URL,
+): Promise<RedisHealth> {
+  if (!url) {
+    return { status: "unconfigured", latency_ms: 0, db: null };
+  }
+
+  const db = parseRedisDb(url);
+  const client = createClient({
+    url,
+    socket: { connectTimeout: CONNECT_TIMEOUT_MS, reconnectStrategy: false },
+  });
+  // A bare error listener prevents an unhandled 'error' from crashing node
+  // when the endpoint is unreachable.
+  client.on("error", () => {
+    // swallowed — surfaced via the catch below
+  });
+
+  const start = performance.now();
+  try {
+    await client.connect();
+    const pong = await client.ping();
+    const latency_ms = Math.round(performance.now() - start);
+    if (pong !== "PONG") {
+      return {
+        status: "unavailable",
+        latency_ms,
+        db,
+        error: `unexpected PING reply: ${pong}`,
+      };
+    }
+    return { status: "ok", latency_ms, db };
+  } catch (error) {
+    return {
+      status: "unavailable",
+      latency_ms: Math.round(performance.now() - start),
+      db,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    // destroy() force-closes whether or not connect succeeded.
+    try {
+      client.destroy();
+    } catch {
+      // already closed — nothing to do
+    }
+  }
+}

--- a/apps/broomva/lib/utils/__tests__/rate-limit.test.ts
+++ b/apps/broomva/lib/utils/__tests__/rate-limit.test.ts
@@ -1,0 +1,93 @@
+// Unit tests for the rate-limiter's "is Redis actually wired?" decision logic.
+//
+// These are deterministic (a fake in-memory Redis double — no network) and
+// pin the two behaviours that the 85-day stale-URL outage silently broke:
+//   1. With a working client, counters are written to Redis (durable, shared
+//      across serverless instances) — the path that makes the limit real.
+//   2. With no client OR a throwing client, it falls back to in-memory and
+//      never throws — graceful degradation, not a 500.
+// The live end-to-end wire (real connect + DB isolation) is covered by
+// redis-wiring.integration.test.ts.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { config } from "@/lib/config";
+import { ANONYMOUS_LIMITS } from "@/lib/types/anonymous";
+import { checkAnonymousRateLimit } from "@/lib/utils/rate-limit";
+
+// rate-limit.ts is server-only; neutralize the guard for the test runtime
+// (same pattern as the chat route test).
+vi.mock("server-only", () => ({}));
+
+/** Minimal node-redis double: only the commands checkRateLimit calls. */
+function makeFakeRedis() {
+  const store = new Map<string, number>();
+  return {
+    store,
+    get: vi.fn(async (k: string) => {
+      const v = store.get(k);
+      return v === undefined ? null : String(v);
+    }),
+    incr: vi.fn(async (k: string) => {
+      const v = (store.get(k) ?? 0) + 1;
+      store.set(k, v);
+      return v;
+    }),
+    expire: vi.fn(async () => true),
+  };
+}
+
+const IP = "203.0.113.7";
+const MINUTE_KEY = `${config.appPrefix}:rate-limit:minute:${IP}`;
+const MONTH_KEY = `${config.appPrefix}:rate-limit:month:${IP}`;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("checkAnonymousRateLimit — Redis wiring", () => {
+  it("writes durable counters to Redis on the happy path", async () => {
+    const redis = makeFakeRedis();
+
+    const result = await checkAnonymousRateLimit(IP, redis);
+
+    expect(result.success).toBe(true);
+    // The counter lives in Redis (shared across instances), not process memory.
+    expect(redis.incr).toHaveBeenCalledWith(MINUTE_KEY);
+    expect(redis.incr).toHaveBeenCalledWith(MONTH_KEY);
+    expect(redis.store.get(MINUTE_KEY)).toBe(1);
+    expect(redis.store.get(MONTH_KEY)).toBe(1);
+    // First increment in a window sets the expiry (window roll-over).
+    expect(redis.expire).toHaveBeenCalled();
+  });
+
+  it("blocks once the per-minute counter exceeds the limit", async () => {
+    const redis = makeFakeRedis();
+    const limit = ANONYMOUS_LIMITS.RATE_LIMIT.REQUESTS_PER_MINUTE;
+
+    // Exhaust exactly the allowance.
+    for (let i = 0; i < limit; i++) {
+      const ok = await checkAnonymousRateLimit(IP, redis);
+      expect(ok.success).toBe(true);
+    }
+
+    // One past the limit → blocked, with rate-limit headers.
+    const blocked = await checkAnonymousRateLimit(IP, redis);
+    expect(blocked.success).toBe(false);
+    expect(blocked.headers?.["X-RateLimit-Remaining"]).toBe("0");
+    expect(redis.store.get(MINUTE_KEY)).toBe(limit + 1);
+  });
+
+  it("falls back to in-memory (no throw) when no client is supplied", async () => {
+    const result = await checkAnonymousRateLimit(IP, null);
+    // Graceful degradation — the request still succeeds, just non-durable.
+    expect(result.success).toBe(true);
+  });
+
+  it("falls back to in-memory when the Redis client throws", async () => {
+    const redis = makeFakeRedis();
+    redis.incr.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const result = await checkAnonymousRateLimit(IP, redis);
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -77,6 +77,10 @@ const PUBLIC_API_PREFIXES = [
   "/api/invocations",
   "/api/feedback",
   "/api/metrics",
+  // Infra health probes (e.g. /api/health/redis): status-only JSON (no
+  // secrets), polled by dogfood / uptime checks from terminals with no
+  // session cookie. Must not 307→/login or external probes can't read it.
+  "/api/health",
   // Audio narration: every blog/project post has a "Listen to post" player.
   // The handler stores per-user resume position when signed in, but degrades
   // to no-op for anonymous readers (`NextResponse.json(null)` on GET, 401 on


### PR DESCRIPTION
## What

Adds the **verification + isolation layer** the Redis setup never had. Background: anon rate-limiting silently fell back to in-memory for ~85 days because `REDIS_URL` pointed at a deleted Upstash store — no test or health check could have caught it. This PR makes "is the whole setup wired?" a gated, testable property, and isolates the environments.

## Changes

- **`lib/redis-health.ts`** — `checkRedisHealth(url?)`: connect → PING → `{ status, latency_ms, db }`. Never throws, never leaks the connection string. `unconfigured` (no URL) is a valid graceful mode; `unavailable` (URL set but unreachable) is the real fault — exactly the state that was masked.
- **`GET /api/health/redis`** — status-only probe (200 ok/unconfigured, 503 unavailable) for dogfood/uptime. Registered in `proxy.ts` `PUBLIC_API_PREFIXES` under `/api/health` so external probes aren't 307→/login.
- **`lib/utils/__tests__/rate-limit.test.ts`** — deterministic unit tests of the wiring *decision*: durable counters written to Redis on the happy path; over-limit blocks; **falls back to in-memory (no throw) when the client is null or throws**. These are the two behaviours the stale-URL outage broke.
- **`lib/__tests__/redis-wiring.integration.test.ts`** — self-gated (`skipIf(!REDIS_URL)`) end-to-end: real connect + PING, `checkRedisHealth` ok with the expected DB, **logical-DB isolation** (a key in db N is absent in db N±1), and a durable rate-limit counter through a real client.
- **CI (`ci.yml`)** — adds a `redis:8` service + a **vitest step** (`REDIS_URL=…/15`). The full 661-test suite was **never run in CI before** (only `test:types` was) — now it gates PRs, and the integration test verifies the real wire.

## Per-environment isolation

One Railway Redis, separate logical DB per Vercel env via the `redis://…/N` path — **prod=0, preview=1, dev=2**, CI=15. Real keyspace isolation (a scan/FLUSHDB in one never touches another) at zero extra cost. Preview/Dev `REDIS_URL` env vars are applied out-of-band on Vercel (not in git).

## Dep-Chain (P14)

**Upstream:** `redis@^5.5.6` `createClient` (socket `reconnectStrategy:false`, `connectTimeout`); `lib/utils/rate-limit.ts` `checkAnonymousRateLimit` (get/incr/expire); `proxy.ts` `PUBLIC_API_PREFIXES`; `lib/config` `appPrefix`.
**Downstream:** dogfood/uptime probes of `/api/health/redis`; CI `validate` job now runs vitest (all PRs); `app/(chat)/api/chat/route.ts` rate-limit + resumable-stream paths are the runtime consumers (unchanged here).

## Validation

- `bunx biome check` (all 5 files) → clean
- `bun run test:unit` with `REDIS_URL=<railway>/15` → **661 passed / 1 skipped (82 files)**; integration suite connected to a real Redis, asserted DB isolation + durable counter
- Without `REDIS_URL` → integration suite **skips** (4 passed / 4 skipped), unit suite green — hermetic
- `bun run test:types` → clean
- Post-merge dogfood: `GET https://broomva.tech/api/health/redis` → `{status:"ok", db:0}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
