### PR TITLE
fix(profile): "Most recent push" uses newest push, not top-starred repo [BRO-1723]

### DIFF
--- a/apps/broomva/app/(site)/profile/page.tsx
+++ b/apps/broomva/app/(site)/profile/page.tsx
@@ -379,8 +379,8 @@ export default async function ProfilePage() {
               totalRepos: github.totalRepos,
               totalStars: github.totalStars,
             }}
-            lastPushRelative={github.topRepos[0]?.pushedAtRelative ?? "—"}
-            lastPushRepo={github.topRepos[0]?.name ?? "—"}
+            lastPushRelative={github.lastPush?.pushedAtRelative ?? "—"}
+            lastPushRepo={github.lastPush?.name ?? "—"}
             recentCount={writing.length + notes.length}
             recentLabel="Recent writing"
           />

--- a/apps/broomva/lib/profile-stats.ts
+++ b/apps/broomva/lib/profile-stats.ts
@@ -19,6 +19,13 @@ export interface GitHubAggregateStats {
     pushedAtRelative: string;
     language: string | null;
   }>;
+  // The genuinely most-recently-pushed repo (max pushed_at), independent of the
+  // star-sorted topRepos list. Null when no repos are available.
+  lastPush: {
+    name: string;
+    pushedAt: string;
+    pushedAtRelative: string;
+  } | null;
 }
 
 async function fetchGitHubAggregate(
@@ -68,7 +75,7 @@ async function fetchGitHubAggregate(
     const repos = pages.flat();
 
     if (repos.length === 0) {
-      return { totalStars: 0, totalRepos: 0, topRepos: [] };
+      return { totalStars: 0, totalRepos: 0, topRepos: [], lastPush: null };
     }
 
     // Stars: sum across every owned public repo (matches GitHub's own "Total
@@ -77,8 +84,8 @@ async function fetchGitHubAggregate(
     // in "most-starred repos".
     const totalStars = repos.reduce((sum, r) => sum + r.stargazers_count, 0);
     const now = Date.now();
-    const topRepos = repos
-      .filter((r) => !r.fork)
+    const nonFork = repos.filter((r) => !r.fork);
+    const topRepos = nonFork
       .toSorted((a, b) => b.stargazers_count - a.stargazers_count)
       .slice(0, 6)
       .map((r) => ({
@@ -92,9 +99,24 @@ async function fetchGitHubAggregate(
         language: r.language,
       }));
 
-    return { totalStars, totalRepos: repos.length, topRepos };
+    // "Most recent push" must be the repo with the newest pushed_at — NOT
+    // topRepos[0], which is star-sorted. Restrict to non-fork so a passive
+    // fork sync doesn't masquerade as authored activity.
+    const mostRecent = nonFork.toSorted(
+      (a, b) =>
+        new Date(b.pushed_at).getTime() - new Date(a.pushed_at).getTime(),
+    )[0];
+    const lastPush = mostRecent
+      ? {
+          name: mostRecent.name,
+          pushedAt: mostRecent.pushed_at,
+          pushedAtRelative: relativeFrom(mostRecent.pushed_at, now),
+        }
+      : null;
+
+    return { totalStars, totalRepos: repos.length, topRepos, lastPush };
   } catch {
-    return { totalStars: 0, totalRepos: 0, topRepos: [] };
+    return { totalStars: 0, totalRepos: 0, topRepos: [], lastPush: null };
   }
 }
 


### PR DESCRIPTION
## Problem
The Live signals **"Most recent push"** KPI showed **harness-engineering · 8d ago**, which isn't your most recent push. It was fed `github.topRepos[0]` — and `topRepos` is sorted by **stars**, so it surfaced the most-starred repo's push date, not the newest push.

Your true most-recent public pushes (GitHub API `sort=pushed`): broomva.tech (~today), ember, bstack, genesis, broomva, skills — all within ~2 days.

## Fix
- `lib/profile-stats.ts`: add a `lastPush { name, pushedAt, pushedAtRelative } | null` field to `GitHubAggregateStats`, computed as the **non-fork repo with the max `pushed_at`** across the full paginated set (non-fork so a passive fork sync doesn't masquerade as authored activity).
- `app/(site)/profile/page.tsx`: feed the KPI from `github.lastPush` instead of `github.topRepos[0]`.

## Validation (P11)
- Standalone check against the live API → newest non-fork push = **broomva.tech (2026-07-07)**.
- `bun run test:types` exit 0, `biome lint` clean, no other consumers of the interface.
- Will live-verify the KPI shows broomva.tech with a <1d timestamp after deploy.

Two-file, small — below the P20 cross-review threshold. Follow-up to BRO-1721 / BRO-1722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)