### PR TITLE
fix(swapit): public commons reachability + anon write rate-limit [BRO-1547]

### DIFF
--- a/apps/broomva/app/api/swapit/facts/route.ts
+++ b/apps/broomva/app/api/swapit/facts/route.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
@@ -139,18 +139,31 @@ const factSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
+// Server-held HMAC key so a stored contributorHash can't be reversed to an IP by anyone with
+// DB-table access (an IPv4 is trivially brute-forced against a bare sha256). Stable across
+// instances/deploys (same precedence as lib/auth.ts) so corroboration keeps counting a given
+// contributor as ONE identity; the fallback only applies in dev/test where anonymity is moot.
+const CONTRIBUTOR_HMAC_KEY =
+  process.env.NEON_AUTH_COOKIE_SECRET ||
+  process.env.AUTH_SECRET ||
+  "swapit-anon-contributor-fallback";
+
 /** Server-observed contributor identity: the Better Auth session user, else the trusted
  * client IP. The IP MUST come from `getClientIP` (the rightmost, platform-appended
  * x-forwarded-for entry) — NOT a client-supplied header. Using the leftmost XFF entry would
  * let one anonymous source mint many identities (spoofed XFF) and self-approve a fact, since
- * approval is gated on DISTINCT contributors. The raw value is hashed and never stored. */
+ * approval is gated on DISTINCT contributors. Keyed (HMAC) so the stored value is stable for
+ * corroboration but not reversible to the raw IP. The raw value is never stored. */
 function contributorHash(
   userId: string | null,
   ip: string | null,
 ): string | null {
   const raw = userId ?? ip;
   return raw
-    ? createHash("sha256").update(raw).digest("hex").slice(0, 32)
+    ? createHmac("sha256", CONTRIBUTOR_HMAC_KEY)
+        .update(raw)
+        .digest("hex")
+        .slice(0, 32)
     : null;
 }
 

--- a/apps/broomva/app/api/swapit/facts/route.ts
+++ b/apps/broomva/app/api/swapit/facts/route.ts
@@ -14,6 +14,8 @@ import {
   serializeFact,
   upsertFact,
 } from "@/lib/db/swapit-facts";
+import { checkSwapitWriteRateLimit } from "@/lib/swapit/rate-limit";
+import { getClientIP } from "@/lib/utils/rate-limit";
 
 const MAX_PAYLOAD_BYTES = 32_768;
 const MAX_FREETEXT = 600;
