### PR TITLE
feat(profile): data-driven metrics + live GitHub profile plots [BRO-1721]

### DIFF
--- a/apps/broomva/app/(site)/profile/page.tsx
+++ b/apps/broomva/app/(site)/profile/page.tsx
@@ -16,6 +16,7 @@ import {
 import type { Metadata, Route } from "next";
 import Link from "next/link";
 import { ContentCard } from "@/components/site/content-card";
+import { GitHubPlots } from "@/components/site/github-plots";
 import { PageHero } from "@/components/site/page-hero";
 import { ProfileKPIs } from "@/components/site/profile-kpis";
 import {
@@ -30,7 +31,9 @@ import {
   formatNumber,
   getBookkeepingSnapshot,
   getCratesAggregate,
+  getExperienceYears,
   getGitHubAggregate,
+  getHuggingFaceAggregate,
 } from "@/lib/profile-stats";
 
 export const metadata: Metadata = {
@@ -39,64 +42,66 @@ export const metadata: Metadata = {
     "Agent OS architect and AI engineering lead. AI Lead at Stimulus, Data Architect contractor at TEAM International, Co-founder/CTO at Wedi Pay (2024–2026). Builder of Life Agent OS, bstack, broomva/skills, Lago, Vigil, and the RCS paper series.",
   alternates: { canonical: "/profile" },
   openGraph: {
-    title: "Carlos D. Escobar-Valbuena — Agent OS Architect & AI Engineering Lead",
+    title:
+      "Carlos D. Escobar-Valbuena — Agent OS Architect & AI Engineering Lead",
     description:
       "AI-native, multi-tenant data platforms in production. AI Lead at Stimulus, Data Architect at TEAM International, Co-founder/CTO at Wedi Pay (2024–2026). MSc AI at Universidad de los Andes.",
     type: "profile",
   },
 };
 
-const personJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "Person",
-  name: "Carlos D. Escobar-Valbuena",
-  alternateName: "broomva",
-  jobTitle: "Agent OS Architect & AI Engineering Lead",
-  description:
-    "AI Engineering Lead and data platform architect with 7+ years building AI-native, multi-tenant data platforms in production across regulated and high-stakes domains.",
-  url: "https://broomva.tech/profile",
-  sameAs: [
-    "https://linkedin.com/in/broomva",
-    "https://github.com/Broomva",
-    "https://x.com/broomva_tech",
-    "https://broomva.tech",
-  ],
-  email: "carlosdavidescobar@gmail.com",
-  address: {
-    "@type": "PostalAddress",
-    addressLocality: "Bogotá",
-    addressCountry: "Colombia",
-  },
-  knowsAbout: [
-    "Lakehouse architecture",
-    "Databricks",
-    "Unity Catalog",
-    "Medallion architecture",
-    "Production RAG",
-    "Agent orchestration",
-    "LangGraph",
-    "MCP",
-    "Data governance",
-    "OpenTelemetry",
-    "CDC and event sourcing",
-    "Multi-tenant data isolation",
-    "Rust",
-    "Python",
-    "TypeScript",
-  ],
-  alumniOf: [
-    {
-      "@type": "EducationalOrganization",
-      name: "Universidad de los Andes",
-      description: "MSc Artificial Intelligence (2026)",
+function buildPersonJsonLd(experienceYears: number) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Carlos D. Escobar-Valbuena",
+    alternateName: "broomva",
+    jobTitle: "Agent OS Architect & AI Engineering Lead",
+    description: `AI Engineering Lead and data platform architect with ${experienceYears}+ years building AI-native, multi-tenant data platforms in production across regulated and high-stakes domains.`,
+    url: "https://broomva.tech/profile",
+    sameAs: [
+      "https://linkedin.com/in/broomva",
+      "https://github.com/Broomva",
+      "https://x.com/broomva_tech",
+      "https://broomva.tech",
+    ],
+    email: "carlosdavidescobar@gmail.com",
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: "Bogotá",
+      addressCountry: "Colombia",
     },
-    {
-      "@type": "EducationalOrganization",
-      name: "Universidad de San Buenaventura",
-      description: "BSc Mechatronics Engineering (2018, GPA 4.1/5.0)",
-    },
-  ],
-};
+    knowsAbout: [
+      "Lakehouse architecture",
+      "Databricks",
+      "Unity Catalog",
+      "Medallion architecture",
+      "Production RAG",
+      "Agent orchestration",
+      "LangGraph",
+      "MCP",
+      "Data governance",
+      "OpenTelemetry",
+      "CDC and event sourcing",
+      "Multi-tenant data isolation",
+      "Rust",
+      "Python",
+      "TypeScript",
+    ],
+    alumniOf: [
+      {
+        "@type": "EducationalOrganization",
+        name: "Universidad de los Andes",
+        description: "MSc Artificial Intelligence (2026)",
+      },
+      {
+        "@type": "EducationalOrganization",
+        name: "Universidad de San Buenaventura",
+        description: "BSc Mechatronics Engineering (2018, GPA 4.1/5.0)",
+      },
+    ],
+  } as const;
+}
 
 const concurrent = [
   {
@@ -308,13 +313,38 @@ const elsewhereLinks = [
 ];
 
 export default async function ProfilePage() {
-  const [github, crates, bookkeeping, writing, notes] = await Promise.all([
+  const [
+    github,
+    crates,
+    huggingface,
+    experienceYears,
+    bookkeeping,
+    writing,
+    notes,
+  ] = await Promise.all([
     getGitHubAggregate("broomva"),
     getCratesAggregate(),
+    getHuggingFaceAggregate("Broomva"),
+    getExperienceYears(),
     getBookkeepingSnapshot(),
     getLatest("writing", 3),
     getLatest("notes", 3),
   ]);
+
+  const personJsonLd = buildPersonJsonLd(experienceYears);
+
+  // Live, data-driven "at a glance" strip — mirrors the shield badges on the
+  // GitHub profile. Deliberately scoped to metrics NOT already shown in the
+  // "Live signals" KPIs above (stars, crates, downloads) so nothing is doubled;
+  // every number is still pulled from an API and self-updates.
+  const liveBadges = [
+    { label: "yrs shipping AI platforms", value: `${experienceYears}+` },
+    { label: "public repos", value: formatNumber(github.totalRepos) },
+    {
+      label: "Hugging Face models",
+      value: formatNumber(huggingface.totalModels),
+    },
+  ].filter((b) => b.value !== "0");
 
   return (
     <main className="mx-auto w-full max-w-6xl px-4 pb-24 pt-10 sm:px-6 sm:pt-14">
@@ -361,6 +391,50 @@ export default async function ProfilePage() {
         </section>
       </FadeIn>
 
+      {/* GitHub activity — live plots mirrored from the GitHub profile */}
+      <FadeIn delay={0.11}>
+        <section className="mt-12">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 className="font-display text-2xl text-text-primary sm:text-3xl">
+                GitHub activity
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm leading-relaxed text-text-secondary">
+                The same plots on my{" "}
+                <a
+                  className="text-ai-blue hover:underline"
+                  href="https://github.com/Broomva"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  GitHub profile
+                </a>{" "}
+                — each card is a live SVG that re-renders from the GitHub API,
+                so it stays current on its own.
+              </p>
+            </div>
+          </div>
+
+          {liveBadges.length > 0 && (
+            <div className="mt-5 flex flex-wrap gap-2">
+              {liveBadges.map((badge) => (
+                <span
+                  className="inline-flex items-baseline gap-1.5 rounded-full border border-border px-3 py-1 text-xs text-text-secondary"
+                  key={badge.label}
+                >
+                  <span className="font-display text-sm text-text-primary">
+                    {badge.value}
+                  </span>
+                  {badge.label}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <GitHubPlots />
+        </section>
+      </FadeIn>
+
       {/* Knowledge graph */}
       {bookkeeping && bookkeeping.totalEntities > 0 && (
         <FadeIn delay={0.13}>
@@ -381,9 +455,7 @@ export default async function ProfilePage() {
                 <div className="mt-3 font-display text-3xl text-text-primary">
                   {formatNumber(bookkeeping.totalEntities)}
                 </div>
-                <div className="mt-1 text-xs text-text-muted">
-                  in the graph
-                </div>
+                <div className="mt-1 text-xs text-text-muted">in the graph</div>
               </div>
               <div className="rounded-2xl glass p-5">
                 <div className="text-xs uppercase tracking-wider text-text-muted">
@@ -803,7 +875,9 @@ export default async function ProfilePage() {
       {/* Contact CTA */}
       <FadeIn delay={0.6}>
         <section className="mt-16 rounded-2xl glass p-8">
-          <h2 className="font-display text-2xl text-text-primary">Talk to me</h2>
+          <h2 className="font-display text-2xl text-text-primary">
+            Talk to me
+          </h2>
           <p className="mt-3 max-w-2xl text-sm leading-relaxed text-text-secondary">
             If you're building production agent systems, multi-tenant
             lakehouses, or governed AI platforms — and want to compare

--- a/apps/broomva/components/site/github-plots.tsx
+++ b/apps/broomva/components/site/github-plots.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+
+/**
+ * GitHubPlots — embeds the same live, self-updating "plot" cards that live on
+ * the GitHub profile README (github.com/Broomva). Each card is an SVG endpoint
+ * that re-renders from the GitHub API on request, so the visuals stay current
+ * with zero maintenance.
+ *
+ * Theme-aware: the site uses class-based `next-themes` (dark by default), so we
+ * read `resolvedTheme` and pick the matching card variant. Mount-gated to keep
+ * SSR output (dark) identical to the first client render — no hydration flash.
+ */
+
+const USER = "broomva";
+
+interface PlotSpec {
+  key: string;
+  title: string;
+  alt: string;
+  span: "half" | "full";
+  src: (dark: boolean) => string;
+}
+
+const PLOTS: PlotSpec[] = [
+  {
+    key: "stats",
+    title: "Overall stats & rank",
+    alt: "GitHub stats card — total commits, stars, PRs, issues, and rank",
+    span: "half",
+    src: (dark) =>
+      `https://broomva-github-stats.vercel.app/api?username=${USER}&show_icons=true&theme=${dark ? "tokyonight" : "default"}&hide_border=true&count_private=true&include_all_commits=true&rank_icon=github&bg_color=00000000&title_color=${dark ? "5B9BFF" : "0A3D8F"}&icon_color=5B9BFF`,
+  },
+  {
+    key: "langs",
+    title: "Top languages",
+    alt: "Top languages breakdown across public and private repositories",
+    span: "half",
+    src: (dark) =>
+      `https://broomva-github-stats.vercel.app/api/top-langs/?username=${USER}&layout=compact&theme=${dark ? "tokyonight" : "default"}&hide_border=true&langs_count=10&hide=jupyter%20notebook,html,css&bg_color=00000000&title_color=${dark ? "5B9BFF" : "0A3D8F"}`,
+  },
+  {
+    key: "activity",
+    title: "Contribution activity",
+    alt: "Contribution activity graph over time",
+    span: "full",
+    src: (dark) =>
+      `https://github-readme-activity-graph.vercel.app/graph?username=${USER}&theme=${dark ? "tokyo-night" : "github-light"}&hide_border=true&area=true&custom_title=Contribution%20Activity&bg_color=00000000&color=${dark ? "5B9BFF" : "0A3D8F"}&line=5B9BFF&point=B8D4FF`,
+  },
+  {
+    key: "streak",
+    title: "Contribution streak",
+    alt: "GitHub contribution streak — current and longest streak",
+    span: "half",
+    src: (dark) =>
+      `https://github-readme-streak-stats.herokuapp.com/?user=${USER}&theme=${dark ? "tokyonight" : "default"}&hide_border=true&date_format=j%20M%5B%20Y%5D&background=00000000&ring=5B9BFF&fire=5B9BFF&currStreakLabel=5B9BFF`,
+  },
+  {
+    key: "productive-time",
+    title: "When the commits land",
+    alt: "Productive time of day for commits (UTC-5)",
+    span: "half",
+    src: (dark) =>
+      `https://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=${USER}&theme=${dark ? "tokyonight" : "default"}&utcOffset=-5`,
+  },
+];
+
+function Plot({ spec, dark }: { spec: PlotSpec; dark: boolean }) {
+  const src = spec.src(dark);
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return null;
+  }
+
+  return (
+    <figure
+      className={`overflow-hidden rounded-2xl glass p-3 ${
+        spec.span === "full" ? "lg:col-span-2" : ""
+      }`}
+    >
+      <img
+        alt={spec.alt}
+        className="h-auto w-full"
+        loading="lazy"
+        onError={() => setFailed(true)}
+        src={src}
+      />
+      <figcaption className="mt-2 px-1 text-xs text-text-muted">
+        {spec.title}
+      </figcaption>
+    </figure>
+  );
+}
+
+export function GitHubPlots() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Default to dark (the site's default theme) until mounted, so the server
+  // render and first client render agree.
+  const dark = !mounted || resolvedTheme !== "light";
+
+  return (
+    <div className="mt-6 grid gap-4 lg:grid-cols-2">
+      {PLOTS.map((spec) => (
+        // Key includes the theme so a toggle remounts the figure, resetting the
+        // load-error state cleanly (no effect needed).
+        <Plot dark={dark} key={`${spec.key}-${dark ? "d" : "l"}`} spec={spec} />
+      ))}
+    </div>
+  );
+}

--- a/apps/broomva/lib/profile-stats.ts
+++ b/apps/broomva/lib/profile-stats.ts
@@ -114,7 +114,9 @@ const TARGET_CRATES = [
 async function fetchCrateMeta(name: string) {
   try {
     const res = await fetch(`https://crates.io/api/v1/crates/${name}`, {
-      headers: { "User-Agent": "broomva.tech profile page (carlos@broomva.tech)" },
+      headers: {
+        "User-Agent": "broomva.tech profile page (carlos@broomva.tech)",
+      },
     });
     if (!res.ok) {
       return null;
@@ -211,6 +213,63 @@ async function fetchBookkeepingSnapshot(): Promise<BookkeepingSnapshot | null> {
 
 export async function getBookkeepingSnapshot(): Promise<BookkeepingSnapshot | null> {
   return fetchBookkeepingSnapshot();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hugging Face aggregate — models published under the Broomva author namespace
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface HuggingFaceAggregateStats {
+  totalModels: number;
+}
+
+async function fetchHuggingFaceAggregate(
+  author: string,
+): Promise<HuggingFaceAggregateStats> {
+  "use cache";
+  cacheLife("hours");
+
+  try {
+    const res = await fetch(
+      `https://huggingface.co/api/models?author=${encodeURIComponent(author)}&limit=1000`,
+      { headers: { Accept: "application/json" } },
+    );
+    if (!res.ok) {
+      return { totalModels: 0 };
+    }
+    const models = (await res.json()) as unknown[];
+    return { totalModels: Array.isArray(models) ? models.length : 0 };
+  } catch {
+    return { totalModels: 0 };
+  }
+}
+
+export async function getHuggingFaceAggregate(
+  author = "Broomva",
+): Promise<HuggingFaceAggregateStats> {
+  return fetchHuggingFaceAggregate(author);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Derived career metrics — self-updating so hardcoded "N+ years" never rots
+// ─────────────────────────────────────────────────────────────────────────────
+
+// First professional engineering role (INSA Ingeniería, Digitalization Leader).
+// Years of experience are derived from this anchor so the number increments on
+// its own every year instead of drifting out of date.
+const CAREER_START_ISO = "2019-05-01";
+
+async function fetchExperienceYears(): Promise<number> {
+  "use cache";
+  cacheLife("hours");
+
+  const start = new Date(CAREER_START_ISO).getTime();
+  const years = (Date.now() - start) / (365.25 * 24 * 60 * 60 * 1000);
+  return Math.max(0, Math.floor(years));
+}
+
+export async function getExperienceYears(): Promise<number> {
+  return fetchExperienceYears();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Makes `broomva.tech/profile` metrics **self-updating** and embeds the live "plots" from the GitHub profile README (github.com/Broomva) — so the page reflects current reality with zero manual edits.

Closes **BRO-1721**. Continues the BRO-1487 profile arc.

## Changes

**`lib/profile-stats.ts`**
- `getHuggingFaceAggregate("Broomva")` — live model count from the HF API (confirms the "14 models" the CV + GitHub badge cite).
- `getExperienceYears()` — derived from a career-start anchor (`2019-05-01`) so "7+ yrs" **auto-increments** instead of silently rotting. Currently → `7`.
- Both `"use cache"` + `cacheLife("hours")`, matching the existing GitHub/crates/bookkeeping fetchers. Every helper is `try`/`catch`ed → an upstream API failure can't break page SSR.

**`components/site/github-plots.tsx`** (new, client)
- Theme-aware embeds of the five live SVG cards from the GitHub profile: overall stats & rank, top languages, contribution activity graph, streak, productive-time.
- Reads `next-themes` `resolvedTheme`, **mount-gated** so SSR output == first client render (no hydration flash); picks `tokyonight`/`tokyo-night` in dark, `default`/`github-light` in light.
- Transparent card backgrounds + ai-blue accents blend into the arcan-glass panels.
- `onError` hides any card that fails to load (the streak host cold-starts on Heroku); remount-via-`key` resets that state cleanly on theme toggle.

**`app/(site)/profile/page.tsx`**
- New **"GitHub activity"** section: a live badge strip (yrs experience · public repos · Hugging Face models — deliberately scoped to metrics **not** already in the "Live signals" KPIs, so nothing is doubled) + `<GitHubPlots/>`.
- `personJsonLd` → `buildPersonJsonLd(experienceYears)` so the Person schema description uses the derived years.

## Data sources (all self-updating)
`broomva-github-stats.vercel.app` (own github-readme-stats fork) · `github-readme-activity-graph.vercel.app` · `github-readme-streak-stats.herokuapp.com` · `github-profile-summary-cards.vercel.app` · `huggingface.co/api/models`

## Validation (P11)
- `bun run test:types` → exit 0 (rebased onto current `main`).
- `biome lint` → clean (only the accepted `<img>` warning — `next/image` can't optimize external dynamic SVGs).
- All five plot endpoints return valid images; headless-Chrome render confirms composition + transparent-bg blend on the dark theme.

## Cross-review (P20)
Fresh-context adversarial review: **9/10, no blocking defects**. Confirmed hydration mount-gating, `"use cache"` time access, no-throw SSR, and the badge filter are all correct. The three non-blocking nits it raised (badge/KPI duplication, dead HF computation, JSON-LD indentation) are folded into this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GitHub activity section on the profile page with visual plots and live badges for experience, repositories, and models.
  * Profile metadata now updates dynamically based on fetched career and activity stats.
* **Bug Fixes**
  * Improved theme-aware plot rendering to avoid display issues and hide broken images automatically.
* **Style**
  * Refined a few profile page headings and labels for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->