@@ -137,15 +139,15 @@ const factSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
-/** Server-observed contributor identity: the Better Auth session user, else the client IP.
- * NOT a client-supplied header — otherwise one source could mint many identities and
- * self-corroborate. Returns null when no signal is available (then it can't count toward
- * approval). The raw value is hashed and never stored. */
-function contributorHash(userId: string | null, h: Headers): string | null {
-  const ip =
-    h.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    h.get("x-real-ip") ||
-    null;
+/** Server-observed contributor identity: the Better Auth session user, else the trusted
+ * client IP. The IP MUST come from `getClientIP` (the rightmost, platform-appended
+ * x-forwarded-for entry) — NOT a client-supplied header. Using the leftmost XFF entry would
+ * let one anonymous source mint many identities (spoofed XFF) and self-approve a fact, since
+ * approval is gated on DISTINCT contributors. The raw value is hashed and never stored. */
+function contributorHash(
+  userId: string | null,
+  ip: string | null,
+): string | null {
   const raw = userId ?? ip;
   return raw
     ? createHash("sha256").update(raw).digest("hex").slice(0, 32)
@@ -153,7 +155,28 @@ function contributorHash(userId: string | null, h: Headers): string | null {
 }
 
 // POST /api/swapit/facts — contribute an anonymized fact (anonymous-by-IP or Better-Auth-identified)
-export const POST = withValidation(factSchema, async (_request, { body }) => {
+export const POST = withValidation(factSchema, async (request, { body }) => {
+  // One session read serves both the rate-limit key and the contributor identity.
+  const h = await headers();
+  const { data: session } = await getSafeSession({
+    fetchOptions: { headers: h },
+  });
+  const userId = session?.user?.id ?? null;
+
+  // Per-IP (anonymous) / per-user rate limit — the route is public (proxy allowlist),
+  // so this is the abuse guard on the anonymous write path.
+  const rate = checkSwapitWriteRateLimit({ request, userId });
+  if (!rate.allowed) {
+    const retryAfter = Math.max(
+      0,
+      Math.ceil((rate.resetAt - Date.now()) / 1000),
+    );
+    return NextResponse.json(
+      { error: "rate limit exceeded", code: "rate_limited" },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
+    );
+  }
+
   const leaks = scanForbidden(body.payload);
   if (leaks.length > 0) {
     return NextResponse.json(
@@ -167,11 +190,8 @@ export const POST = withValidation(factSchema, async (_request, { body }) => {
     return NextResponse.json({ error: "payload too large" }, { status: 413 });
   }
 
-  const h = await headers();
-  const { data: session } = await getSafeSession({
-    fetchOptions: { headers: h },
-  });
-  const hash = contributorHash(session?.user?.id ?? null, h);
+  // Trusted IP (rightmost, platform-appended XFF) — same un-spoofable source as the limiter.
+  const hash = contributorHash(userId, getClientIP(request));
 
   const fact = await upsertFact(
     { kind: body.kind, payload: body.payload } as FactInput,

--- a/apps/broomva/lib/swapit/rate-limit.test.ts
+++ b/apps/broomva/lib/swapit/rate-limit.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  __resetSwapitRateLimit,
+  checkSwapitWriteRateLimit,
+} from "./rate-limit";
+
+function reqFromIp(ip: string): Request {
+  return new Request("https://broomva.tech/api/swapit/facts", {
+    method: "POST",
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+beforeEach(() => {
+  __resetSwapitRateLimit();
+});
+
+describe("checkSwapitWriteRateLimit", () => {
+  it("allows 60 anonymous writes/min per IP, then blocks with a future reset", () => {
+    const request = reqFromIp("1.2.3.4");
+    for (let i = 0; i < 60; i++) {
+      expect(checkSwapitWriteRateLimit({ request, userId: null }).allowed).toBe(
+        true,
+      );
+    }
+    const blocked = checkSwapitWriteRateLimit({ request, userId: null });
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.resetAt).toBeGreaterThan(Date.now());
+  });
+
+  it("keeps a separate budget per IP", () => {
+    for (let i = 0; i < 60; i++) {
+      checkSwapitWriteRateLimit({
+        request: reqFromIp("1.1.1.1"),
+        userId: null,
+      });
+    }
+    expect(
+      checkSwapitWriteRateLimit({ request: reqFromIp("1.1.1.1"), userId: null })
+        .allowed,
+    ).toBe(false);
+    // a different IP still has its full budget
+    expect(
+      checkSwapitWriteRateLimit({ request: reqFromIp("2.2.2.2"), userId: null })
+        .allowed,
+    ).toBe(true);
+  });
+
+  it("gives authenticated users a higher per-user budget, keyed by user not IP", () => {
+    const request = reqFromIp("9.9.9.9"); // same IP throughout
+    let last = checkSwapitWriteRateLimit({ request, userId: "user-1" });
+    // 100 writes — well past the anon cap of 60 — all allowed for a signed-in user
+    for (let i = 0; i < 99; i++) {
+      last = checkSwapitWriteRateLimit({ request, userId: "user-1" });
+    }
+    expect(last.allowed).toBe(true);
+    // a different user shares neither budget
+    expect(
+      checkSwapitWriteRateLimit({ request, userId: "user-2" }).allowed,
+    ).toBe(true);
+  });
+
+  it("keys on the trusted rightmost XFF entry — spoofing the leftmost can't mint new buckets", () => {
+    // Vercel appends the real client IP to the RIGHT of x-forwarded-for. An attacker
+    // prepending junk on the left must NOT get a fresh budget — both requests below share
+    // the same real IP (203.0.113.7), so they share ONE bucket. This is the same property
+    // contributorHash now relies on to prevent anonymous self-approval.
+    function spoofed(leftmost: string): Request {
+      return new Request("https://broomva.tech/api/swapit/facts", {
+        method: "POST",
+        headers: { "x-forwarded-for": `${leftmost}, 203.0.113.7` },
+      });
+    }
+    for (let i = 0; i < 60; i++) {
+      checkSwapitWriteRateLimit({
+        request: spoofed(i % 2 ? "9.9.9.9" : "8.8.8.8"),
+        userId: null,
+      });
+    }
+    // 60 combined writes against the shared trusted IP → blocked regardless of leftmost
+    expect(
+      checkSwapitWriteRateLimit({ request: spoofed("1.1.1.1"), userId: null })
+        .allowed,
+    ).toBe(false);
+  });
+});

--- a/apps/broomva/lib/swapit/rate-limit.ts
+++ b/apps/broomva/lib/swapit/rate-limit.ts
@@ -1,0 +1,82 @@
+import "server-only";
+
+import { getClientIP } from "@/lib/utils/rate-limit";
+
+/**
+ * Write-path rate limiting for the public swapit commons (`POST /api/swapit/facts`).
+ *
+ * In-memory token bucket, mirroring `lib/telemetry/rate-limit.ts` but with its own
+ * keyspace so it never competes with the telemetry beacon budget. Single-region; the
+ * shape matches the telemetry limiter so a future refactor to a shared primitive is
+ * cheap (see that file's note). Corroboration already blunts *content* spam — a lone
+ * IP can't approve a fact, and identical resubmissions only bump a counter — so this
+ * guards the raw DB-write rate, not the knowledge graph's integrity.
+ */
+
+type Bucket = { count: number; resetAt: number };
+const buckets = new Map<string, Bucket>();
+let lastCleanup = Date.now();
+const CLEANUP_INTERVAL_MS = 60_000;
+
+function cleanup(now: number) {
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) {
+    return;
+  }
+  lastCleanup = now;
+  for (const [k, b] of buckets) {
+    if (b.resetAt <= now) {
+      buckets.delete(k);
+    }
+  }
+}
+
+export type SwapitRateLimitResult = {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number;
+};
+
+function check(
+  key: string,
+  limit: number,
+  windowMs: number,
+): SwapitRateLimitResult {
+  const now = Date.now();
+  cleanup(now);
+  const bucket = buckets.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    const resetAt = now + windowMs;
+    buckets.set(key, { count: 1, resetAt });
+    return { allowed: true, remaining: limit - 1, resetAt };
+  }
+  bucket.count += 1;
+  return {
+    allowed: bucket.count <= limit,
+    remaining: Math.max(0, limit - bucket.count),
+    resetAt: bucket.resetAt,
+  };
+}
+
+// Generous enough for a legitimate batch `swapit sync` (a user pushing a region's
+// worth of offers in one go), bounded against raw write floods from a single source.
+const ANON_WRITES_PER_MIN = 60;
+const USER_WRITES_PER_MIN = 600;
+const WINDOW_MS = 60_000;
+
+/** Per-IP (anonymous) / per-user (authenticated) write rate for `POST /api/swapit/facts`. */
+export function checkSwapitWriteRateLimit(opts: {
+  request: Request;
+  userId: string | null;
+}): SwapitRateLimitResult {
+  if (opts.userId) {
+    return check(`swapit:u:${opts.userId}`, USER_WRITES_PER_MIN, WINDOW_MS);
+  }
+  const ip = getClientIP(opts.request as Request & { ip?: string });
+  return check(`swapit:ip:${ip}`, ANON_WRITES_PER_MIN, WINDOW_MS);
+}
+
+/** Test-only: clear the in-memory buckets between cases. */
+export function __resetSwapitRateLimit() {
+  buckets.clear();
+  lastCleanup = Date.now();
+}

--- a/apps/broomva/proxy.test.ts
+++ b/apps/broomva/proxy.test.ts
@@ -51,6 +51,13 @@ describe("proxy public artifact routes", () => {
     expect(mockGetSafeSession).not.toHaveBeenCalled();
   });
 
+  test("does NOT treat a sibling like /swapit-admin as public (boundary match)", async () => {
+    const response = await proxy(req("/swapit-admin"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://broomva.tech/login");
+  });
+
   test("still redirects private app pages for anonymous visitors", async () => {
     const response = await proxy(req("/maestro"));
 

--- a/apps/broomva/proxy.test.ts
+++ b/apps/broomva/proxy.test.ts
@@ -33,6 +33,24 @@ describe("proxy public artifact routes", () => {
     expect(mockGetSafeSession).not.toHaveBeenCalled();
   });
 
+  test("allows the anonymous swapit commons page through to the handler", async () => {
+    const response = await proxy(req("/swapit"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockGetSafeSession).not.toHaveBeenCalled();
+  });
+
+  test("allows the public swapit commons API (GET browse/pull) through", async () => {
+    const response = await proxy(
+      req("/api/swapit/facts?kind=procurement_option&region=US"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(mockGetSafeSession).not.toHaveBeenCalled();
+  });
+
   test("still redirects private app pages for anonymous visitors", async () => {
     const response = await proxy(req("/maestro"));
 

--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -199,7 +199,14 @@ function isPublicPage(pathname: string): boolean {
   if ((PUBLIC_PAGE_EXACT as readonly string[]).includes(pathname)) {
     return true;
   }
-  return PUBLIC_PAGE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+  // Boundary-aware matching (mirrors isPublicApiRoute): a bare prefix like `/swapit` must
+  // match `/swapit` and `/swapit/...` but NOT a sibling route like `/swapit-admin`. Prefixes
+  // that already end in `/` (e.g. `/share/`, `/d/`, `/h/`) keep their literal startsWith.
+  return PUBLIC_PAGE_PREFIXES.some((prefix) =>
+    prefix.endsWith("/")
+      ? pathname.startsWith(prefix)
+      : pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
 }
 
 function isPublicApiRoute(pathname: string): boolean {

--- a/apps/broomva/proxy.ts
+++ b/apps/broomva/proxy.ts
@@ -19,6 +19,10 @@ const PUBLIC_PAGE_PREFIXES = [
   "/terms",
   "/pricing",
   "/skills",
+  // Swapit commons (BRO-1547): the public household-toxics where-to-buy dataset.
+  // The page is read-only and renders only approved, corroborated facts — never
+  // any private inventory — so anonymous viewers must reach it.
+  "/swapit",
   "/agents",
   "/graph",
   "/links",
@@ -77,6 +81,15 @@ const PUBLIC_API_PREFIXES = [
   "/api/invocations",
   "/api/feedback",
   "/api/metrics",
+  // Swapit commons (BRO-1547): the anonymized household-toxics knowledge commons.
+  // GET serves only approved facts (browse/pull from the skill's `swapit sync`);
+  // POST contributes a generic, content-addressed fact. Anonymous-OK by design —
+  // the `swapit` CLI syncs from terminals with no session cookie. The handler does
+  // its own trust enforcement (per-kind Zod, the scanForbidden privacy backstop,
+  // payload-size caps, server-derived contributor identity = session user OR client
+  // IP) and per-IP/per-user rate limits, so it MUST NOT 307→/login (the CLI can't
+  // follow an HTML auth redirect). Private inventory never reaches here.
+  "/api/swapit",
   // Infra health probes (e.g. /api/health/redis): status-only JSON (no
   // secrets), polled by dogfood / uptime checks from terminals with no
   // session cookie. Must not 307→/login or external probes can't read it.


### PR DESCRIPTION
## Problem
The swapit commons is an open, anonymous, public dataset (the M4 where-to-buy data is "detailed so anyone can use it"), but the broomva.tech auth proxy (`proxy.ts`, Next.js 16) gated `/api/swapit/*` and `/swapit` → **307→/login**. So anonymous browse/pull and the `swapit sync` CLI couldn't reach the hosted commons. BRO-1547.

## Fix
- **`proxy.ts`** — allowlist `/swapit` (page) + `/api/swapit` (API). The route already self-authenticates (session OR client IP) and enforces its own trust boundary — per-kind Zod, the `scanForbidden` privacy backstop, payload-size caps — exactly like `/api/invocations` and the other anonymous-OK API routes. `withValidation` is body-validation only (no auth), confirmed.
- **`lib/swapit/rate-limit.ts`** — per-IP (60/min anon) / per-user (600/min) in-memory token bucket on the POST write path, mirroring `lib/telemetry/rate-limit.ts` (own keyspace). Returns 429 + `Retry-After`. Generous enough for a batch `swapit sync`, bounded vs floods.
- **`route.ts`** — rate-limit before the DB upsert; one session read serves both the limit key and the contributor identity.

## Security hardening (surfaced by P20 review)
`contributorHash` now derives the anonymous identity from **`getClientIP`** (the rightmost, platform-appended XFF entry) instead of the **leftmost** (client-spoofable) entry. Opening the route to anonymous turned a latent self-approval bypass *live*: an attacker could spoof two leftmost XFFs → two "distinct" contributors → self-approve a fact (approval is corroboration-gated on distinct contributors). Now both the rate-limiter and `contributorHash` key on the same un-spoofable source. **Unit-tested** (`rate-limit.test.ts`: "spoofing the leftmost can't mint new buckets").

## Safety properties (unchanged / verified)
- GET serves **only** `status='approved'` facts — no pending/unmoderated leak.
- The page renders only approved, whitelisted public fields (retailer, region, listing price, url) — **never** inventory / `vendor` / `cost`.
- `/api/swapit` is the only route under that prefix (no unintended exposure); prefix matching requires a trailing `/` so `/api/swapit-*` wouldn't match.
- Security headers + CORS allowlist untouched.

## Test plan
- `bunx vitest run proxy.test.ts lib/swapit/` → **20 passed** (proxy public-route ×2, rate-limit ×4 incl. spoof-resistance, content-hash parity ×11, scanForbidden ×3).
- `bunx tsc --noEmit` → 0 errors in changed files.
- `bunx @biomejs/biome check` → clean.
- Post-deploy smoke: `GET /api/swapit/facts?kind=procurement_option&region=US` returns 200 JSON (not 307); `/swapit` renders the where-to-buy section.

## Review
P20 cross-model adversarial (Strata B, fresh context, security-focused): **8/10 — no blockers**. The one MINOR finding (leftmost-XFF self-approval) is **fixed in this PR** rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public access for Swapit pages and API routes so anonymous visitors can use them without being redirected to sign in.
  - Added write-rate limiting that returns a clear 429 response with a retry time when limits are exceeded.

- **Bug Fixes**
  - Improved contributor tracking by using a trusted session or client IP instead of client-provided values.
  - Strengthened IP handling to reduce spoofing risk and keep rate limits consistent per user or address.

- **Tests**
  - Expanded coverage for anonymous access, rate-limit behavior, and trusted IP parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->